### PR TITLE
remove shaping behavior of U+2D4F TIFINAGH LETTER YAN

### DIFF
--- a/src/NotoSansTifinagh/Noto Sans Tifinagh GSUB.txt
+++ b/src/NotoSansTifinagh/Noto Sans Tifinagh GSUB.txt
@@ -7,23 +7,23 @@ script table end
 
 
 feature table begin
-0	ccmp	0, 1
+0	ccmp	1
 
 feature table end
 
-lookup	0	ligature
+%lookup	0	ligature
 
-RightToLeft	no
-IgnoreBaseGlyphs	no
-IgnoreLigatures	no
-IgnoreMarks	no
+%RightToLeft	no
+%IgnoreBaseGlyphs	no
+%IgnoreLigatures	no
+%IgnoreMarks	no
 
 %uni2D4D2D4D	uni2D4D	uni2D4D
-uni2D4D2D4F	uni2D4D	uni2D4F
+%uni2D4D2D4F	uni2D4D	uni2D4F
 %uni2D4F2D4D	uni2D4F	uni2D4D
-uni2D4F2D4F	uni2D4F	uni2D4F
+%uni2D4F2D4F	uni2D4F	uni2D4F
 
-lookup end
+%lookup end
 
 
 lookup	1	ligature


### PR DESCRIPTION
see https://github.com/googlefonts/noto-fonts/issues/1571

note: I just commented out the entire lookup table for the slant-shaping and left the shaped glyphs in the font, as this appears to be what was done to remove the shaping for U+2D4D TIFINAGH LETTER YAL.