### PR TITLE
Add source for Noto Sans Nushü

### DIFF
--- a/src/NotoSansNushu/NotoSansNushu.glyphs
+++ b/src/NotoSansNushu/NotoSansNushu.glyphs
@@ -1,0 +1,52304 @@
+{
+.appVersion = "1312";
+copyright = "Copyright 2020 Google Inc. All Rights Reserved.";
+customParameters = (
+{
+name = vendorID;
+value = GOOG;
+},
+{
+name = unicodeRanges;
+value = (
+0,
+1,
+31,
+45,
+57
+);
+},
+{
+name = glyphOrder;
+value = (
+.notdef,
+NULL,
+CR,
+space,
+nbspace,
+u16FE1,
+u1B170,
+u1B171,
+u1B172,
+u1B173,
+u1B174,
+u1B175,
+u1B176,
+u1B177,
+u1B178,
+u1B179,
+u1B17A,
+u1B17B,
+u1B17C,
+u1B17D,
+u1B17E,
+u1B17F,
+u1B180,
+u1B181,
+u1B182,
+u1B183,
+u1B184,
+u1B185,
+u1B186,
+u1B187,
+u1B188,
+u1B189,
+u1B18A,
+u1B18B,
+u1B18C,
+u1B18D,
+u1B18E,
+u1B18F,
+u1B190,
+u1B191,
+u1B192,
+u1B193,
+u1B194,
+u1B195,
+u1B196,
+u1B197,
+u1B198,
+u1B199,
+u1B19A,
+u1B19B,
+u1B19C,
+u1B19D,
+u1B19E,
+u1B19F,
+u1B1A0,
+u1B1A1,
+u1B1A2,
+u1B1A3,
+u1B1A4,
+u1B1A5,
+u1B1A6,
+u1B1A7,
+u1B1A8,
+u1B1A9,
+u1B1AA,
+u1B1AB,
+u1B1AC,
+u1B1AD,
+u1B1AE,
+u1B1AF,
+u1B1B0,
+u1B1B1,
+u1B1B2,
+u1B1B3,
+u1B1B4,
+u1B1B5,
+u1B1B6,
+u1B1B7,
+u1B1B8,
+u1B1B9,
+u1B1BA,
+u1B1BB,
+u1B1BC,
+u1B1BD,
+u1B1BE,
+u1B1BF,
+u1B1C0,
+u1B1C1,
+u1B1C2,
+u1B1C3,
+u1B1C4,
+u1B1C5,
+u1B1C6,
+u1B1C7,
+u1B1C8,
+u1B1C9,
+u1B1CA,
+u1B1CB,
+u1B1CC,
+u1B1CD,
+u1B1CE,
+u1B1CF,
+u1B1D0,
+u1B1D1,
+u1B1D2,
+u1B1D3,
+u1B1D4,
+u1B1D5,
+u1B1D6,
+u1B1D7,
+u1B1D8,
+u1B1D9,
+u1B1DA,
+u1B1DB,
+u1B1DC,
+u1B1DD,
+u1B1DE,
+u1B1DF,
+u1B1E0,
+u1B1E1,
+u1B1E2,
+u1B1E3,
+u1B1E4,
+u1B1E5,
+u1B1E6,
+u1B1E7,
+u1B1E8,
+u1B1E9,
+u1B1EA,
+u1B1EB,
+u1B1EC,
+u1B1ED,
+u1B1EE,
+u1B1EF,
+u1B1F0,
+u1B1F1,
+u1B1F2,
+u1B1F3,
+u1B1F4,
+u1B1F5,
+u1B1F6,
+u1B1F7,
+u1B1F8,
+u1B1F9,
+u1B1FA,
+u1B1FB,
+u1B1FC,
+u1B1FD,
+u1B1FE,
+u1B1FF,
+u1B200,
+u1B201,
+u1B202,
+u1B203,
+u1B204,
+u1B205,
+u1B206,
+u1B207,
+u1B208,
+u1B209,
+u1B20A,
+u1B20B,
+u1B20C,
+u1B20D,
+u1B20E,
+u1B20F,
+u1B210,
+u1B211,
+u1B212,
+u1B213,
+u1B214,
+u1B215,
+u1B216,
+u1B217,
+u1B218,
+u1B219,
+u1B21A,
+u1B21B,
+u1B21C,
+u1B21D,
+u1B21E,
+u1B21F,
+u1B220,
+u1B221,
+u1B222,
+u1B223,
+u1B224,
+u1B225,
+u1B226,
+u1B227,
+u1B228,
+u1B229,
+u1B22A,
+u1B22B,
+u1B22C,
+u1B22D,
+u1B22E,
+u1B22F,
+u1B230,
+u1B231,
+u1B232,
+u1B233,
+u1B234,
+u1B235,
+u1B236,
+u1B237,
+u1B238,
+u1B239,
+u1B23A,
+u1B23B,
+u1B23C,
+u1B23D,
+u1B23E,
+u1B23F,
+u1B240,
+u1B241,
+u1B242,
+u1B243,
+u1B244,
+u1B245,
+u1B246,
+u1B247,
+u1B248,
+u1B249,
+u1B24A,
+u1B24B,
+u1B24C,
+u1B24D,
+u1B24E,
+u1B24F,
+u1B250,
+u1B251,
+u1B252,
+u1B253,
+u1B254,
+u1B255,
+u1B256,
+u1B257,
+u1B258,
+u1B259,
+u1B25A,
+u1B25B,
+u1B25C,
+u1B25D,
+u1B25E,
+u1B25F,
+u1B260,
+u1B261,
+u1B262,
+u1B263,
+u1B264,
+u1B265,
+u1B266,
+u1B267,
+u1B268,
+u1B269,
+u1B26A,
+u1B26B,
+u1B26C,
+u1B26D,
+u1B26E,
+u1B26F,
+u1B270,
+u1B271,
+u1B272,
+u1B273,
+u1B274,
+u1B275,
+u1B276,
+u1B277,
+u1B278,
+u1B279,
+u1B27A,
+u1B27B,
+u1B27C,
+u1B27D,
+u1B27E,
+u1B27F,
+u1B280,
+u1B281,
+u1B282,
+u1B283,
+u1B284,
+u1B285,
+u1B286,
+u1B287,
+u1B288,
+u1B289,
+u1B28A,
+u1B28B,
+u1B28C,
+u1B28D,
+u1B28E,
+u1B28F,
+u1B290,
+u1B291,
+u1B292,
+u1B293,
+u1B294,
+u1B295,
+u1B296,
+u1B297,
+u1B298,
+u1B299,
+u1B29A,
+u1B29B,
+u1B29C,
+u1B29D,
+u1B29E,
+u1B29F,
+u1B2A0,
+u1B2A1,
+u1B2A2,
+u1B2A3,
+u1B2A4,
+u1B2A5,
+u1B2A6,
+u1B2A7,
+u1B2A8,
+u1B2A9,
+u1B2AA,
+u1B2AB,
+u1B2AC,
+u1B2AD,
+u1B2AE,
+u1B2AF,
+u1B2B0,
+u1B2B1,
+u1B2B2,
+u1B2B3,
+u1B2B4,
+u1B2B5,
+u1B2B6,
+u1B2B7,
+u1B2B8,
+u1B2B9,
+u1B2BA,
+u1B2BB,
+u1B2BC,
+u1B2BD,
+u1B2BE,
+u1B2BF,
+u1B2C0,
+u1B2C1,
+u1B2C2,
+u1B2C3,
+u1B2C4,
+u1B2C5,
+u1B2C6,
+u1B2C7,
+u1B2C8,
+u1B2C9,
+u1B2CA,
+u1B2CB,
+u1B2CC,
+u1B2CD,
+u1B2CE,
+u1B2CF,
+u1B2D0,
+u1B2D1,
+u1B2D2,
+u1B2D3,
+u1B2D4,
+u1B2D5,
+u1B2D6,
+u1B2D7,
+u1B2D8,
+u1B2D9,
+u1B2DA,
+u1B2DB,
+u1B2DC,
+u1B2DD,
+u1B2DE,
+u1B2DF,
+u1B2E0,
+u1B2E1,
+u1B2E2,
+u1B2E3,
+u1B2E4,
+u1B2E5,
+u1B2E6,
+u1B2E7,
+u1B2E8,
+u1B2E9,
+u1B2EA,
+u1B2EB,
+u1B2EC,
+u1B2ED,
+u1B2EE,
+u1B2EF,
+u1B2F0,
+u1B2F1,
+u1B2F2,
+u1B2F3,
+u1B2F4,
+u1B2F5,
+u1B2F6,
+u1B2F7,
+u1B2F8,
+u1B2F9,
+u1B2FA,
+u1B2FB
+);
+},
+{
+name = description;
+value = "Designed by Lisa Huang";
+},
+{
+name = license;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+},
+{
+name = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+name = trademark;
+value = "Noto is a trademark of Google Inc.";
+},
+{
+name = versionString;
+value = "Version 1.000";
+},
+{
+name = fsType;
+value = (
+);
+},
+{
+name = codePageRanges;
+value = (
+"1252"
+);
+},
+{
+name = Axes;
+value = (
+{
+Name = Weight;
+Tag = wght;
+}
+);
+},
+{
+name = "Has WWS Names";
+value = 1;
+},
+{
+name = "Don't use Production Names";
+value = 1;
+}
+);
+date = "2020-04-15 14:14:32 +0000";
+designer = "Lisa Huang";
+designerURL = "http://www.lisahuang.work";
+familyName = "Noto Sans Nushu";
+featurePrefixes = (
+{
+code = "languagesystem nshu dflt;";
+name = Languagesystems;
+}
+);
+fontMaster = (
+{
+ascender = 1069;
+capHeight = 714;
+customParameters = (
+{
+name = head.ymax;
+value = 941;
+},
+{
+name = head.ymin;
+value = -205;
+},
+{
+name = hheaAscender;
+value = 1069;
+},
+{
+name = hheaDescender;
+value = -293;
+},
+{
+name = hheaLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1069;
+},
+{
+name = winDescent;
+value = -293;
+},
+{
+name = typoAscender;
+value = 1069;
+},
+{
+name = typoDescender;
+value = -293;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = panose;
+value = (
+2,
+11,
+2,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+}
+);
+descender = -293;
+guideLines = (
+{
+locked = 1;
+position = "{138, -293}";
+},
+{
+locked = 1;
+position = "{410, 363}";
+},
+{
+locked = 1;
+position = "{511, 1069}";
+},
+{
+locked = 1;
+position = "{403, -253}";
+},
+{
+locked = 1;
+position = "{401, 979}";
+},
+{
+locked = 1;
+position = "{402, -203}";
+},
+{
+locked = 1;
+position = "{413, 939}";
+}
+);
+id = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+xHeight = 536;
+}
+);
+glyphs = (
+{
+glyphname = .notdef;
+lastChange = "2020-04-15 16:53:23 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"505 0 LINE",
+"505 714 LINE",
+"94 714 LINE",
+"94 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"145 663 LINE",
+"454 663 LINE",
+"454 51 LINE",
+"145 51 LINE"
+);
+}
+);
+width = 600;
+}
+);
+note = .notdef;
+},
+{
+glyphname = NULL;
+lastChange = "2020-04-16 01:14:21 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+width = 0;
+}
+);
+note = NULL;
+unicode = 0000;
+},
+{
+glyphname = CR;
+lastChange = "2020-04-16 01:14:28 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+width = 260;
+}
+);
+note = CR;
+unicode = 000D;
+},
+{
+glyphname = space;
+lastChange = "2020-03-26 11:01:55 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+width = 260;
+}
+);
+note = space;
+unicode = 0020;
+},
+{
+glyphname = nbspace;
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+width = 260;
+}
+);
+widthMetricsKey = space;
+unicode = 00A0;
+},
+{
+glyphname = u16FE1;
+lastChange = "2020-04-13 08:25:41 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"677 210 OFFCURVE",
+"603 52 OFFCURVE",
+"458 -137 CURVE",
+"522 -182 LINE",
+"672 14 OFFCURVE",
+"753 195 OFFCURVE",
+"753 326 CURVE SMOOTH",
+"753 424 OFFCURVE",
+"709 493 OFFCURVE",
+"602 559 CURVE",
+"561 489 LINE",
+"651 444 OFFCURVE",
+"677 395 OFFCURVE",
+"677 326 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 223 OFFCURVE",
+"163 240 OFFCURVE",
+"163 279 CURVE SMOOTH",
+"163 318 OFFCURVE",
+"140 335 OFFCURVE",
+"112 335 CURVE SMOOTH",
+"83 335 OFFCURVE",
+"60 318 OFFCURVE",
+"60 279 CURVE SMOOTH",
+"60 240 OFFCURVE",
+"83 223 OFFCURVE",
+"112 223 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"438 635 OFFCURVE",
+"461 652 OFFCURVE",
+"461 691 CURVE SMOOTH",
+"461 730 OFFCURVE",
+"438 747 OFFCURVE",
+"410 747 CURVE SMOOTH",
+"381 747 OFFCURVE",
+"358 730 OFFCURVE",
+"358 691 CURVE SMOOTH",
+"358 652 OFFCURVE",
+"381 635 OFFCURVE",
+"410 635 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"650 909 LINE",
+"586 685 OFFCURVE",
+"524 526 OFFCURVE",
+"474 424 CURVE SMOOTH",
+"446 366 OFFCURVE",
+"423 319 OFFCURVE",
+"393 259 CURVE",
+"389 259 LINE",
+"376 308 OFFCURVE",
+"364 348 OFFCURVE",
+"351 381 CURVE SMOOTH",
+"332 429 OFFCURVE",
+"291 516 OFFCURVE",
+"241 598 CURVE",
+"174 559 LINE",
+"248 433 OFFCURVE",
+"297 327 OFFCURVE",
+"341 189 CURVE",
+"424 177 LINE",
+"573 406 OFFCURVE",
+"650 632 OFFCURVE",
+"725 889 CURVE"
+);
+}
+);
+width = 853;
+}
+);
+leftMetricsKey = u1B193;
+unicode = 16FE1;
+},
+{
+glyphname = u1B170;
+lastChange = "2020-04-13 08:25:56 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"304 939 LINE",
+"303 472 OFFCURVE",
+"217 93 OFFCURVE",
+"80 -169 CURVE",
+"150 -203 LINE",
+"289 61 OFFCURVE",
+"379 443 OFFCURVE",
+"382 938 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 512;
+}
+);
+unicode = 1B170;
+},
+{
+glyphname = u1B171;
+lastChange = "2020-04-13 08:26:31 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"491 268 LINE",
+"419 90 OFFCURVE",
+"319 -35 OFFCURVE",
+"198 -150 CURVE",
+"253 -203 LINE",
+"378 -84 OFFCURVE",
+"482 46 OFFCURVE",
+"562 239 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"379 939 LINE",
+"378 478 OFFCURVE",
+"292 269 OFFCURVE",
+"80 54 CURVE",
+"136 0 LINE",
+"350 217 OFFCURVE",
+"454 432 OFFCURVE",
+"457 938 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 662;
+}
+);
+unicode = 1B171;
+},
+{
+glyphname = u1B172;
+lastChange = "2020-04-13 08:26:27 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"459 939 LINE",
+"424 757 OFFCURVE",
+"386 632 OFFCURVE",
+"336 509 CURVE",
+"317 479 LINE",
+"253 349 OFFCURVE",
+"190 251 OFFCURVE",
+"95 132 CURVE",
+"152 85 LINE",
+"238 188 OFFCURVE",
+"306 287 OFFCURVE",
+"366 415 CURVE",
+"390 440 LINE",
+"457 592 OFFCURVE",
+"492 716 OFFCURVE",
+"536 924 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"354 457 OFFCURVE",
+"446 301 OFFCURVE",
+"446 137 CURVE SMOOTH",
+"446 21 OFFCURVE",
+"417 -62 OFFCURVE",
+"335 -155 CURVE",
+"391 -203 LINE",
+"480 -105 OFFCURVE",
+"524 0 OFFCURVE",
+"524 139 CURVE SMOOTH",
+"524 315 OFFCURVE",
+"430 491 OFFCURVE",
+"130 768 CURVE",
+"80 711 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 656;
+}
+);
+unicode = 1B172;
+},
+{
+glyphname = u1B173;
+lastChange = "2020-04-13 08:26:23 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"644 -72 LINE",
+"555 154 OFFCURVE",
+"460 313 OFFCURVE",
+"323 504 CURVE",
+"308 391 LINE",
+"413 242 OFFCURVE",
+"499 84 OFFCURVE",
+"572 -101 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"293 939 LINE",
+"292 478 OFFCURVE",
+"207 93 OFFCURVE",
+"70 -169 CURVE",
+"138 -203 LINE",
+"277 61 OFFCURVE",
+"368 443 OFFCURVE",
+"371 938 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 694;
+}
+);
+unicode = 1B173;
+},
+{
+glyphname = u1B174;
+lastChange = "2020-04-13 08:26:17 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"179 522 OFFCURVE",
+"212 371 OFFCURVE",
+"212 202 CURVE SMOOTH",
+"212 69 OFFCURVE",
+"189 -51 OFFCURVE",
+"134 -175 CURVE",
+"202 -203 LINE",
+"266 -65 OFFCURVE",
+"288 56 OFFCURVE",
+"288 202 CURVE SMOOTH",
+"288 393 OFFCURVE",
+"255 529 OFFCURVE",
+"169 735 CURVE",
+"100 707 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"562 279 OFFCURVE",
+"517 415 OFFCURVE",
+"517 593 CURVE SMOOTH",
+"517 692 OFFCURVE",
+"528 794 OFFCURVE",
+"559 923 CURVE",
+"487 939 LINE",
+"457 812 OFFCURVE",
+"441 710 OFFCURVE",
+"441 594 CURVE SMOOTH",
+"441 405 OFFCURVE",
+"488 248 OFFCURVE",
+"596 97 CURVE",
+"656 139 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 756;
+}
+);
+unicode = 1B174;
+},
+{
+glyphname = u1B175;
+lastChange = "2020-04-13 08:26:39 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"586 -89 LINE",
+"532 74 OFFCURVE",
+"459 244 OFFCURVE",
+"391 368 CURVE",
+"363 398 LINE",
+"284 543 OFFCURVE",
+"221 643 OFFCURVE",
+"131 762 CURVE",
+"70 717 LINE",
+"168 587 OFFCURVE",
+"243 470 OFFCURVE",
+"330 304 CURVE",
+"359 269 LINE",
+"412 162 OFFCURVE",
+"471 24 OFFCURVE",
+"515 -110 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"466 939 LINE",
+"412 543 OFFCURVE",
+"285 176 OFFCURVE",
+"117 -172 CURVE",
+"184 -203 LINE",
+"350 141 OFFCURVE",
+"484 514 OFFCURVE",
+"541 928 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 686;
+}
+);
+unicode = 1B175;
+},
+{
+glyphname = u1B176;
+lastChange = "2020-04-13 08:26:46 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"160 306 OFFCURVE",
+"183 323 OFFCURVE",
+"183 362 CURVE SMOOTH",
+"183 401 OFFCURVE",
+"160 418 OFFCURVE",
+"132 418 CURVE SMOOTH",
+"103 418 OFFCURVE",
+"80 401 OFFCURVE",
+"80 362 CURVE SMOOTH",
+"80 323 OFFCURVE",
+"103 306 OFFCURVE",
+"132 306 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"421 939 LINE",
+"420 472 OFFCURVE",
+"334 93 OFFCURVE",
+"197 -169 CURVE",
+"267 -203 LINE",
+"406 61 OFFCURVE",
+"496 443 OFFCURVE",
+"499 938 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 629;
+}
+);
+rightMetricsKey = u1B170;
+unicode = 1B176;
+},
+{
+glyphname = u1B177;
+lastChange = "2020-04-13 08:26:52 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"424 295 OFFCURVE",
+"401 278 OFFCURVE",
+"401 239 CURVE SMOOTH",
+"401 200 OFFCURVE",
+"424 183 OFFCURVE",
+"452 183 CURVE SMOOTH",
+"481 183 OFFCURVE",
+"504 200 OFFCURVE",
+"504 239 CURVE SMOOTH",
+"504 278 OFFCURVE",
+"481 295 OFFCURVE",
+"452 295 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"143 478 OFFCURVE",
+"107 93 OFFCURVE",
+"143 -203 CURVE",
+"220 -194 LINE",
+"185 99 OFFCURVE",
+"224 481 OFFCURVE",
+"392 912 CURVE",
+"319 939 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 584;
+}
+);
+unicode = 1B177;
+},
+{
+glyphname = u1B178;
+lastChange = "2020-04-13 08:26:58 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"262 442 LINE",
+"239 276 OFFCURVE",
+"183 141 OFFCURVE",
+"100 39 CURVE",
+"158 -4 LINE",
+"253 119 OFFCURVE",
+"309 248 OFFCURVE",
+"335 432 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"642 213 OFFCURVE",
+"629 114 OFFCURVE",
+"629 12 CURVE SMOOTH",
+"629 -78 OFFCURVE",
+"639 -144 OFFCURVE",
+"653 -203 CURVE",
+"723 -188 LINE",
+"708 -120 OFFCURVE",
+"704 -65 OFFCURVE",
+"704 12 CURVE SMOOTH",
+"704 106 OFFCURVE",
+"714 198 OFFCURVE",
+"752 307 CURVE",
+"683 328 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"507 939 LINE",
+"504 445 OFFCURVE",
+"464 130 OFFCURVE",
+"304 -147 CURVE",
+"369 -183 LINE",
+"529 96 OFFCURVE",
+"582 417 OFFCURVE",
+"583 938 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 862;
+}
+);
+unicode = 1B178;
+},
+{
+glyphname = u1B179;
+lastChange = "2020-04-13 08:27:04 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"523 939 LINE",
+"371 765 OFFCURVE",
+"235 646 OFFCURVE",
+"60 520 CURVE",
+"104 461 LINE",
+"280 588 OFFCURVE",
+"416 704 OFFCURVE",
+"582 891 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"525 740 OFFCURVE",
+"549 692 OFFCURVE",
+"549 634 CURVE SMOOTH",
+"549 528 OFFCURVE",
+"456 441 OFFCURVE",
+"140 229 CURVE",
+"182 168 LINE",
+"527 396 OFFCURVE",
+"625 499 OFFCURVE",
+"625 634 CURVE SMOOTH",
+"625 719 OFFCURVE",
+"594 781 OFFCURVE",
+"511 864 CURVE",
+"472 793 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"392 363 LINE",
+"408 247 OFFCURVE",
+"413 170 OFFCURVE",
+"413 42 CURVE SMOOTH",
+"413 -51 OFFCURVE",
+"409 -113 OFFCURVE",
+"401 -196 CURVE",
+"476 -203 LINE",
+"485 -122 OFFCURVE",
+"489 -53 OFFCURVE",
+"489 40 CURVE SMOOTH",
+"489 170 OFFCURVE",
+"480 281 OFFCURVE",
+"457 408 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 755;
+}
+);
+unicode = 1B179;
+},
+{
+glyphname = u1B17A;
+lastChange = "2020-04-13 08:27:09 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"381 340 LINE",
+"395 237 OFFCURVE",
+"398 153 OFFCURVE",
+"398 55 CURVE SMOOTH",
+"398 -33 OFFCURVE",
+"393 -114 OFFCURVE",
+"382 -194 CURVE",
+"456 -203 LINE",
+"469 -119 OFFCURVE",
+"474 -39 OFFCURVE",
+"474 56 CURVE SMOOTH",
+"474 155 OFFCURVE",
+"467 249 OFFCURVE",
+"452 349 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"462 939 LINE",
+"395 675 OFFCURVE",
+"302 467 OFFCURVE",
+"127 223 CURVE",
+"187 180 LINE",
+"361 424 OFFCURVE",
+"464 636 OFFCURVE",
+"536 921 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"293 582 OFFCURVE",
+"456 462 OFFCURVE",
+"625 303 CURVE",
+"677 358 LINE",
+"493 530 OFFCURVE",
+"343 638 OFFCURVE",
+"103 756 CURVE",
+"70 688 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 767;
+}
+);
+unicode = 1B17A;
+},
+{
+glyphname = u1B17B;
+lastChange = "2020-04-13 08:27:15 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"462 939 LINE",
+"357 689 OFFCURVE",
+"237 506 OFFCURVE",
+"70 304 CURVE",
+"129 257 LINE",
+"294 455 OFFCURVE",
+"424 653 OFFCURVE",
+"533 911 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"113 836 LINE",
+"317 495 OFFCURVE",
+"466 158 OFFCURVE",
+"576 -203 CURVE",
+"649 -182 LINE",
+"539 183 OFFCURVE",
+"385 521 OFFCURVE",
+"179 875 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"390 313 LINE",
+"316 168 OFFCURVE",
+"248 58 OFFCURVE",
+"157 -65 CURVE",
+"219 -109 LINE",
+"311 16 OFFCURVE",
+"383 130 OFFCURVE",
+"454 271 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 679;
+}
+);
+unicode = 1B17B;
+},
+{
+glyphname = u1B17C;
+lastChange = "2020-04-13 08:27:19 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"129 495 LINE",
+"268 303 OFFCURVE",
+"380 116 OFFCURVE",
+"494 -107 CURVE",
+"560 -74 LINE",
+"505 36 OFFCURVE",
+"451 129 OFFCURVE",
+"372 260 CURVE",
+"355 260 LINE",
+"318 354 OFFCURVE",
+"284 412 OFFCURVE",
+"168 576 CURVE",
+"180 499 LINE",
+"275 670 OFFCURVE",
+"301 730 OFFCURVE",
+"324 798 CURVE",
+"347 839 LINE",
+"356 864 OFFCURVE",
+"365 892 OFFCURVE",
+"374 918 CURVE",
+"301 939 LINE",
+"250 786 OFFCURVE",
+"199 678 OFFCURVE",
+"129 566 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"328 798 LINE",
+"380 718 OFFCURVE",
+"409 628 OFFCURVE",
+"409 536 CURVE SMOOTH",
+"409 451 OFFCURVE",
+"392 357 OFFCURVE",
+"359 260 CURVE",
+"347 260 LINE",
+"291 127 OFFCURVE",
+"212 4 OFFCURVE",
+"90 -159 CURVE",
+"152 -203 LINE",
+"411 150 OFFCURVE",
+"485 330 OFFCURVE",
+"485 536 CURVE SMOOTH",
+"485 662 OFFCURVE",
+"445 766 OFFCURVE",
+"340 889 CURVE",
+"297 798 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 670;
+}
+);
+unicode = 1B17C;
+},
+{
+glyphname = u1B17D;
+lastChange = "2020-04-13 08:27:21 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"370 939 LINE",
+"345 546 OFFCURVE",
+"257 306 OFFCURVE",
+"70 95 CURVE",
+"127 47 LINE",
+"322 269 OFFCURVE",
+"417 505 OFFCURVE",
+"446 933 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"681 279 OFFCURVE",
+"704 296 OFFCURVE",
+"704 335 CURVE SMOOTH",
+"704 374 OFFCURVE",
+"681 391 OFFCURVE",
+"653 391 CURVE SMOOTH",
+"624 391 OFFCURVE",
+"601 374 OFFCURVE",
+"601 335 CURVE SMOOTH",
+"601 296 OFFCURVE",
+"624 279 OFFCURVE",
+"653 279 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"332 504 LINE",
+"411 341 OFFCURVE",
+"425 208 OFFCURVE",
+"425 54 CURVE SMOOTH",
+"425 -39 OFFCURVE",
+"421 -115 OFFCURVE",
+"412 -198 CURVE",
+"486 -203 LINE",
+"495 -122 OFFCURVE",
+"501 -41 OFFCURVE",
+"501 52 CURVE SMOOTH",
+"501 220 OFFCURVE",
+"480 363 OFFCURVE",
+"385 573 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 784;
+}
+);
+leftMetricsKey = u1B173;
+rightMetricsKey = u1B177;
+unicode = 1B17D;
+},
+{
+glyphname = u1B17E;
+lastChange = "2020-04-13 08:27:25 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"447 939 LINE",
+"356 789 OFFCURVE",
+"247 669 OFFCURVE",
+"120 550 CURVE",
+"162 417 OFFCURVE",
+"175 311 OFFCURVE",
+"175 187 CURVE SMOOTH",
+"175 51 OFFCURVE",
+"158 -64 OFFCURVE",
+"120 -182 CURVE",
+"191 -203 LINE",
+"235 -77 OFFCURVE",
+"251 46 OFFCURVE",
+"251 187 CURVE SMOOTH",
+"251 315 OFFCURVE",
+"234 431 OFFCURVE",
+"196 568 CURVE",
+"190 512 LINE",
+"310 626 OFFCURVE",
+"420 745 OFFCURVE",
+"515 903 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"558 315 LINE",
+"530 492 OFFCURVE",
+"490 611 OFFCURVE",
+"403 777 CURVE",
+"359 703 LINE",
+"427 558 OFFCURVE",
+"457 460 OFFCURVE",
+"481 303 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 658;
+}
+);
+unicode = 1B17E;
+},
+{
+glyphname = u1B17F;
+lastChange = "2020-04-11 14:47:57 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"160 274 OFFCURVE",
+"183 291 OFFCURVE",
+"183 330 CURVE SMOOTH",
+"183 369 OFFCURVE",
+"160 386 OFFCURVE",
+"132 386 CURVE SMOOTH",
+"103 386 OFFCURVE",
+"80 369 OFFCURVE",
+"80 330 CURVE SMOOTH",
+"80 291 OFFCURVE",
+"103 274 OFFCURVE",
+"132 274 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"637 12 OFFCURVE",
+"660 29 OFFCURVE",
+"660 68 CURVE SMOOTH",
+"660 107 OFFCURVE",
+"637 124 OFFCURVE",
+"609 124 CURVE SMOOTH",
+"580 124 OFFCURVE",
+"557 107 OFFCURVE",
+"557 68 CURVE SMOOTH",
+"557 29 OFFCURVE",
+"580 12 OFFCURVE",
+"609 12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"401 939 LINE",
+"400 472 OFFCURVE",
+"314 93 OFFCURVE",
+"177 -169 CURVE",
+"247 -203 LINE",
+"386 61 OFFCURVE",
+"476 443 OFFCURVE",
+"479 938 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 740;
+}
+);
+leftMetricsKey = u1B176;
+rightMetricsKey = u1B177;
+unicode = 1B17F;
+},
+{
+glyphname = u1B180;
+lastChange = "2020-04-13 08:27:28 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"547 68 LINE",
+"422 328 OFFCURVE",
+"314 525 OFFCURVE",
+"143 774 CURVE",
+"80 731 LINE",
+"248 490 OFFCURVE",
+"363 278 OFFCURVE",
+"480 30 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"568 939 LINE",
+"488 765 OFFCURVE",
+"405 614 OFFCURVE",
+"315 474 CURVE",
+"286 434 LINE",
+"223 339 OFFCURVE",
+"156 250 OFFCURVE",
+"84 161 CURVE",
+"144 114 LINE",
+"210 195 OFFCURVE",
+"275 281 OFFCURVE",
+"335 371 CURVE",
+"359 403 LINE",
+"457 552 OFFCURVE",
+"549 716 OFFCURVE",
+"638 909 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"675 367 LINE",
+"572 177 OFFCURVE",
+"449 -2 OFFCURVE",
+"313 -155 CURVE",
+"372 -203 LINE",
+"520 -33 OFFCURVE",
+"631 128 OFFCURVE",
+"743 331 CURVE"
+);
+}
+);
+vertOrigin = 30;
+vertWidth = 1362;
+width = 813;
+}
+);
+unicode = 1B180;
+},
+{
+glyphname = u1B181;
+lastChange = "2020-04-13 08:33:31 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"131 344 LINE",
+"274 172 OFFCURVE",
+"374 6 OFFCURVE",
+"469 -203 CURVE",
+"539 -172 LINE",
+"488 -65 OFFCURVE",
+"443 21 OFFCURVE",
+"364 154 CURVE",
+"353 154 LINE",
+"310 235 OFFCURVE",
+"282 276 OFFCURVE",
+"179 408 CURVE",
+"177 346 LINE",
+"273 474 OFFCURVE",
+"299 519 OFFCURVE",
+"334 590 CURVE",
+"344 590 LINE",
+"420 721 OFFCURVE",
+"455 812 OFFCURVE",
+"490 915 CURVE",
+"418 939 LINE",
+"387 849 OFFCURVE",
+"354 770 OFFCURVE",
+"315 696 CURVE",
+"299 660 LINE",
+"253 576 OFFCURVE",
+"196 494 OFFCURVE",
+"131 415 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"196 730 OFFCURVE",
+"260 673 OFFCURVE",
+"330 590 CURVE",
+"338 590 LINE",
+"395 524 OFFCURVE",
+"422 451 OFFCURVE",
+"422 380 CURVE SMOOTH",
+"422 310 OFFCURVE",
+"403 233 OFFCURVE",
+"357 154 CURVE",
+"346 154 LINE",
+"282 59 OFFCURVE",
+"217 -8 OFFCURVE",
+"120 -104 CURVE",
+"174 -158 LINE",
+"396 65 OFFCURVE",
+"498 205 OFFCURVE",
+"498 380 CURVE SMOOTH",
+"498 524 OFFCURVE",
+"425 648 OFFCURVE",
+"158 854 CURVE",
+"110 794 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 659;
+}
+);
+unicode = 1B181;
+},
+{
+glyphname = u1B182;
+lastChange = "2020-04-13 08:27:35 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"254 473 LINE",
+"335 594 OFFCURVE",
+"376 681 OFFCURVE",
+"406 763 CURVE",
+"434 802 LINE",
+"448 836 OFFCURVE",
+"465 875 OFFCURVE",
+"480 914 CURVE",
+"409 939 LINE",
+"343 766 OFFCURVE",
+"284 649 OFFCURVE",
+"207 532 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"410 763 LINE",
+"451 683 OFFCURVE",
+"464 611 OFFCURVE",
+"464 521 CURVE SMOOTH",
+"464 441 OFFCURVE",
+"450 364 OFFCURVE",
+"413 274 CURVE",
+"402 274 LINE",
+"339 130 OFFCURVE",
+"253 -1 OFFCURVE",
+"138 -160 CURVE",
+"201 -203 LINE",
+"453 146 OFFCURVE",
+"540 347 OFFCURVE",
+"540 521 CURVE SMOOTH",
+"540 653 OFFCURVE",
+"505 758 OFFCURVE",
+"414 869 CURVE",
+"379 763 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 623 LINE",
+"274 364 OFFCURVE",
+"422 147 OFFCURVE",
+"570 -95 CURVE",
+"635 -55 LINE",
+"572 47 OFFCURVE",
+"511 143 OFFCURVE",
+"423 274 CURVE",
+"409 274 LINE",
+"350 378 OFFCURVE",
+"296 459 OFFCURVE",
+"139 668 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 705;
+}
+);
+unicode = 1B182;
+},
+{
+glyphname = u1B183;
+lastChange = "2020-04-13 08:27:38 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"274 432 LINE",
+"362 290 OFFCURVE",
+"433 170 OFFCURVE",
+"501 22 CURVE",
+"566 62 LINE",
+"493 217 OFFCURVE",
+"416 352 OFFCURVE",
+"316 505 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"552 939 LINE",
+"412 658 OFFCURVE",
+"213 362 OFFCURVE",
+"60 165 CURVE",
+"118 120 LINE",
+"269 310 OFFCURVE",
+"480 627 OFFCURVE",
+"622 908 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"690 367 LINE",
+"583 180 OFFCURVE",
+"449 -11 OFFCURVE",
+"322 -155 CURVE",
+"378 -203 LINE",
+"524 -34 OFFCURVE",
+"636 129 OFFCURVE",
+"756 331 CURVE"
+);
+}
+);
+vertOrigin = 24;
+vertWidth = 1362;
+width = 826;
+}
+);
+rightMetricsKey = u1B180;
+unicode = 1B183;
+},
+{
+glyphname = u1B184;
+lastChange = "2020-04-13 08:27:44 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"340 -62 OFFCURVE",
+"363 -45 OFFCURVE",
+"363 -6 CURVE SMOOTH",
+"363 33 OFFCURVE",
+"340 50 OFFCURVE",
+"312 50 CURVE SMOOTH",
+"283 50 OFFCURVE",
+"260 33 OFFCURVE",
+"260 -6 CURVE SMOOTH",
+"260 -45 OFFCURVE",
+"283 -62 OFFCURVE",
+"312 -62 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"390 939 LINE",
+"365 546 OFFCURVE",
+"267 306 OFFCURVE",
+"70 95 CURVE",
+"125 45 LINE",
+"330 264 OFFCURVE",
+"437 505 OFFCURVE",
+"466 933 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"361 510 LINE",
+"448 348 OFFCURVE",
+"479 198 OFFCURVE",
+"479 22 CURVE SMOOTH",
+"479 -59 OFFCURVE",
+"477 -114 OFFCURVE",
+"469 -197 CURVE",
+"543 -203 LINE",
+"552 -122 OFFCURVE",
+"555 -61 OFFCURVE",
+"555 20 CURVE SMOOTH",
+"555 220 OFFCURVE",
+"521 373 OFFCURVE",
+"403 591 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 675;
+}
+);
+leftMetricsKey = u1B173;
+unicode = 1B184;
+},
+{
+glyphname = u1B185;
+lastChange = "2020-04-13 08:29:59 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"355 939 LINE",
+"293 691 OFFCURVE",
+"222 543 OFFCURVE",
+"80 364 CURVE",
+"141 319 LINE",
+"286 499 OFFCURVE",
+"366 671 OFFCURVE",
+"429 923 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"360 788 LINE",
+"474 652 OFFCURVE",
+"561 521 OFFCURVE",
+"648 344 CURVE",
+"719 377 LINE",
+"617 579 OFFCURVE",
+"532 699 OFFCURVE",
+"407 854 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"368 457 LINE",
+"383 341 OFFCURVE",
+"388 225 OFFCURVE",
+"388 122 CURVE SMOOTH",
+"388 -11 OFFCURVE",
+"383 -97 OFFCURVE",
+"367 -192 CURVE",
+"441 -203 LINE",
+"457 -106 OFFCURVE",
+"464 -10 OFFCURVE",
+"464 123 CURVE SMOOTH",
+"464 233 OFFCURVE",
+"457 346 OFFCURVE",
+"439 464 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 809;
+}
+);
+unicode = 1B185;
+},
+{
+glyphname = u1B186;
+lastChange = "2020-04-13 08:29:50 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"207 570 OFFCURVE",
+"240 425 OFFCURVE",
+"240 266 CURVE SMOOTH",
+"240 89 OFFCURVE",
+"218 -41 OFFCURVE",
+"170 -181 CURVE",
+"241 -203 LINE",
+"292 -62 OFFCURVE",
+"314 75 OFFCURVE",
+"314 266 CURVE SMOOTH",
+"314 289 OFFCURVE",
+"313 311 OFFCURVE",
+"312 363 CURVE",
+"298 384 LINE",
+"293 501 OFFCURVE",
+"267 612 OFFCURVE",
+"189 784 CURVE",
+"120 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"517 654 OFFCURVE",
+"404 489 OFFCURVE",
+"302 383 CURVE",
+"274 390 LINE",
+"285 271 LINE",
+"460 441 OFFCURVE",
+"569 589 OFFCURVE",
+"648 924 CURVE",
+"573 939 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"462 530 LINE",
+"537 394 OFFCURVE",
+"577 279 OFFCURVE",
+"603 135 CURVE",
+"679 149 LINE",
+"649 318 OFFCURVE",
+"599 439 OFFCURVE",
+"506 593 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 779;
+}
+);
+leftMetricsKey = u1B17E;
+rightMetricsKey = u1B17E;
+unicode = 1B186;
+},
+{
+glyphname = u1B187;
+lastChange = "2020-04-13 08:29:47 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"553 -199 LINE",
+"527 272 OFFCURVE",
+"408 552 OFFCURVE",
+"191 896 CURVE",
+"126 856 LINE",
+"343 515 OFFCURVE",
+"461 215 OFFCURVE",
+"477 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"477 939 LINE",
+"423 845 OFFCURVE",
+"364 757 OFFCURVE",
+"298 676 CURVE",
+"270 648 LINE",
+"207 572 OFFCURVE",
+"138 501 OFFCURVE",
+"60 432 CURVE",
+"112 377 LINE",
+"183 440 OFFCURVE",
+"249 506 OFFCURVE",
+"310 577 CURVE",
+"341 608 LINE",
+"416 699 OFFCURVE",
+"483 796 OFFCURVE",
+"543 902 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"634 675 LINE",
+"567 574 OFFCURVE",
+"498 484 OFFCURVE",
+"424 401 CURVE",
+"395 375 LINE",
+"323 299 OFFCURVE",
+"247 229 OFFCURVE",
+"163 162 CURVE",
+"211 103 LINE",
+"283 160 OFFCURVE",
+"351 221 OFFCURVE",
+"417 288 CURVE",
+"456 323 LINE",
+"540 414 OFFCURVE",
+"620 516 OFFCURVE",
+"697 632 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 787;
+}
+);
+unicode = 1B187;
+},
+{
+glyphname = u1B188;
+lastChange = "2020-04-13 08:29:39 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"140 -1 OFFCURVE",
+"163 16 OFFCURVE",
+"163 55 CURVE SMOOTH",
+"163 94 OFFCURVE",
+"140 111 OFFCURVE",
+"112 111 CURVE SMOOTH",
+"83 111 OFFCURVE",
+"60 94 OFFCURVE",
+"60 55 CURVE SMOOTH",
+"60 16 OFFCURVE",
+"83 -1 OFFCURVE",
+"112 -1 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"694 863 LINE",
+"648 587 OFFCURVE",
+"593 361 OFFCURVE",
+"517 160 CURVE SMOOTH",
+"489 87 OFFCURVE",
+"463 26 OFFCURVE",
+"442 -28 CURVE",
+"438 -28 LINE",
+"424 20 OFFCURVE",
+"405 72 OFFCURVE",
+"376 136 CURVE SMOOTH",
+"339 217 OFFCURVE",
+"298 294 OFFCURVE",
+"248 370 CURVE",
+"184 329 LINE",
+"270 192 OFFCURVE",
+"322 86 OFFCURVE",
+"386 -83 CURVE",
+"486 -89 LINE",
+"611 156 OFFCURVE",
+"700 428 OFFCURVE",
+"769 854 CURVE"
+);
+}
+);
+vertOrigin = 24;
+vertWidth = 1362;
+width = 849;
+}
+);
+unicode = 1B188;
+},
+{
+glyphname = u1B189;
+lastChange = "2020-04-13 08:29:36 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"563 -199 LINE",
+"539 194 OFFCURVE",
+"483 409 OFFCURVE",
+"355 692 CURVE",
+"303 624 LINE",
+"421 363 OFFCURVE",
+"467 130 OFFCURVE",
+"487 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"477 939 LINE",
+"363 743 OFFCURVE",
+"232 578 OFFCURVE",
+"60 426 CURVE",
+"113 372 LINE",
+"285 524 OFFCURVE",
+"427 698 OFFCURVE",
+"543 902 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"634 670 LINE",
+"575 580 OFFCURVE",
+"513 500 OFFCURVE",
+"448 424 CURVE",
+"413 390 LINE",
+"336 306 OFFCURVE",
+"254 229 OFFCURVE",
+"163 156 CURVE",
+"211 97 LINE",
+"289 160 OFFCURVE",
+"364 227 OFFCURVE",
+"436 302 CURVE",
+"474 338 LINE",
+"552 424 OFFCURVE",
+"626 519 OFFCURVE",
+"698 628 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 788;
+}
+);
+leftMetricsKey = u1B187;
+rightMetricsKey = u1B187;
+unicode = 1B189;
+},
+{
+glyphname = u1B18A;
+lastChange = "2020-04-13 08:29:33 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"459 342 LINE",
+"378 204 OFFCURVE",
+"294 120 OFFCURVE",
+"169 26 CURVE",
+"213 -31 LINE",
+"344 66 OFFCURVE",
+"432 156 OFFCURVE",
+"522 306 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"564 155 LINE",
+"474 24 OFFCURVE",
+"379 -64 OFFCURVE",
+"264 -144 CURVE",
+"306 -203 LINE",
+"428 -118 OFFCURVE",
+"532 -22 OFFCURVE",
+"623 114 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"424 939 LINE",
+"393 571 OFFCURVE",
+"323 405 OFFCURVE",
+"80 190 CURVE",
+"127 133 LINE",
+"372 350 OFFCURVE",
+"467 521 OFFCURVE",
+"500 934 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 723;
+}
+);
+leftMetricsKey = u1B171;
+rightMetricsKey = u1B171;
+unicode = 1B18A;
+},
+{
+glyphname = u1B18B;
+lastChange = "2020-04-12 09:59:30 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"570 733 LINE",
+"500 625 OFFCURVE",
+"442 560 OFFCURVE",
+"347 478 CURVE",
+"377 372 OFFCURVE",
+"388 287 OFFCURVE",
+"388 189 CURVE SMOOTH",
+"388 100 OFFCURVE",
+"383 41 OFFCURVE",
+"370 -32 CURVE",
+"443 -43 LINE",
+"457 39 OFFCURVE",
+"464 106 OFFCURVE",
+"464 190 CURVE SMOOTH",
+"464 287 OFFCURVE",
+"452 376 OFFCURVE",
+"416 497 CURVE",
+"414 435 LINE",
+"498 509 OFFCURVE",
+"564 583 OFFCURVE",
+"634 692 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"447 939 LINE",
+"356 789 OFFCURVE",
+"247 669 OFFCURVE",
+"120 550 CURVE",
+"162 417 OFFCURVE",
+"175 311 OFFCURVE",
+"175 187 CURVE SMOOTH",
+"175 51 OFFCURVE",
+"158 -64 OFFCURVE",
+"120 -182 CURVE",
+"191 -203 LINE",
+"235 -77 OFFCURVE",
+"251 46 OFFCURVE",
+"251 187 CURVE SMOOTH",
+"251 315 OFFCURVE",
+"234 431 OFFCURVE",
+"196 568 CURVE",
+"190 512 LINE",
+"310 626 OFFCURVE",
+"420 745 OFFCURVE",
+"515 903 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 714;
+}
+);
+leftMetricsKey = u1B17E;
+unicode = 1B18B;
+},
+{
+glyphname = u1B18C;
+lastChange = "2020-04-11 14:57:49 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"721 558 OFFCURVE",
+"744 575 OFFCURVE",
+"744 614 CURVE SMOOTH",
+"744 653 OFFCURVE",
+"721 670 OFFCURVE",
+"693 670 CURVE SMOOTH",
+"664 670 OFFCURVE",
+"641 653 OFFCURVE",
+"641 614 CURVE SMOOTH",
+"641 575 OFFCURVE",
+"664 558 OFFCURVE",
+"693 558 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"160 156 OFFCURVE",
+"183 173 OFFCURVE",
+"183 212 CURVE SMOOTH",
+"183 251 OFFCURVE",
+"160 268 OFFCURVE",
+"132 268 CURVE SMOOTH",
+"103 268 OFFCURVE",
+"80 251 OFFCURVE",
+"80 212 CURVE SMOOTH",
+"80 173 OFFCURVE",
+"103 156 OFFCURVE",
+"132 156 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"249 522 OFFCURVE",
+"282 371 OFFCURVE",
+"282 202 CURVE SMOOTH",
+"282 69 OFFCURVE",
+"259 -51 OFFCURVE",
+"204 -175 CURVE",
+"270 -203 LINE",
+"334 -65 OFFCURVE",
+"358 56 OFFCURVE",
+"358 202 CURVE SMOOTH",
+"358 393 OFFCURVE",
+"325 529 OFFCURVE",
+"239 735 CURVE",
+"170 707 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"572 279 OFFCURVE",
+"527 415 OFFCURVE",
+"527 593 CURVE SMOOTH",
+"527 692 OFFCURVE",
+"538 794 OFFCURVE",
+"569 923 CURVE",
+"497 939 LINE",
+"467 812 OFFCURVE",
+"451 710 OFFCURVE",
+"451 594 CURVE SMOOTH",
+"451 405 OFFCURVE",
+"501 250 OFFCURVE",
+"609 99 CURVE",
+"666 139 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 824;
+}
+);
+leftMetricsKey = u1B176;
+rightMetricsKey = u1B177;
+unicode = 1B18C;
+},
+{
+glyphname = u1B18D;
+lastChange = "2020-04-13 08:29:28 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"483 270 LINE",
+"473 339 OFFCURVE",
+"455 395 OFFCURVE",
+"417 485 CURVE",
+"354 459 LINE",
+"387 383 OFFCURVE",
+"414 307 OFFCURVE",
+"436 221 CURVE",
+"525 218 LINE",
+"589 308 OFFCURVE",
+"611 394 OFFCURVE",
+"611 476 CURVE SMOOTH",
+"611 590 OFFCURVE",
+"563 705 OFFCURVE",
+"409 846 CURVE",
+"378 782 LINE",
+"502 652 OFFCURVE",
+"535 568 OFFCURVE",
+"535 470 CURVE SMOOTH",
+"535 402 OFFCURVE",
+"521 342 OFFCURVE",
+"487 270 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"447 939 LINE",
+"356 789 OFFCURVE",
+"247 669 OFFCURVE",
+"120 550 CURVE",
+"162 417 OFFCURVE",
+"175 311 OFFCURVE",
+"175 187 CURVE SMOOTH",
+"175 51 OFFCURVE",
+"158 -64 OFFCURVE",
+"120 -182 CURVE",
+"191 -203 LINE",
+"235 -77 OFFCURVE",
+"251 46 OFFCURVE",
+"251 187 CURVE SMOOTH",
+"251 315 OFFCURVE",
+"234 431 OFFCURVE",
+"196 568 CURVE",
+"190 512 LINE",
+"310 626 OFFCURVE",
+"420 745 OFFCURVE",
+"515 903 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 711;
+}
+);
+leftMetricsKey = u1B17E;
+unicode = 1B18D;
+},
+{
+glyphname = u1B18E;
+lastChange = "2020-04-13 08:29:24 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"487 919 LINE",
+"432 819 OFFCURVE",
+"374 725 OFFCURVE",
+"306 633 CURVE",
+"278 591 LINE",
+"217 512 OFFCURVE",
+"149 432 OFFCURVE",
+"70 349 CURVE",
+"125 297 LINE",
+"199 374 OFFCURVE",
+"264 450 OFFCURVE",
+"324 528 CURVE",
+"347 562 LINE",
+"423 662 OFFCURVE",
+"491 767 OFFCURVE",
+"556 886 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"130 811 LINE",
+"365 450 OFFCURVE",
+"495 178 OFFCURVE",
+"635 -169 CURVE",
+"705 -140 LINE",
+"557 234 OFFCURVE",
+"422 490 OFFCURVE",
+"193 854 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"404 399 LINE",
+"307 254 OFFCURVE",
+"233 158 OFFCURVE",
+"113 31 CURVE",
+"167 -19 LINE",
+"276 97 OFFCURVE",
+"362 206 OFFCURVE",
+"457 352 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"409 -142 OFFCURVE",
+"432 -125 OFFCURVE",
+"432 -86 CURVE SMOOTH",
+"432 -47 OFFCURVE",
+"409 -30 OFFCURVE",
+"381 -30 CURVE SMOOTH",
+"352 -30 OFFCURVE",
+"329 -47 OFFCURVE",
+"329 -86 CURVE SMOOTH",
+"329 -125 OFFCURVE",
+"352 -142 OFFCURVE",
+"381 -142 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 735;
+}
+);
+leftMetricsKey = u1B17B;
+rightMetricsKey = u1B17B;
+unicode = 1B18E;
+},
+{
+glyphname = u1B18F;
+lastChange = "2020-04-13 08:19:56 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"638 383 OFFCURVE",
+"661 400 OFFCURVE",
+"661 439 CURVE SMOOTH",
+"661 478 OFFCURVE",
+"638 495 OFFCURVE",
+"610 495 CURVE SMOOTH",
+"581 495 OFFCURVE",
+"558 478 OFFCURVE",
+"558 439 CURVE SMOOTH",
+"558 400 OFFCURVE",
+"581 383 OFFCURVE",
+"610 383 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"178 255 OFFCURVE",
+"201 272 OFFCURVE",
+"201 311 CURVE SMOOTH",
+"201 350 OFFCURVE",
+"178 367 OFFCURVE",
+"150 367 CURVE SMOOTH",
+"121 367 OFFCURVE",
+"98 350 OFFCURVE",
+"98 311 CURVE SMOOTH",
+"98 272 OFFCURVE",
+"121 255 OFFCURVE",
+"150 255 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"596 -89 LINE",
+"542 74 OFFCURVE",
+"469 244 OFFCURVE",
+"398 372 CURVE",
+"370 402 LINE",
+"294 543 OFFCURVE",
+"230 644 OFFCURVE",
+"140 763 CURVE",
+"80 717 LINE",
+"178 587 OFFCURVE",
+"253 470 OFFCURVE",
+"337 308 CURVE",
+"366 273 LINE",
+"422 162 OFFCURVE",
+"481 24 OFFCURVE",
+"525 -110 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"476 939 LINE",
+"422 543 OFFCURVE",
+"295 176 OFFCURVE",
+"127 -172 CURVE",
+"194 -203 LINE",
+"360 141 OFFCURVE",
+"494 514 OFFCURVE",
+"551 928 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 741;
+}
+);
+leftMetricsKey = u1B176;
+rightMetricsKey = u1B177;
+unicode = 1B18F;
+},
+{
+glyphname = u1B190;
+lastChange = "2020-04-13 08:29:19 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"287 -102 OFFCURVE",
+"325 -156 OFFCURVE",
+"404 -203 CURVE",
+"475 -194 LINE",
+"555 -106 OFFCURVE",
+"582 -33 OFFCURVE",
+"582 43 CURVE SMOOTH",
+"582 130 OFFCURVE",
+"545 186 OFFCURVE",
+"461 236 CURVE",
+"387 226 LINE",
+"310 123 OFFCURVE",
+"287 50 OFFCURVE",
+"287 -9 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"437 170 LINE",
+"486 131 OFFCURVE",
+"508 92 OFFCURVE",
+"508 40 CURVE SMOOTH",
+"508 -23 OFFCURVE",
+"486 -79 OFFCURVE",
+"435 -143 CURVE",
+"430 -144 LINE",
+"382 -102 OFFCURVE",
+"361 -64 OFFCURVE",
+"361 -10 CURVE SMOOTH",
+"361 43 OFFCURVE",
+"382 109 OFFCURVE",
+"432 169 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"200 684 OFFCURVE",
+"211 591 OFFCURVE",
+"211 486 CURVE SMOOTH",
+"211 359 OFFCURVE",
+"182 262 OFFCURVE",
+"100 150 CURVE",
+"160 110 LINE",
+"254 240 OFFCURVE",
+"285 339 OFFCURVE",
+"285 490 CURVE SMOOTH",
+"285 599 OFFCURVE",
+"272 691 OFFCURVE",
+"226 817 CURVE",
+"158 793 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"595 431 OFFCURVE",
+"561 519 OFFCURVE",
+"561 651 CURVE SMOOTH",
+"561 745 OFFCURVE",
+"573 820 OFFCURVE",
+"607 918 CURVE",
+"538 939 LINE",
+"499 830 OFFCURVE",
+"487 749 OFFCURVE",
+"487 651 CURVE SMOOTH",
+"487 499 OFFCURVE",
+"534 383 OFFCURVE",
+"642 273 CURVE",
+"694 320 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 794;
+}
+);
+leftMetricsKey = u1B174;
+rightMetricsKey = u1B174;
+unicode = 1B190;
+},
+{
+glyphname = u1B191;
+lastChange = "2020-04-13 08:29:15 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"663 343 LINE",
+"596 279 OFFCURVE",
+"531 224 OFFCURVE",
+"462 172 CURVE",
+"427 150 LINE",
+"355 99 OFFCURVE",
+"278 52 OFFCURVE",
+"191 4 CURVE",
+"227 -61 LINE",
+"303 -18 OFFCURVE",
+"368 21 OFFCURVE",
+"429 63 CURVE",
+"473 89 LINE",
+"554 147 OFFCURVE",
+"629 210 OFFCURVE",
+"715 290 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"523 939 LINE",
+"371 765 OFFCURVE",
+"235 646 OFFCURVE",
+"60 520 CURVE",
+"105 460 LINE",
+"281 587 OFFCURVE",
+"414 702 OFFCURVE",
+"580 889 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"525 740 OFFCURVE",
+"549 692 OFFCURVE",
+"549 634 CURVE SMOOTH",
+"549 528 OFFCURVE",
+"456 441 OFFCURVE",
+"140 229 CURVE",
+"183 167 LINE",
+"528 395 OFFCURVE",
+"625 499 OFFCURVE",
+"625 634 CURVE SMOOTH",
+"625 719 OFFCURVE",
+"594 781 OFFCURVE",
+"511 864 CURVE",
+"472 793 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"392 363 LINE",
+"408 247 OFFCURVE",
+"413 170 OFFCURVE",
+"413 42 CURVE SMOOTH",
+"413 -51 OFFCURVE",
+"409 -113 OFFCURVE",
+"401 -196 CURVE",
+"476 -203 LINE",
+"485 -122 OFFCURVE",
+"489 -53 OFFCURVE",
+"489 40 CURVE SMOOTH",
+"489 170 OFFCURVE",
+"480 281 OFFCURVE",
+"457 408 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 795;
+}
+);
+leftMetricsKey = u1B179;
+unicode = 1B191;
+},
+{
+glyphname = u1B192;
+lastChange = "2020-04-13 08:29:12 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"160 101 OFFCURVE",
+"183 118 OFFCURVE",
+"183 157 CURVE SMOOTH",
+"183 196 OFFCURVE",
+"160 213 OFFCURVE",
+"132 213 CURVE SMOOTH",
+"103 213 OFFCURVE",
+"80 196 OFFCURVE",
+"80 157 CURVE SMOOTH",
+"80 118 OFFCURVE",
+"103 101 OFFCURVE",
+"132 101 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"523 939 LINE",
+"432 789 OFFCURVE",
+"323 669 OFFCURVE",
+"196 550 CURVE",
+"260 403 OFFCURVE",
+"290 299 OFFCURVE",
+"290 167 CURVE SMOOTH",
+"290 52 OFFCURVE",
+"269 -61 OFFCURVE",
+"223 -178 CURVE",
+"290 -203 LINE",
+"340 -84 OFFCURVE",
+"366 39 OFFCURVE",
+"366 167 CURVE SMOOTH",
+"366 299 OFFCURVE",
+"333 428 OFFCURVE",
+"273 561 CURVE",
+"266 512 LINE",
+"386 624 OFFCURVE",
+"495 742 OFFCURVE",
+"591 901 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"634 315 LINE",
+"606 492 OFFCURVE",
+"566 611 OFFCURVE",
+"479 777 CURVE",
+"435 703 LINE",
+"503 558 OFFCURVE",
+"533 460 OFFCURVE",
+"557 303 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 734;
+}
+);
+leftMetricsKey = u1B176;
+rightMetricsKey = u1B17E;
+unicode = 1B192;
+},
+{
+glyphname = u1B193;
+lastChange = "2020-04-13 08:29:09 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"140 29 OFFCURVE",
+"163 46 OFFCURVE",
+"163 85 CURVE SMOOTH",
+"163 124 OFFCURVE",
+"140 141 OFFCURVE",
+"112 141 CURVE SMOOTH",
+"83 141 OFFCURVE",
+"60 124 OFFCURVE",
+"60 85 CURVE SMOOTH",
+"60 46 OFFCURVE",
+"83 29 OFFCURVE",
+"112 29 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"448 409 OFFCURVE",
+"471 426 OFFCURVE",
+"471 465 CURVE SMOOTH",
+"471 504 OFFCURVE",
+"448 521 OFFCURVE",
+"420 521 CURVE SMOOTH",
+"391 521 OFFCURVE",
+"368 504 OFFCURVE",
+"368 465 CURVE SMOOTH",
+"368 426 OFFCURVE",
+"391 409 OFFCURVE",
+"420 409 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"694 863 LINE",
+"648 587 OFFCURVE",
+"593 361 OFFCURVE",
+"517 160 CURVE SMOOTH",
+"489 87 OFFCURVE",
+"463 26 OFFCURVE",
+"442 -28 CURVE",
+"438 -28 LINE",
+"424 20 OFFCURVE",
+"405 72 OFFCURVE",
+"376 136 CURVE SMOOTH",
+"339 217 OFFCURVE",
+"298 294 OFFCURVE",
+"248 370 CURVE",
+"184 329 LINE",
+"270 192 OFFCURVE",
+"322 86 OFFCURVE",
+"386 -83 CURVE",
+"486 -89 LINE",
+"611 156 OFFCURVE",
+"700 428 OFFCURVE",
+"769 854 CURVE"
+);
+}
+);
+vertOrigin = 24;
+vertWidth = 1362;
+width = 849;
+}
+);
+leftMetricsKey = u1B188;
+rightMetricsKey = u1B188;
+unicode = 1B193;
+},
+{
+glyphname = u1B194;
+lastChange = "2020-04-13 08:29:04 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"496 168 LINE",
+"435 56 OFFCURVE",
+"377 -30 OFFCURVE",
+"287 -148 CURVE",
+"344 -192 LINE",
+"433 -78 OFFCURVE",
+"492 14 OFFCURVE",
+"555 134 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"471 939 LINE",
+"415 831 OFFCURVE",
+"358 736 OFFCURVE",
+"294 642 CURVE",
+"264 605 LINE",
+"207 525 OFFCURVE",
+"144 445 OFFCURVE",
+"70 360 CURVE",
+"129 312 LINE",
+"196 389 OFFCURVE",
+"255 462 OFFCURVE",
+"309 537 CURVE",
+"336 569 LINE",
+"408 671 OFFCURVE",
+"474 779 OFFCURVE",
+"541 908 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"606 711 LINE",
+"547 607 OFFCURVE",
+"484 508 OFFCURVE",
+"414 410 CURVE",
+"384 375 LINE",
+"320 289 OFFCURVE",
+"249 203 OFFCURVE",
+"170 114 CURVE",
+"227 66 LINE",
+"299 148 OFFCURVE",
+"364 227 OFFCURVE",
+"425 308 CURVE",
+"454 341 LINE",
+"533 447 OFFCURVE",
+"604 556 OFFCURVE",
+"673 678 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"110 829 LINE",
+"338 468 OFFCURVE",
+"485 144 OFFCURVE",
+"626 -203 CURVE",
+"696 -175 LINE",
+"549 199 OFFCURVE",
+"393 512 OFFCURVE",
+"174 870 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 786;
+}
+);
+leftMetricsKey = u1B17B;
+unicode = 1B194;
+},
+{
+glyphname = u1B195;
+lastChange = "2020-04-13 08:29:01 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"735 509 OFFCURVE",
+"758 526 OFFCURVE",
+"758 565 CURVE SMOOTH",
+"758 604 OFFCURVE",
+"735 621 OFFCURVE",
+"707 621 CURVE SMOOTH",
+"678 621 OFFCURVE",
+"655 604 OFFCURVE",
+"655 565 CURVE SMOOTH",
+"655 526 OFFCURVE",
+"678 509 OFFCURVE",
+"707 509 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"160 386 OFFCURVE",
+"183 403 OFFCURVE",
+"183 442 CURVE SMOOTH",
+"183 481 OFFCURVE",
+"160 498 OFFCURVE",
+"132 498 CURVE SMOOTH",
+"103 498 OFFCURVE",
+"80 481 OFFCURVE",
+"80 442 CURVE SMOOTH",
+"80 403 OFFCURVE",
+"103 386 OFFCURVE",
+"132 386 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"754 -72 LINE",
+"665 154 OFFCURVE",
+"570 313 OFFCURVE",
+"433 504 CURVE",
+"418 395 LINE",
+"526 235 OFFCURVE",
+"609 84 OFFCURVE",
+"682 -101 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"403 939 LINE",
+"402 465 OFFCURVE",
+"311 114 OFFCURVE",
+"146 -169 CURVE",
+"214 -203 LINE",
+"376 82 OFFCURVE",
+"478 443 OFFCURVE",
+"481 938 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 838;
+}
+);
+leftMetricsKey = u1B176;
+unicode = 1B195;
+},
+{
+glyphname = u1B196;
+lastChange = "2020-04-13 08:28:58 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"457 742 OFFCURVE",
+"428 593 OFFCURVE",
+"390 449 CURVE",
+"372 399 LINE",
+"322 223 OFFCURVE",
+"255 49 OFFCURVE",
+"152 -172 CURVE",
+"219 -203 LINE",
+"306 -17 OFFCURVE",
+"371 147 OFFCURVE",
+"422 309 CURVE",
+"439 353 LINE",
+"465 440 OFFCURVE",
+"488 528 OFFCURVE",
+"507 619 CURVE SMOOTH",
+"524 702 OFFCURVE",
+"538 776 OFFCURVE",
+"542 853 CURVE",
+"546 854 LINE",
+"578 772 OFFCURVE",
+"605 697 OFFCURVE",
+"633 594 CURVE",
+"705 612 LINE",
+"669 732 OFFCURVE",
+"635 820 OFFCURVE",
+"578 934 CURVE",
+"487 925 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"228 606 OFFCURVE",
+"274 544 OFFCURVE",
+"306 488 CURVE SMOOTH",
+"415 298 OFFCURVE",
+"503 112 OFFCURVE",
+"575 -109 CURVE",
+"646 -85 LINE",
+"536 239 OFFCURVE",
+"408 484 OFFCURVE",
+"212 772 CURVE",
+"128 752 LINE",
+"113 585 OFFCURVE",
+"100 491 OFFCURVE",
+"80 390 CURVE",
+"153 378 LINE",
+"171 479 OFFCURVE",
+"185 573 OFFCURVE",
+"187 680 CURVE",
+"191 681 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 765;
+}
+);
+unicode = 1B196;
+},
+{
+glyphname = u1B197;
+lastChange = "2020-04-13 08:18:20 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"474 939 LINE",
+"361 688 OFFCURVE",
+"236 502 OFFCURVE",
+"80 318 CURVE",
+"147 264 LINE",
+"308 450 OFFCURVE",
+"426 633 OFFCURVE",
+"554 906 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"662 286 LINE",
+"575 132 OFFCURVE",
+"463 -12 OFFCURVE",
+"331 -142 CURVE",
+"389 -203 LINE",
+"532 -57 OFFCURVE",
+"643 80 OFFCURVE",
+"737 243 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"560 -1 LINE",
+"479 289 OFFCURVE",
+"364 562 OFFCURVE",
+"207 863 CURVE",
+"131 823 LINE",
+"296 518 OFFCURVE",
+"402 239 OFFCURVE",
+"483 -29 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"549 573 LINE",
+"448 394 OFFCURVE",
+"336 236 OFFCURVE",
+"200 87 CURVE",
+"263 31 LINE",
+"399 180 OFFCURVE",
+"515 343 OFFCURVE",
+"623 532 CURVE"
+);
+}
+);
+};
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"474 939 LINE",
+"420 818 OFFCURVE",
+"362 712 OFFCURVE",
+"300 615 CURVE",
+"272 577 LINE",
+"213 488 OFFCURVE",
+"150 405 OFFCURVE",
+"80 323 CURVE",
+"138 275 LINE",
+"202 349 OFFCURVE",
+"259 422 OFFCURVE",
+"313 501 CURVE",
+"343 541 LINE",
+"413 648 OFFCURVE",
+"478 766 OFFCURVE",
+"545 910 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"673 280 LINE",
+"586 126 OFFCURVE",
+"468 -20 OFFCURVE",
+"336 -150 CURVE",
+"389 -203 LINE",
+"532 -57 OFFCURVE",
+"643 80 OFFCURVE",
+"737 243 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"550 -4 LINE",
+"469 286 OFFCURVE",
+"354 557 OFFCURVE",
+"197 858 CURVE",
+"131 823 LINE",
+"296 518 OFFCURVE",
+"402 239 OFFCURVE",
+"483 -29 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"552 570 LINE",
+"510 495 OFFCURVE",
+"465 423 OFFCURVE",
+"418 355 CURVE",
+"388 317 LINE",
+"331 238 OFFCURVE",
+"270 162 OFFCURVE",
+"203 89 CURVE",
+"258 39 LINE",
+"316 103 OFFCURVE",
+"371 170 OFFCURVE",
+"423 240 CURVE",
+"449 270 LINE",
+"508 353 OFFCURVE",
+"564 441 OFFCURVE",
+"618 535 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 817;
+}
+);
+leftMetricsKey = u1B180;
+unicode = 1B197;
+},
+{
+glyphname = u1B198;
+lastChange = "2020-04-13 08:27:52 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"378 359 OFFCURVE",
+"409 292 OFFCURVE",
+"485 241 CURVE",
+"560 247 LINE",
+"608 316 OFFCURVE",
+"626 378 OFFCURVE",
+"626 440 CURVE SMOOTH",
+"626 556 OFFCURVE",
+"582 658 OFFCURVE",
+"421 851 CURVE",
+"387 777 LINE",
+"515 621 OFFCURVE",
+"552 546 OFFCURVE",
+"552 440 CURVE SMOOTH",
+"552 386 OFFCURVE",
+"541 339 OFFCURVE",
+"518 294 CURVE",
+"514 294 LINE",
+"472 339 OFFCURVE",
+"452 376 OFFCURVE",
+"452 434 CURVE SMOOTH",
+"452 492 OFFCURVE",
+"472 543 OFFCURVE",
+"541 627 CURVE",
+"515 679 LINE",
+"408 568 OFFCURVE",
+"378 497 OFFCURVE",
+"378 429 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"447 939 LINE",
+"356 789 OFFCURVE",
+"247 669 OFFCURVE",
+"120 550 CURVE",
+"162 417 OFFCURVE",
+"175 311 OFFCURVE",
+"175 187 CURVE SMOOTH",
+"175 51 OFFCURVE",
+"158 -64 OFFCURVE",
+"120 -182 CURVE",
+"191 -203 LINE",
+"235 -77 OFFCURVE",
+"251 46 OFFCURVE",
+"251 187 CURVE SMOOTH",
+"251 315 OFFCURVE",
+"234 431 OFFCURVE",
+"196 568 CURVE",
+"190 512 LINE",
+"310 626 OFFCURVE",
+"420 745 OFFCURVE",
+"515 903 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 726;
+}
+);
+leftMetricsKey = u1B17E;
+rightMetricsKey = u1B18D;
+unicode = 1B198;
+},
+{
+glyphname = u1B199;
+lastChange = "2020-04-13 08:30:01 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"375 403 LINE",
+"319 178 OFFCURVE",
+"248 27 OFFCURVE",
+"129 -146 CURVE",
+"191 -186 LINE",
+"313 -6 OFFCURVE",
+"389 143 OFFCURVE",
+"449 387 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"373 245 LINE",
+"484 99 OFFCURVE",
+"552 -24 OFFCURVE",
+"615 -168 CURVE",
+"684 -136 LINE",
+"610 24 OFFCURVE",
+"536 156 OFFCURVE",
+"421 303 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"355 919 LINE",
+"293 671 OFFCURVE",
+"222 523 OFFCURVE",
+"80 344 CURVE",
+"139 299 LINE",
+"284 479 OFFCURVE",
+"366 651 OFFCURVE",
+"429 903 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"362 769 LINE",
+"476 633 OFFCURVE",
+"563 502 OFFCURVE",
+"650 325 CURVE",
+"719 357 LINE",
+"617 559 OFFCURVE",
+"532 679 OFFCURVE",
+"407 834 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 809;
+}
+);
+leftMetricsKey = u1B185;
+rightMetricsKey = u1B185;
+unicode = 1B199;
+},
+{
+glyphname = u1B19A;
+lastChange = "2020-04-13 08:30:27 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"617 939 LINE",
+"539 676 OFFCURVE",
+"429 515 OFFCURVE",
+"266 371 CURVE",
+"311 320 LINE",
+"505 481 OFFCURVE",
+"604 642 OFFCURVE",
+"690 917 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"200 614 OFFCURVE",
+"227 471 OFFCURVE",
+"227 291 CURVE SMOOTH",
+"227 114 OFFCURVE",
+"208 -12 OFFCURVE",
+"146 -180 CURVE",
+"216 -203 LINE",
+"279 -32 OFFCURVE",
+"303 108 OFFCURVE",
+"303 291 CURVE SMOOTH",
+"303 481 OFFCURVE",
+"268 642 OFFCURVE",
+"188 820 CURVE",
+"120 792 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"585 -107 LINE",
+"657 11 OFFCURVE",
+"708 144 OFFCURVE",
+"748 294 CURVE",
+"674 313 LINE",
+"635 162 OFFCURVE",
+"596 62 OFFCURVE",
+"547 -43 CURVE",
+"541 -43 LINE",
+"528 31 OFFCURVE",
+"505 88 OFFCURVE",
+"481 141 CURVE SMOOTH",
+"447 215 OFFCURVE",
+"394 298 OFFCURVE",
+"327 371 CURVE",
+"280 329 LINE",
+"386 191 OFFCURVE",
+"445 56 OFFCURVE",
+"491 -96 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 828;
+}
+);
+leftMetricsKey = u1B186;
+unicode = 1B19A;
+},
+{
+glyphname = u1B19B;
+lastChange = "2020-04-13 08:21:42 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"180 50 OFFCURVE",
+"203 67 OFFCURVE",
+"203 106 CURVE SMOOTH",
+"203 145 OFFCURVE",
+"180 162 OFFCURVE",
+"152 162 CURVE SMOOTH",
+"123 162 OFFCURVE",
+"100 145 OFFCURVE",
+"100 106 CURVE SMOOTH",
+"100 67 OFFCURVE",
+"123 50 OFFCURVE",
+"152 50 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"246 259 OFFCURVE",
+"269 276 OFFCURVE",
+"269 315 CURVE SMOOTH",
+"269 354 OFFCURVE",
+"246 371 OFFCURVE",
+"218 371 CURVE SMOOTH",
+"189 371 OFFCURVE",
+"166 354 OFFCURVE",
+"166 315 CURVE SMOOTH",
+"166 276 OFFCURVE",
+"189 259 OFFCURVE",
+"218 259 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"676 -89 LINE",
+"622 74 OFFCURVE",
+"549 244 OFFCURVE",
+"480 369 CURVE",
+"452 399 LINE",
+"374 543 OFFCURVE",
+"310 644 OFFCURVE",
+"220 763 CURVE",
+"160 717 LINE",
+"258 587 OFFCURVE",
+"333 470 OFFCURVE",
+"419 305 CURVE",
+"448 270 LINE",
+"502 162 OFFCURVE",
+"561 24 OFFCURVE",
+"605 -110 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"556 939 LINE",
+"502 543 OFFCURVE",
+"375 176 OFFCURVE",
+"207 -172 CURVE",
+"274 -203 LINE",
+"440 141 OFFCURVE",
+"574 514 OFFCURVE",
+"631 928 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 776;
+}
+);
+rightMetricsKey = u1B175;
+unicode = 1B19B;
+},
+{
+glyphname = u1B19C;
+lastChange = "2020-04-13 08:30:31 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"634 406 LINE",
+"558 305 OFFCURVE",
+"538 221 OFFCURVE",
+"538 125 CURVE SMOOTH",
+"538 27 OFFCURVE",
+"562 -58 OFFCURVE",
+"630 -129 CURVE",
+"686 -84 LINE",
+"634 -19 OFFCURVE",
+"614 45 OFFCURVE",
+"614 126 CURVE SMOOTH",
+"614 202 OFFCURVE",
+"634 282 OFFCURVE",
+"693 365 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"196 -203 LINE",
+"239 -133 OFFCURVE",
+"256 -65 OFFCURVE",
+"256 26 CURVE SMOOTH",
+"256 122 OFFCURVE",
+"227 188 OFFCURVE",
+"154 276 CURVE",
+"100 232 LINE",
+"161 162 OFFCURVE",
+"182 104 OFFCURVE",
+"182 26 CURVE SMOOTH",
+"182 -62 OFFCURVE",
+"169 -115 OFFCURVE",
+"136 -170 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"576 907 LINE",
+"534 737 OFFCURVE",
+"494 607 OFFCURVE",
+"451 493 CURVE SMOOTH",
+"419 412 OFFCURVE",
+"393 354 OFFCURVE",
+"358 285 CURVE",
+"354 285 LINE",
+"326 359 OFFCURVE",
+"298 416 OFFCURVE",
+"272 465 CURVE SMOOTH",
+"245 516 OFFCURVE",
+"208 569 OFFCURVE",
+"179 612 CURVE",
+"119 573 LINE",
+"191 465 OFFCURVE",
+"249 366 OFFCURVE",
+"307 238 CURVE",
+"402 232 LINE",
+"508 417 OFFCURVE",
+"570 578 OFFCURVE",
+"650 892 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 793;
+}
+);
+leftMetricsKey = u1B174;
+rightMetricsKey = u1B174;
+unicode = 1B19C;
+},
+{
+glyphname = u1B19D;
+lastChange = "2020-04-13 08:30:34 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"547 591 LINE",
+"466 316 OFFCURVE",
+"350 95 OFFCURVE",
+"182 -162 CURVE",
+"247 -203 LINE",
+"419 64 OFFCURVE",
+"524 266 OFFCURVE",
+"612 541 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"227 475 LINE",
+"365 280 OFFCURVE",
+"475 91 OFFCURVE",
+"566 -123 CURVE",
+"635 -93 LINE",
+"528 152 OFFCURVE",
+"411 346 OFFCURVE",
+"269 541 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"364 939 LINE",
+"297 686 OFFCURVE",
+"219 506 OFFCURVE",
+"80 297 CURVE",
+"143 255 LINE",
+"282 466 OFFCURVE",
+"363 639 OFFCURVE",
+"438 922 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"354 812 LINE",
+"489 644 OFFCURVE",
+"596 491 OFFCURVE",
+"700 303 CURVE",
+"767 343 LINE",
+"658 534 OFFCURVE",
+"552 690 OFFCURVE",
+"394 879 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 857;
+}
+);
+leftMetricsKey = u1B185;
+rightMetricsKey = u1B185;
+unicode = 1B19D;
+},
+{
+glyphname = u1B19E;
+lastChange = "2020-04-13 08:30:38 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"508 15 OFFCURVE",
+"503 102 OFFCURVE",
+"485 207 CURVE SMOOTH",
+"455 378 OFFCURVE",
+"407 552 OFFCURVE",
+"345 694 CURVE",
+"292 636 LINE",
+"378 420 OFFCURVE",
+"428 159 OFFCURVE",
+"444 -122 CURVE",
+"531 -153 LINE",
+"636 -41 OFFCURVE",
+"712 60 OFFCURVE",
+"804 204 CURVE",
+"739 241 LINE",
+"659 108 OFFCURVE",
+"592 22 OFFCURVE",
+"515 -77 CURVE",
+"509 -75 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"476 939 LINE",
+"362 743 OFFCURVE",
+"232 580 OFFCURVE",
+"60 428 CURVE",
+"110 370 LINE",
+"279 522 OFFCURVE",
+"427 701 OFFCURVE",
+"543 903 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"613 666 LINE",
+"550 572 OFFCURVE",
+"487 491 OFFCURVE",
+"421 416 CURVE",
+"386 384 LINE",
+"321 315 OFFCURVE",
+"253 251 OFFCURVE",
+"178 186 CURVE",
+"229 130 LINE",
+"295 188 OFFCURVE",
+"357 245 OFFCURVE",
+"417 307 CURVE",
+"446 332 LINE",
+"525 417 OFFCURVE",
+"601 511 OFFCURVE",
+"677 625 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 884;
+}
+);
+leftMetricsKey = u1B187;
+unicode = 1B19E;
+},
+{
+glyphname = u1B19F;
+lastChange = "2020-04-13 08:30:44 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"90 385 LINE",
+"121 275 OFFCURVE",
+"141 184 OFFCURVE",
+"153 76 CURVE",
+"223 86 LINE",
+"212 198 OFFCURVE",
+"191 292 OFFCURVE",
+"158 404 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"197 495 LINE",
+"336 303 OFFCURVE",
+"448 116 OFFCURVE",
+"562 -107 CURVE",
+"628 -74 LINE",
+"573 36 OFFCURVE",
+"519 129 OFFCURVE",
+"440 260 CURVE",
+"423 260 LINE",
+"386 354 OFFCURVE",
+"334 438 OFFCURVE",
+"236 576 CURVE",
+"248 499 LINE",
+"324 625 OFFCURVE",
+"362 704 OFFCURVE",
+"392 798 CURVE",
+"415 839 LINE",
+"424 864 OFFCURVE",
+"433 892 OFFCURVE",
+"442 918 CURVE",
+"369 939 LINE",
+"318 786 OFFCURVE",
+"267 678 OFFCURVE",
+"197 566 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"396 798 LINE",
+"448 718 OFFCURVE",
+"477 628 OFFCURVE",
+"477 536 CURVE SMOOTH",
+"477 451 OFFCURVE",
+"460 357 OFFCURVE",
+"427 260 CURVE",
+"415 260 LINE",
+"359 127 OFFCURVE",
+"280 4 OFFCURVE",
+"158 -159 CURVE",
+"220 -203 LINE",
+"322 -64 OFFCURVE",
+"393 54 OFFCURVE",
+"444 154 CURVE",
+"468 189 LINE",
+"531 318 OFFCURVE",
+"553 423 OFFCURVE",
+"553 536 CURVE SMOOTH",
+"553 662 OFFCURVE",
+"513 766 OFFCURVE",
+"408 889 CURVE",
+"365 798 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 738;
+}
+);
+rightMetricsKey = u1B17C;
+unicode = 1B19F;
+},
+{
+glyphname = u1B1A0;
+lastChange = "2020-04-13 08:30:47 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"416 248 LINE",
+"458 381 OFFCURVE",
+"484 485 OFFCURVE",
+"505 596 CURVE SMOOTH",
+"521 682 OFFCURVE",
+"536 762 OFFCURVE",
+"539 861 CURVE",
+"545 862 LINE",
+"579 765 OFFCURVE",
+"601 711 OFFCURVE",
+"633 594 CURVE",
+"705 612 LINE",
+"669 735 OFFCURVE",
+"633 825 OFFCURVE",
+"578 939 CURVE",
+"487 925 LINE",
+"457 722 OFFCURVE",
+"428 553 OFFCURVE",
+"386 401 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"474 363 OFFCURVE",
+"374 594 OFFCURVE",
+"204 782 CURVE",
+"128 759 LINE",
+"115 602 OFFCURVE",
+"100 491 OFFCURVE",
+"80 390 CURVE",
+"153 379 LINE",
+"171 480 OFFCURVE",
+"187 594 OFFCURVE",
+"184 697 CURVE",
+"190 699 LINE",
+"249 611 OFFCURVE",
+"292 545 OFFCURVE",
+"329 456 CURVE SMOOTH",
+"384 325 OFFCURVE",
+"398 217 OFFCURVE",
+"398 56 CURVE SMOOTH",
+"398 -38 OFFCURVE",
+"394 -105 OFFCURVE",
+"383 -196 CURVE",
+"457 -203 LINE",
+"467 -124 OFFCURVE",
+"474 -46 OFFCURVE",
+"474 56 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 765;
+}
+);
+leftMetricsKey = u1B196;
+rightMetricsKey = u1B196;
+unicode = 1B1A0;
+},
+{
+glyphname = u1B1A1;
+lastChange = "2020-04-13 08:30:50 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"541 870 LINE",
+"409 567 OFFCURVE",
+"263 345 OFFCURVE",
+"60 90 CURVE",
+"119 43 LINE",
+"322 295 OFFCURVE",
+"473 523 OFFCURVE",
+"612 843 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"202 554 OFFCURVE",
+"225 571 OFFCURVE",
+"225 610 CURVE SMOOTH",
+"225 649 OFFCURVE",
+"202 666 OFFCURVE",
+"174 666 CURVE SMOOTH",
+"145 666 OFFCURVE",
+"122 649 OFFCURVE",
+"122 610 CURVE SMOOTH",
+"122 571 OFFCURVE",
+"145 554 OFFCURVE",
+"174 554 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"267 315 LINE",
+"291 187 OFFCURVE",
+"303 47 OFFCURVE",
+"309 -122 CURVE",
+"396 -153 LINE",
+"507 -49 OFFCURVE",
+"588 69 OFFCURVE",
+"692 261 CURVE",
+"627 297 LINE",
+"591 231 OFFCURVE",
+"559 174 OFFCURVE",
+"529 125 CURVE SMOOTH",
+"474 36 OFFCURVE",
+"437 -12 OFFCURVE",
+"380 -75 CURVE",
+"375 -74 LINE",
+"378 10 OFFCURVE",
+"373 87 OFFCURVE",
+"366 149 CURVE SMOOTH",
+"356 237 OFFCURVE",
+"341 326 OFFCURVE",
+"322 415 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 772;
+}
+);
+leftMetricsKey = u1B183;
+rightMetricsKey = u1B19E;
+unicode = 1B1A1;
+},
+{
+glyphname = u1B1A2;
+lastChange = "2020-04-13 08:30:53 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"351 -64 LINE",
+"322 9 OFFCURVE",
+"299 69 OFFCURVE",
+"266 139 CURVE SMOOTH",
+"229 218 OFFCURVE",
+"188 296 OFFCURVE",
+"145 373 CURVE",
+"80 336 LINE",
+"157 200 OFFCURVE",
+"234 45 OFFCURVE",
+"294 -112 CURVE",
+"395 -126 LINE",
+"564 112 OFFCURVE",
+"688 348 OFFCURVE",
+"783 621 CURVE",
+"713 644 LINE",
+"653 472 OFFCURVE",
+"574 303 OFFCURVE",
+"492 157 CURVE SMOOTH",
+"445 73 OFFCURVE",
+"404 15 OFFCURVE",
+"355 -64 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"510 896 LINE",
+"462 726 OFFCURVE",
+"417 588 OFFCURVE",
+"365 458 CURVE",
+"345 421 LINE",
+"310 339 OFFCURVE",
+"273 259 OFFCURVE",
+"230 174 CURVE",
+"268 99 LINE",
+"312 180 OFFCURVE",
+"349 255 OFFCURVE",
+"382 328 CURVE",
+"407 373 LINE",
+"476 532 OFFCURVE",
+"527 686 OFFCURVE",
+"583 879 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"158 699 LINE",
+"282 496 OFFCURVE",
+"372 320 OFFCURVE",
+"466 85 CURVE",
+"522 139 LINE",
+"430 372 OFFCURVE",
+"345 529 OFFCURVE",
+"224 737 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 873;
+}
+);
+leftMetricsKey = u1B19D;
+rightMetricsKey = u1B19D;
+unicode = 1B1A2;
+},
+{
+glyphname = u1B1A3;
+lastChange = "2020-04-13 08:30:56 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"322 -203 LINE",
+"468 -38 OFFCURVE",
+"518 102 OFFCURVE",
+"518 285 CURVE SMOOTH",
+"518 450 OFFCURVE",
+"468 561 OFFCURVE",
+"337 735 CURVE",
+"279 686 LINE",
+"398 540 OFFCURVE",
+"442 428 OFFCURVE",
+"442 282 CURVE SMOOTH",
+"442 116 OFFCURVE",
+"397 -12 OFFCURVE",
+"266 -158 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"436 939 LINE",
+"324 782 OFFCURVE",
+"213 666 OFFCURVE",
+"70 548 CURVE",
+"115 492 LINE",
+"259 611 OFFCURVE",
+"377 731 OFFCURVE",
+"497 896 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"604 741 LINE",
+"545 666 OFFCURVE",
+"491 606 OFFCURVE",
+"436 552 CURVE",
+"403 525 LINE",
+"342 467 OFFCURVE",
+"277 414 OFFCURVE",
+"199 356 CURVE",
+"242 297 LINE",
+"313 351 OFFCURVE",
+"376 402 OFFCURVE",
+"434 456 CURVE",
+"466 481 LINE",
+"532 545 OFFCURVE",
+"594 613 OFFCURVE",
+"662 695 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"166 115 LINE",
+"248 74 OFFCURVE",
+"323 31 OFFCURVE",
+"391 -12 CURVE",
+"425 -31 LINE",
+"494 -75 OFFCURVE",
+"557 -121 OFFCURVE",
+"616 -169 CURVE",
+"661 -112 LINE",
+"592 -58 OFFCURVE",
+"524 -9 OFFCURVE",
+"452 38 CURVE",
+"415 59 LINE",
+"348 102 OFFCURVE",
+"277 142 OFFCURVE",
+"198 182 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 772;
+}
+);
+unicode = 1B1A3;
+},
+{
+glyphname = u1B1A4;
+lastChange = "2020-04-13 08:30:59 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"290 384 OFFCURVE",
+"454 268 OFFCURVE",
+"573 160 CURVE",
+"579 205 LINE",
+"494 53 OFFCURVE",
+"445 -24 OFFCURVE",
+"341 -160 CURVE",
+"398 -203 LINE",
+"511 -56 OFFCURVE",
+"570 34 OFFCURVE",
+"655 191 CURVE",
+"502 327 OFFCURVE",
+"339 441 OFFCURVE",
+"179 548 CURVE",
+"178 514 LINE",
+"257 632 OFFCURVE",
+"324 748 OFFCURVE",
+"402 906 CURVE",
+"333 939 LINE",
+"259 788 OFFCURVE",
+"195 676 OFFCURVE",
+"90 516 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"527 680 LINE",
+"472 582 OFFCURVE",
+"419 491 OFFCURVE",
+"364 403 CURVE",
+"334 365 LINE",
+"270 268 OFFCURVE",
+"213 195 OFFCURVE",
+"143 112 CURVE",
+"200 62 LINE",
+"273 149 OFFCURVE",
+"328 225 OFFCURVE",
+"387 317 CURVE",
+"418 353 LINE",
+"480 446 OFFCURVE",
+"537 540 OFFCURVE",
+"594 645 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 745;
+}
+);
+unicode = 1B1A4;
+},
+{
+glyphname = u1B1A5;
+lastChange = "2020-04-13 08:31:02 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"577 655 LINE",
+"535 603 OFFCURVE",
+"495 558 OFFCURVE",
+"454 517 CURVE",
+"421 488 LINE",
+"357 428 OFFCURVE",
+"287 376 OFFCURVE",
+"201 319 CURVE",
+"238 257 LINE",
+"312 303 OFFCURVE",
+"378 350 OFFCURVE",
+"439 403 CURVE",
+"474 431 LINE",
+"531 483 OFFCURVE",
+"583 541 OFFCURVE",
+"636 608 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"321 716 LINE",
+"416 476 OFFCURVE",
+"455 297 OFFCURVE",
+"477 87 CURVE",
+"551 93 LINE",
+"524 327 OFFCURVE",
+"480 514 OFFCURVE",
+"374 778 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"447 939 LINE",
+"356 789 OFFCURVE",
+"247 669 OFFCURVE",
+"120 550 CURVE",
+"162 417 OFFCURVE",
+"175 311 OFFCURVE",
+"175 187 CURVE SMOOTH",
+"175 51 OFFCURVE",
+"158 -64 OFFCURVE",
+"120 -182 CURVE",
+"191 -203 LINE",
+"235 -77 OFFCURVE",
+"251 46 OFFCURVE",
+"251 187 CURVE SMOOTH",
+"251 315 OFFCURVE",
+"234 431 OFFCURVE",
+"196 568 CURVE",
+"190 512 LINE",
+"310 626 OFFCURVE",
+"420 745 OFFCURVE",
+"515 903 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 726;
+}
+);
+leftMetricsKey = u1B17E;
+unicode = 1B1A5;
+},
+{
+glyphname = u1B1A6;
+lastChange = "2020-04-13 08:31:04 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"474 939 LINE",
+"386 634 OFFCURVE",
+"284 384 OFFCURVE",
+"120 99 CURVE",
+"186 64 LINE",
+"229 139 OFFCURVE",
+"266 209 OFFCURVE",
+"300 277 CURVE",
+"314 327 LINE",
+"350 401 OFFCURVE",
+"376 460 OFFCURVE",
+"401 520 CURVE",
+"428 566 LINE",
+"471 677 OFFCURVE",
+"508 787 OFFCURVE",
+"547 919 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"172 769 LINE",
+"239 695 OFFCURVE",
+"299 624 OFFCURVE",
+"355 553 CURVE",
+"388 523 LINE",
+"436 459 OFFCURVE",
+"475 405 OFFCURVE",
+"514 349 CURVE",
+"536 305 LINE",
+"581 238 OFFCURVE",
+"626 167 OFFCURVE",
+"671 91 CURVE",
+"731 130 LINE",
+"565 409 OFFCURVE",
+"425 596 OFFCURVE",
+"225 818 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"629 673 LINE",
+"600 592 OFFCURVE",
+"568 507 OFFCURVE",
+"534 424 CURVE",
+"521 376 LINE",
+"495 313 OFFCURVE",
+"467 249 OFFCURVE",
+"430 172 CURVE",
+"410 146 LINE",
+"360 41 OFFCURVE",
+"306 -63 OFFCURVE",
+"247 -168 CURVE",
+"312 -203 LINE",
+"464 68 OFFCURVE",
+"591 346 OFFCURVE",
+"699 651 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"90 521 LINE",
+"286 301 OFFCURVE",
+"440 64 OFFCURVE",
+"568 -168 CURVE",
+"632 -135 LINE",
+"578 -36 OFFCURVE",
+"521 59 OFFCURVE",
+"461 151 CURVE",
+"443 172 LINE",
+"394 241 OFFCURVE",
+"356 296 OFFCURVE",
+"307 363 CURVE",
+"285 398 LINE",
+"240 457 OFFCURVE",
+"192 515 OFFCURVE",
+"143 573 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 831;
+}
+);
+unicode = 1B1A6;
+},
+{
+glyphname = u1B1A7;
+lastChange = "2020-04-13 08:31:07 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"295 540 LINE",
+"372 351 OFFCURVE",
+"429 176 OFFCURVE",
+"476 -19 CURVE",
+"542 13 LINE",
+"493 231 OFFCURVE",
+"426 420 OFFCURVE",
+"347 615 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"474 939 LINE",
+"361 688 OFFCURVE",
+"236 502 OFFCURVE",
+"80 318 CURVE",
+"137 271 LINE",
+"298 457 OFFCURVE",
+"416 638 OFFCURVE",
+"544 911 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"671 280 LINE",
+"584 126 OFFCURVE",
+"471 -23 OFFCURVE",
+"339 -153 CURVE",
+"389 -203 LINE",
+"532 -57 OFFCURVE",
+"643 80 OFFCURVE",
+"737 243 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"558 568 LINE",
+"518 496 OFFCURVE",
+"476 429 OFFCURVE",
+"431 363 CURVE",
+"397 321 LINE",
+"338 238 OFFCURVE",
+"274 159 OFFCURVE",
+"204 82 CURVE",
+"258 33 LINE",
+"318 99 OFFCURVE",
+"374 167 OFFCURVE",
+"427 239 CURVE",
+"462 279 LINE",
+"518 358 OFFCURVE",
+"572 442 OFFCURVE",
+"623 532 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 817;
+}
+);
+leftMetricsKey = u1B197;
+rightMetricsKey = u1B197;
+unicode = 1B1A7;
+},
+{
+glyphname = u1B1A8;
+lastChange = "2020-04-13 08:31:10 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"334 -74 OFFCURVE",
+"357 -57 OFFCURVE",
+"357 -18 CURVE SMOOTH",
+"357 21 OFFCURVE",
+"334 38 OFFCURVE",
+"306 38 CURVE SMOOTH",
+"277 38 OFFCURVE",
+"254 21 OFFCURVE",
+"254 -18 CURVE SMOOTH",
+"254 -57 OFFCURVE",
+"277 -74 OFFCURVE",
+"306 -74 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"712 229 OFFCURVE",
+"735 246 OFFCURVE",
+"735 285 CURVE SMOOTH",
+"735 324 OFFCURVE",
+"712 341 OFFCURVE",
+"684 341 CURVE SMOOTH",
+"655 341 OFFCURVE",
+"632 324 OFFCURVE",
+"632 285 CURVE SMOOTH",
+"632 246 OFFCURVE",
+"655 229 OFFCURVE",
+"684 229 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"594 -194 LINE",
+"550 179 OFFCURVE",
+"483 409 OFFCURVE",
+"355 692 CURVE",
+"303 624 LINE",
+"421 363 OFFCURVE",
+"479 110 OFFCURVE",
+"519 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"477 939 LINE",
+"363 743 OFFCURVE",
+"232 578 OFFCURVE",
+"60 426 CURVE",
+"113 372 LINE",
+"285 524 OFFCURVE",
+"427 698 OFFCURVE",
+"543 902 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"634 671 LINE",
+"574 580 OFFCURVE",
+"512 498 OFFCURVE",
+"446 423 CURVE",
+"415 392 LINE",
+"338 306 OFFCURVE",
+"255 229 OFFCURVE",
+"163 156 CURVE",
+"211 97 LINE",
+"292 162 OFFCURVE",
+"369 231 OFFCURVE",
+"442 309 CURVE",
+"477 343 LINE",
+"554 428 OFFCURVE",
+"627 522 OFFCURVE",
+"698 629 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 855;
+}
+);
+leftMetricsKey = u1B187;
+unicode = 1B1A8;
+},
+{
+glyphname = u1B1A9;
+lastChange = "2020-04-13 08:31:12 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"482 246 LINE",
+"463 344 OFFCURVE",
+"442 406 OFFCURVE",
+"401 492 CURVE",
+"343 447 LINE",
+"382 356 OFFCURVE",
+"398 306 OFFCURVE",
+"420 204 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"661 415 LINE",
+"505 298 OFFCURVE",
+"343 199 OFFCURVE",
+"169 115 CURVE",
+"203 49 LINE",
+"382 136 OFFCURVE",
+"540 233 OFFCURVE",
+"707 357 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"628 254 OFFCURVE",
+"642 216 OFFCURVE",
+"642 170 CURVE SMOOTH",
+"642 80 OFFCURVE",
+"549 3 OFFCURVE",
+"241 -135 CURVE",
+"271 -203 LINE",
+"582 -63 OFFCURVE",
+"718 29 OFFCURVE",
+"718 174 CURVE SMOOTH",
+"718 234 OFFCURVE",
+"695 289 OFFCURVE",
+"633 363 CURVE",
+"586 313 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"541 939 LINE",
+"374 812 OFFCURVE",
+"253 737 OFFCURVE",
+"60 634 CURVE",
+"94 569 LINE",
+"287 672 OFFCURVE",
+"420 752 OFFCURVE",
+"588 882 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"517 782 OFFCURVE",
+"535 736 OFFCURVE",
+"535 686 CURVE SMOOTH",
+"535 602 OFFCURVE",
+"457 536 OFFCURVE",
+"115 365 CURVE",
+"148 299 LINE",
+"554 494 OFFCURVE",
+"611 584 OFFCURVE",
+"611 686 CURVE SMOOTH",
+"611 762 OFFCURVE",
+"580 817 OFFCURVE",
+"519 888 CURVE",
+"466 842 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 848;
+}
+);
+leftMetricsKey = u1B179;
+rightMetricsKey = u1B179;
+unicode = 1B1A9;
+},
+{
+glyphname = u1B1AA;
+lastChange = "2020-04-13 08:31:15 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"534 754 OFFCURVE",
+"547 711 OFFCURVE",
+"547 667 CURVE SMOOTH",
+"547 571 OFFCURVE",
+"462 504 OFFCURVE",
+"156 332 CURVE",
+"192 265 LINE",
+"527 453 OFFCURVE",
+"623 536 OFFCURVE",
+"623 667 CURVE SMOOTH",
+"623 738 OFFCURVE",
+"597 795 OFFCURVE",
+"514 884 CURVE",
+"481 813 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"529 -33 LINE",
+"520 121 OFFCURVE",
+"500 278 OFFCURVE",
+"467 438 CURVE",
+"399 393 LINE",
+"430 229 OFFCURVE",
+"444 111 OFFCURVE",
+"453 -41 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"567 939 LINE",
+"414 796 OFFCURVE",
+"268 701 OFFCURVE",
+"80 584 CURVE",
+"120 522 LINE",
+"308 638 OFFCURVE",
+"452 731 OFFCURVE",
+"619 886 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 -95 OFFCURVE",
+"109 -143 OFFCURVE",
+"177 -183 CURVE",
+"248 -174 LINE",
+"316 -95 OFFCURVE",
+"334 -30 OFFCURVE",
+"334 31 CURVE SMOOTH",
+"334 91 OFFCURVE",
+"300 132 OFFCURVE",
+"232 170 CURVE",
+"158 160 LINE",
+"100 78 OFFCURVE",
+"80 11 OFFCURVE",
+"80 -38 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 116 LINE",
+"244 84 OFFCURVE",
+"259 49 OFFCURVE",
+"259 20 CURVE SMOOTH",
+"259 -23 OFFCURVE",
+"249 -68 OFFCURVE",
+"209 -132 CURVE",
+"204 -133 LINE",
+"169 -98 OFFCURVE",
+"154 -67 OFFCURVE",
+"154 -34 CURVE SMOOTH",
+"154 8 OFFCURVE",
+"167 52 OFFCURVE",
+"199 115 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 753;
+}
+);
+rightMetricsKey = u1B179;
+unicode = 1B1AA;
+},
+{
+glyphname = u1B1AB;
+lastChange = "2020-04-13 08:31:18 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"360 939 LINE",
+"360 396 OFFCURVE",
+"338 246 OFFCURVE",
+"289 65 CURVE",
+"363 49 LINE",
+"411 239 OFFCURVE",
+"417 382 OFFCURVE",
+"411 522 CURVE",
+"424 615 LINE",
+"435 713 OFFCURVE",
+"436 815 OFFCURVE",
+"436 937 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"384 507 LINE",
+"416 522 LINE",
+"456 447 OFFCURVE",
+"491 383 OFFCURVE",
+"538 284 CURVE",
+"605 315 LINE",
+"553 429 OFFCURVE",
+"493 520 OFFCURVE",
+"412 629 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"446 693 OFFCURVE",
+"280 566 OFFCURVE",
+"120 471 CURVE",
+"149 295 OFFCURVE",
+"160 195 OFFCURVE",
+"160 45 CURVE SMOOTH",
+"160 -55 OFFCURVE",
+"158 -106 OFFCURVE",
+"146 -194 CURVE",
+"220 -203 LINE",
+"231 -112 OFFCURVE",
+"234 -49 OFFCURVE",
+"234 47 CURVE SMOOTH",
+"234 203 OFFCURVE",
+"224 308 OFFCURVE",
+"190 485 CURVE",
+"173 413 LINE",
+"269 472 OFFCURVE",
+"371 545 OFFCURVE",
+"469 625 CURVE SMOOTH",
+"526 672 OFFCURVE",
+"573 716 OFFCURVE",
+"619 771 CURVE",
+"623 770 LINE",
+"638 674 OFFCURVE",
+"652 589 OFFCURVE",
+"659 497 CURVE SMOOTH",
+"663 445 OFFCURVE",
+"665 392 OFFCURVE",
+"665 338 CURVE SMOOTH",
+"665 268 OFFCURVE",
+"662 197 OFFCURVE",
+"656 131 CURVE",
+"730 125 LINE",
+"737 209 OFFCURVE",
+"739 278 OFFCURVE",
+"739 344 CURVE SMOOTH",
+"739 482 OFFCURVE",
+"726 643 OFFCURVE",
+"679 827 CURVE",
+"595 842 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 879;
+}
+);
+leftMetricsKey = u1B17E;
+unicode = 1B1AB;
+},
+{
+glyphname = u1B1AC;
+lastChange = "2020-04-12 10:00:52 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"192 376 LINE",
+"174 258 OFFCURVE",
+"147 156 OFFCURVE",
+"106 51 CURVE",
+"174 26 LINE",
+"216 137 OFFCURVE",
+"245 239 OFFCURVE",
+"266 365 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"50 216 LINE",
+"135 195 OFFCURVE",
+"233 161 OFFCURVE",
+"313 125 CURVE",
+"342 192 LINE",
+"252 230 OFFCURVE",
+"152 261 OFFCURVE",
+"66 285 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"232 495 LINE",
+"371 303 OFFCURVE",
+"483 116 OFFCURVE",
+"597 -107 CURVE",
+"663 -74 LINE",
+"608 36 OFFCURVE",
+"554 129 OFFCURVE",
+"475 260 CURVE",
+"458 260 LINE",
+"421 354 OFFCURVE",
+"369 438 OFFCURVE",
+"271 576 CURVE",
+"283 499 LINE",
+"359 625 OFFCURVE",
+"397 704 OFFCURVE",
+"427 798 CURVE",
+"450 839 LINE",
+"459 864 OFFCURVE",
+"468 892 OFFCURVE",
+"477 918 CURVE",
+"404 939 LINE",
+"353 786 OFFCURVE",
+"302 678 OFFCURVE",
+"232 566 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"431 798 LINE",
+"483 718 OFFCURVE",
+"512 628 OFFCURVE",
+"512 536 CURVE SMOOTH",
+"512 451 OFFCURVE",
+"495 357 OFFCURVE",
+"462 260 CURVE",
+"450 260 LINE",
+"394 127 OFFCURVE",
+"325 16 OFFCURVE",
+"179 -155 CURVE",
+"235 -203 LINE",
+"512 122 OFFCURVE",
+"588 342 OFFCURVE",
+"588 536 CURVE SMOOTH",
+"588 662 OFFCURVE",
+"548 766 OFFCURVE",
+"443 889 CURVE",
+"400 798 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 773;
+}
+);
+rightMetricsKey = u1B17C;
+unicode = 1B1AC;
+},
+{
+glyphname = u1B1AD;
+lastChange = "2020-04-13 08:32:21 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"415 523 LINE",
+"353 407 OFFCURVE",
+"257 289 OFFCURVE",
+"170 205 CURVE",
+"222 154 LINE",
+"313 240 OFFCURVE",
+"409 359 OFFCURVE",
+"479 487 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"494 335 LINE",
+"414 208 OFFCURVE",
+"332 119 OFFCURVE",
+"234 35 CURVE",
+"284 -22 LINE",
+"380 58 OFFCURVE",
+"469 153 OFFCURVE",
+"557 295 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"597 178 LINE",
+"507 39 OFFCURVE",
+"421 -55 OFFCURVE",
+"296 -146 CURVE",
+"343 -203 LINE",
+"471 -108 OFFCURVE",
+"564 -13 OFFCURVE",
+"657 135 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"365 939 LINE",
+"294 694 OFFCURVE",
+"222 562 OFFCURVE",
+"80 398 CURVE",
+"137 348 LINE",
+"286 526 OFFCURVE",
+"362 655 OFFCURVE",
+"441 923 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"364 784 LINE",
+"488 642 OFFCURVE",
+"575 526 OFFCURVE",
+"645 383 CURVE",
+"712 420 LINE",
+"623 586 OFFCURVE",
+"541 694 OFFCURVE",
+"413 838 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 802;
+}
+);
+leftMetricsKey = u1B185;
+rightMetricsKey = u1B185;
+unicode = 1B1AD;
+},
+{
+glyphname = u1B1AE;
+lastChange = "2020-04-13 08:32:19 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"507 468 LINE",
+"444 327 OFFCURVE",
+"366 210 OFFCURVE",
+"262 97 CURVE",
+"317 48 LINE",
+"427 167 OFFCURVE",
+"510 293 OFFCURVE",
+"575 438 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"639 261 LINE",
+"568 111 OFFCURVE",
+"474 -27 OFFCURVE",
+"338 -148 CURVE",
+"390 -203 LINE",
+"525 -82 OFFCURVE",
+"626 56 OFFCURVE",
+"708 229 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"249 314 LINE",
+"359 474 OFFCURVE",
+"446 647 OFFCURVE",
+"532 921 CURVE",
+"458 939 LINE",
+"419 813 OFFCURVE",
+"380 710 OFFCURVE",
+"338 622 CURVE SMOOTH",
+"295 530 OFFCURVE",
+"262 463 OFFCURVE",
+"221 378 CURVE",
+"216 379 LINE",
+"192 474 OFFCURVE",
+"154 580 OFFCURVE",
+"107 681 CURVE",
+"40 649 LINE",
+"94 536 OFFCURVE",
+"133 438 OFFCURVE",
+"168 324 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"453 791 LINE",
+"567 655 OFFCURVE",
+"654 522 OFFCURVE",
+"741 345 CURVE",
+"809 377 LINE",
+"707 579 OFFCURVE",
+"622 699 OFFCURVE",
+"497 854 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 899;
+}
+);
+rightMetricsKey = u1B185;
+unicode = 1B1AE;
+},
+{
+glyphname = u1B1AF;
+lastChange = "2020-04-13 08:32:16 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"160 296 OFFCURVE",
+"183 313 OFFCURVE",
+"183 352 CURVE SMOOTH",
+"183 391 OFFCURVE",
+"160 408 OFFCURVE",
+"132 408 CURVE SMOOTH",
+"103 408 OFFCURVE",
+"80 391 OFFCURVE",
+"80 352 CURVE SMOOTH",
+"80 313 OFFCURVE",
+"103 296 OFFCURVE",
+"132 296 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"452 755 OFFCURVE",
+"475 772 OFFCURVE",
+"475 811 CURVE SMOOTH",
+"475 850 OFFCURVE",
+"452 867 OFFCURVE",
+"424 867 CURVE SMOOTH",
+"395 867 OFFCURVE",
+"372 850 OFFCURVE",
+"372 811 CURVE SMOOTH",
+"372 772 OFFCURVE",
+"395 755 OFFCURVE",
+"424 755 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"270 570 OFFCURVE",
+"303 425 OFFCURVE",
+"303 266 CURVE SMOOTH",
+"303 89 OFFCURVE",
+"281 -41 OFFCURVE",
+"233 -181 CURVE",
+"304 -203 LINE",
+"355 -62 OFFCURVE",
+"377 75 OFFCURVE",
+"377 266 CURVE SMOOTH",
+"377 289 OFFCURVE",
+"376 311 OFFCURVE",
+"375 363 CURVE",
+"361 384 LINE",
+"356 501 OFFCURVE",
+"330 612 OFFCURVE",
+"252 784 CURVE",
+"183 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"580 654 OFFCURVE",
+"467 489 OFFCURVE",
+"365 383 CURVE",
+"337 390 LINE",
+"348 271 LINE",
+"523 441 OFFCURVE",
+"632 589 OFFCURVE",
+"711 924 CURVE",
+"636 939 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"513 530 LINE",
+"588 394 OFFCURVE",
+"628 279 OFFCURVE",
+"654 135 CURVE",
+"730 149 LINE",
+"700 318 OFFCURVE",
+"650 439 OFFCURVE",
+"557 593 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 830;
+}
+);
+leftMetricsKey = u1B192;
+rightMetricsKey = u1B186;
+unicode = 1B1AF;
+},
+{
+glyphname = u1B1B0;
+lastChange = "2020-04-12 10:01:00 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"654 591 OFFCURVE",
+"677 608 OFFCURVE",
+"677 647 CURVE SMOOTH",
+"677 686 OFFCURVE",
+"654 703 OFFCURVE",
+"626 703 CURVE SMOOTH",
+"597 703 OFFCURVE",
+"574 686 OFFCURVE",
+"574 647 CURVE SMOOTH",
+"574 608 OFFCURVE",
+"597 591 OFFCURVE",
+"626 591 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"157 420 OFFCURVE",
+"180 437 OFFCURVE",
+"180 476 CURVE SMOOTH",
+"180 515 OFFCURVE",
+"157 532 OFFCURVE",
+"129 532 CURVE SMOOTH",
+"100 532 OFFCURVE",
+"77 515 OFFCURVE",
+"77 476 CURVE SMOOTH",
+"77 437 OFFCURVE",
+"100 420 OFFCURVE",
+"129 420 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"381 340 LINE",
+"395 237 OFFCURVE",
+"398 153 OFFCURVE",
+"398 55 CURVE SMOOTH",
+"398 -33 OFFCURVE",
+"393 -114 OFFCURVE",
+"382 -194 CURVE",
+"456 -203 LINE",
+"469 -119 OFFCURVE",
+"474 -39 OFFCURVE",
+"474 56 CURVE SMOOTH",
+"474 155 OFFCURVE",
+"467 249 OFFCURVE",
+"452 349 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"462 939 LINE",
+"395 675 OFFCURVE",
+"302 467 OFFCURVE",
+"127 223 CURVE",
+"187 178 LINE",
+"361 422 OFFCURVE",
+"464 636 OFFCURVE",
+"536 921 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"293 582 OFFCURVE",
+"456 462 OFFCURVE",
+"625 303 CURVE",
+"677 358 LINE",
+"493 530 OFFCURVE",
+"341 639 OFFCURVE",
+"101 757 CURVE",
+"70 688 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 767;
+}
+);
+leftMetricsKey = u1B17A;
+rightMetricsKey = u1B17A;
+unicode = 1B1B0;
+},
+{
+glyphname = u1B1B1;
+lastChange = "2020-04-13 08:32:12 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"149 204 LINE",
+"190 67 OFFCURVE",
+"214 -63 OFFCURVE",
+"228 -203 CURVE",
+"301 -194 LINE",
+"287 -43 OFFCURVE",
+"262 86 OFFCURVE",
+"219 225 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"675 572 LINE",
+"650 502 OFFCURVE",
+"625 441 OFFCURVE",
+"595 382 CURVE SMOOTH",
+"550 294 OFFCURVE",
+"508 224 OFFCURVE",
+"451 140 CURVE",
+"446 141 LINE",
+"435 234 OFFCURVE",
+"417 312 OFFCURVE",
+"391 410 CURVE SMOOTH",
+"351 559 OFFCURVE",
+"299 699 OFFCURVE",
+"229 845 CURVE",
+"160 812 LINE",
+"275 579 OFFCURVE",
+"338 364 OFFCURVE",
+"386 88 CURVE",
+"479 70 LINE",
+"601 230 OFFCURVE",
+"670 350 OFFCURVE",
+"747 545 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"454 518 LINE",
+"532 373 OFFCURVE",
+"611 196 OFFCURVE",
+"658 56 CURVE",
+"726 80 LINE",
+"668 255 OFFCURVE",
+"597 408 OFFCURVE",
+"517 552 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"465 939 LINE",
+"366 726 OFFCURVE",
+"248 560 OFFCURVE",
+"80 372 CURVE",
+"134 324 LINE",
+"309 514 OFFCURVE",
+"413 669 OFFCURVE",
+"533 907 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 847;
+}
+);
+leftMetricsKey = u1B180;
+unicode = 1B1B1;
+},
+{
+glyphname = u1B1B2;
+lastChange = "2020-04-13 08:32:10 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"449 939 LINE",
+"392 688 OFFCURVE",
+"314 518 OFFCURVE",
+"164 324 CURVE",
+"223 280 LINE",
+"372 474 OFFCURVE",
+"462 654 OFFCURVE",
+"524 926 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"298 612 OFFCURVE",
+"454 523 OFFCURVE",
+"621 390 CURVE",
+"666 452 LINE",
+"481 590 OFFCURVE",
+"335 668 OFFCURVE",
+"130 759 CURVE",
+"103 690 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"536 -36 LINE",
+"527 118 OFFCURVE",
+"509 259 OFFCURVE",
+"466 435 CURVE",
+"400 419 LINE",
+"438 230 OFFCURVE",
+"453 112 OFFCURVE",
+"462 -40 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 -95 OFFCURVE",
+"109 -143 OFFCURVE",
+"177 -183 CURVE",
+"248 -174 LINE",
+"316 -95 OFFCURVE",
+"334 -30 OFFCURVE",
+"334 31 CURVE SMOOTH",
+"334 91 OFFCURVE",
+"300 132 OFFCURVE",
+"232 170 CURVE",
+"158 160 LINE",
+"100 78 OFFCURVE",
+"80 11 OFFCURVE",
+"80 -38 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 116 LINE",
+"244 84 OFFCURVE",
+"259 49 OFFCURVE",
+"259 20 CURVE SMOOTH",
+"259 -23 OFFCURVE",
+"249 -68 OFFCURVE",
+"209 -132 CURVE",
+"204 -133 LINE",
+"169 -98 OFFCURVE",
+"154 -67 OFFCURVE",
+"154 -34 CURVE SMOOTH",
+"154 8 OFFCURVE",
+"167 52 OFFCURVE",
+"199 115 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 756;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B17A;
+unicode = 1B1B2;
+},
+{
+glyphname = u1B1B3;
+lastChange = "2020-04-11 15:25:38 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"694 162 OFFCURVE",
+"717 179 OFFCURVE",
+"717 218 CURVE SMOOTH",
+"717 257 OFFCURVE",
+"694 274 OFFCURVE",
+"666 274 CURVE SMOOTH",
+"637 274 OFFCURVE",
+"614 257 OFFCURVE",
+"614 218 CURVE SMOOTH",
+"614 179 OFFCURVE",
+"637 162 OFFCURVE",
+"666 162 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"250 -55 OFFCURVE",
+"273 -38 OFFCURVE",
+"273 1 CURVE SMOOTH",
+"273 40 OFFCURVE",
+"250 57 OFFCURVE",
+"222 57 CURVE SMOOTH",
+"193 57 OFFCURVE",
+"170 40 OFFCURVE",
+"170 1 CURVE SMOOTH",
+"170 -38 OFFCURVE",
+"193 -55 OFFCURVE",
+"222 -55 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"523 939 LINE",
+"371 765 OFFCURVE",
+"235 646 OFFCURVE",
+"60 520 CURVE",
+"105 460 LINE",
+"281 587 OFFCURVE",
+"415 701 OFFCURVE",
+"581 888 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"525 740 OFFCURVE",
+"549 692 OFFCURVE",
+"549 634 CURVE SMOOTH",
+"549 528 OFFCURVE",
+"456 441 OFFCURVE",
+"140 229 CURVE",
+"183 167 LINE",
+"528 395 OFFCURVE",
+"625 499 OFFCURVE",
+"625 634 CURVE SMOOTH",
+"625 719 OFFCURVE",
+"594 781 OFFCURVE",
+"511 864 CURVE",
+"472 793 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"392 363 LINE",
+"408 247 OFFCURVE",
+"413 170 OFFCURVE",
+"413 42 CURVE SMOOTH",
+"413 -51 OFFCURVE",
+"409 -113 OFFCURVE",
+"401 -196 CURVE",
+"476 -203 LINE",
+"485 -122 OFFCURVE",
+"489 -53 OFFCURVE",
+"489 40 CURVE SMOOTH",
+"489 170 OFFCURVE",
+"480 281 OFFCURVE",
+"457 408 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 837;
+}
+);
+leftMetricsKey = u1B179;
+rightMetricsKey = u1B1A8;
+unicode = 1B1B3;
+},
+{
+glyphname = u1B1B4;
+lastChange = "2020-04-13 08:32:06 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"394 380 OFFCURVE",
+"330 258 OFFCURVE",
+"236 114 CURVE",
+"283 47 LINE",
+"346 144 OFFCURVE",
+"383 207 OFFCURVE",
+"418 272 CURVE SMOOTH",
+"455 341 OFFCURVE",
+"486 410 OFFCURVE",
+"519 506 CURVE",
+"523 506 LINE",
+"553 418 OFFCURVE",
+"586 346 OFFCURVE",
+"623 248 CURVE",
+"636 325 LINE",
+"600 248 OFFCURVE",
+"559 173 OFFCURVE",
+"513 100 CURVE SMOOTH",
+"468 28 OFFCURVE",
+"423 -42 OFFCURVE",
+"376 -114 CURVE",
+"371 -113 LINE",
+"350 -42 OFFCURVE",
+"321 33 OFFCURVE",
+"285 110 CURVE SMOOTH",
+"246 194 OFFCURVE",
+"202 281 OFFCURVE",
+"152 376 CURVE",
+"145 272 LINE",
+"276 496 OFFCURVE",
+"370 665 OFFCURVE",
+"459 914 CURVE",
+"388 939 LINE",
+"301 698 OFFCURVE",
+"210 532 OFFCURVE",
+"90 330 CURVE",
+"188 145 OFFCURVE",
+"263 -13 OFFCURVE",
+"321 -173 CURVE",
+"408 -183 LINE",
+"510 -53 OFFCURVE",
+"608 91 OFFCURVE",
+"694 271 CURVE",
+"655 379 OFFCURVE",
+"618 473 OFFCURVE",
+"563 583 CURVE",
+"481 583 LINE"
+);
+}
+);
+vertOrigin = 45;
+vertWidth = 1362;
+width = 784;
+}
+);
+unicode = 1B1B4;
+},
+{
+glyphname = u1B1B5;
+lastChange = "2020-04-13 08:32:03 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"566 194 OFFCURVE",
+"589 211 OFFCURVE",
+"589 250 CURVE SMOOTH",
+"589 289 OFFCURVE",
+"566 306 OFFCURVE",
+"538 306 CURVE SMOOTH",
+"509 306 OFFCURVE",
+"486 289 OFFCURVE",
+"486 250 CURVE SMOOTH",
+"486 211 OFFCURVE",
+"509 194 OFFCURVE",
+"538 194 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"552 495 OFFCURVE",
+"575 512 OFFCURVE",
+"575 551 CURVE SMOOTH",
+"575 590 OFFCURVE",
+"552 607 OFFCURVE",
+"524 607 CURVE SMOOTH",
+"495 607 OFFCURVE",
+"472 590 OFFCURVE",
+"472 551 CURVE SMOOTH",
+"472 512 OFFCURVE",
+"495 495 OFFCURVE",
+"524 495 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"216 -203 LINE",
+"357 23 OFFCURVE",
+"405 157 OFFCURVE",
+"405 352 CURVE SMOOTH",
+"405 536 OFFCURVE",
+"335 673 OFFCURVE",
+"153 884 CURVE",
+"97 835 LINE",
+"287 635 OFFCURVE",
+"329 504 OFFCURVE",
+"329 349 CURVE SMOOTH",
+"329 181 OFFCURVE",
+"294 48 OFFCURVE",
+"153 -163 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"391 939 LINE",
+"302 768 OFFCURVE",
+"208 641 OFFCURVE",
+"70 519 CURVE",
+"120 462 LINE",
+"271 602 OFFCURVE",
+"367 730 OFFCURVE",
+"458 910 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"82 130 LINE",
+"224 63 OFFCURVE",
+"370 -27 OFFCURVE",
+"482 -126 CURVE",
+"531 -70 LINE",
+"405 38 OFFCURVE",
+"266 126 OFFCURVE",
+"115 200 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 709;
+}
+);
+unicode = 1B1B5;
+},
+{
+glyphname = u1B1B6;
+lastChange = "2020-04-13 08:31:59 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"414 -44 LINE",
+"583 189 OFFCURVE",
+"674 336 OFFCURVE",
+"776 655 CURVE",
+"694 680 LINE",
+"608 398 OFFCURVE",
+"505 218 OFFCURVE",
+"386 61 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"490 899 LINE",
+"425 628 OFFCURVE",
+"360 463 OFFCURVE",
+"274 300 CURVE",
+"331 242 LINE",
+"437 440 OFFCURVE",
+"502 604 OFFCURVE",
+"574 879 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"176 736 LINE",
+"333 532 OFFCURVE",
+"442 380 OFFCURVE",
+"526 221 CURVE",
+"586 285 LINE",
+"506 431 OFFCURVE",
+"395 595 OFFCURVE",
+"244 789 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"353 -67 OFFCURVE",
+"335 -98 OFFCURVE",
+"280 -98 CURVE SMOOTH",
+"231 -98 OFFCURVE",
+"205 -72 OFFCURVE",
+"205 -19 CURVE SMOOTH",
+"205 9 OFFCURVE",
+"211 29 OFFCURVE",
+"228 59 CURVE",
+"163 93 LINE",
+"136 55 OFFCURVE",
+"123 17 OFFCURVE",
+"123 -27 CURVE SMOOTH",
+"123 -117 OFFCURVE",
+"181 -184 OFFCURVE",
+"272 -184 CURVE SMOOTH",
+"384 -184 OFFCURVE",
+"437 -110 OFFCURVE",
+"437 12 CURVE SMOOTH",
+"437 88 OFFCURVE",
+"405 181 OFFCURVE",
+"145 504 CURVE",
+"80 451 LINE",
+"323 157 OFFCURVE",
+"353 78 OFFCURVE",
+"353 0 CURVE SMOOTH"
+);
+}
+);
+};
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"414 -44 LINE",
+"583 189 OFFCURVE",
+"674 336 OFFCURVE",
+"776 655 CURVE",
+"704 676 LINE",
+"618 394 OFFCURVE",
+"515 205 OFFCURVE",
+"396 48 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"494 899 LINE",
+"461 761 OFFCURVE",
+"428 651 OFFCURVE",
+"392 555 CURVE",
+"373 515 LINE",
+"343 438 OFFCURVE",
+"310 369 OFFCURVE",
+"274 300 CURVE",
+"321 244 LINE",
+"358 313 OFFCURVE",
+"390 379 OFFCURVE",
+"420 447 CURVE",
+"442 490 LINE",
+"488 602 OFFCURVE",
+"527 723 OFFCURVE",
+"568 881 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"184 736 LINE",
+"341 532 OFFCURVE",
+"450 380 OFFCURVE",
+"534 221 CURVE",
+"584 278 LINE",
+"504 424 OFFCURVE",
+"393 588 OFFCURVE",
+"242 782 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"363 -76 OFFCURVE",
+"335 -108 OFFCURVE",
+"280 -108 CURVE SMOOTH",
+"224 -108 OFFCURVE",
+"195 -79 OFFCURVE",
+"195 -27 CURVE SMOOTH",
+"195 9 OFFCURVE",
+"202 31 OFFCURVE",
+"224 61 CURVE",
+"163 93 LINE",
+"136 55 OFFCURVE",
+"123 17 OFFCURVE",
+"123 -27 CURVE SMOOTH",
+"123 -117 OFFCURVE",
+"181 -184 OFFCURVE",
+"272 -184 CURVE SMOOTH",
+"384 -184 OFFCURVE",
+"437 -110 OFFCURVE",
+"437 0 CURVE SMOOTH",
+"437 88 OFFCURVE",
+"398 175 OFFCURVE",
+"138 498 CURVE",
+"80 451 LINE",
+"335 152 OFFCURVE",
+"363 78 OFFCURVE",
+"363 0 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 30;
+vertWidth = 1362;
+width = 866;
+}
+);
+leftMetricsKey = u1B19D;
+rightMetricsKey = u1B19D;
+unicode = 1B1B6;
+},
+{
+glyphname = u1B1B7;
+lastChange = "2020-04-13 08:31:44 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"564 939 LINE",
+"498 848 OFFCURVE",
+"434 762 OFFCURVE",
+"373 696 CURVE SMOOTH",
+"310 629 OFFCURVE",
+"259 580 OFFCURVE",
+"206 530 CURVE",
+"201 531 LINE",
+"191 603 OFFCURVE",
+"174 670 OFFCURVE",
+"140 770 CURVE",
+"70 744 LINE",
+"105 654 OFFCURVE",
+"127 579 OFFCURVE",
+"148 492 CURVE",
+"226 465 LINE",
+"384 589 OFFCURVE",
+"485 702 OFFCURVE",
+"626 898 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"206 255 LINE",
+"383 366 OFFCURVE",
+"497 457 OFFCURVE",
+"650 626 CURVE",
+"593 677 LINE",
+"461 528 OFFCURVE",
+"338 427 OFFCURVE",
+"164 318 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"526 -201 LINE",
+"526 -57 OFFCURVE",
+"519 59 OFFCURVE",
+"492 205 CURVE",
+"435 170 LINE",
+"446 17 OFFCURVE",
+"450 -65 OFFCURVE",
+"450 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"581 338 OFFCURVE",
+"514 277 OFFCURVE",
+"223 109 CURVE",
+"262 46 LINE",
+"574 228 OFFCURVE",
+"657 307 OFFCURVE",
+"657 432 CURVE SMOOTH",
+"657 496 OFFCURVE",
+"635 543 OFFCURVE",
+"579 614 CURVE",
+"535 558 LINE",
+"568 514 OFFCURVE",
+"583 481 OFFCURVE",
+"581 432 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 787;
+}
+);
+rightMetricsKey = u1B179;
+unicode = 1B1B7;
+},
+{
+glyphname = u1B1B8;
+lastChange = "2020-04-13 08:31:41 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"150 271 OFFCURVE",
+"173 288 OFFCURVE",
+"173 327 CURVE SMOOTH",
+"173 366 OFFCURVE",
+"150 383 OFFCURVE",
+"122 383 CURVE SMOOTH",
+"93 383 OFFCURVE",
+"70 366 OFFCURVE",
+"70 327 CURVE SMOOTH",
+"70 288 OFFCURVE",
+"93 271 OFFCURVE",
+"122 271 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"216 7 OFFCURVE",
+"239 24 OFFCURVE",
+"239 63 CURVE SMOOTH",
+"239 102 OFFCURVE",
+"216 119 OFFCURVE",
+"188 119 CURVE SMOOTH",
+"161 119 OFFCURVE",
+"136 102 OFFCURVE",
+"136 63 CURVE SMOOTH",
+"136 24 OFFCURVE",
+"159 7 OFFCURVE",
+"188 7 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"580 939 LINE",
+"524 840 OFFCURVE",
+"467 755 OFFCURVE",
+"404 675 CURVE",
+"379 649 LINE",
+"325 584 OFFCURVE",
+"267 522 OFFCURVE",
+"200 458 CURVE",
+"252 405 LINE",
+"313 466 OFFCURVE",
+"366 520 OFFCURVE",
+"413 574 CURVE",
+"445 608 LINE",
+"515 694 OFFCURVE",
+"576 783 OFFCURVE",
+"645 903 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"700 657 LINE",
+"637 562 OFFCURVE",
+"579 484 OFFCURVE",
+"517 411 CURVE",
+"482 376 LINE",
+"420 307 OFFCURVE",
+"353 242 OFFCURVE",
+"273 172 CURVE",
+"323 117 LINE",
+"390 176 OFFCURVE",
+"449 232 OFFCURVE",
+"506 291 CURVE",
+"541 324 LINE",
+"618 409 OFFCURVE",
+"689 502 OFFCURVE",
+"764 617 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"613 -200 LINE",
+"597 301 OFFCURVE",
+"516 557 OFFCURVE",
+"299 901 CURVE",
+"236 861 LINE",
+"458 520 OFFCURVE",
+"533 215 OFFCURVE",
+"537 -203 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 854;
+}
+);
+rightMetricsKey = u1B187;
+unicode = 1B1B8;
+},
+{
+glyphname = u1B1B9;
+lastChange = "2020-04-13 08:31:38 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"557 939 LINE",
+"498 834 OFFCURVE",
+"437 741 OFFCURVE",
+"370 652 CURVE",
+"342 620 LINE",
+"284 547 OFFCURVE",
+"221 476 OFFCURVE",
+"150 401 CURVE",
+"203 348 LINE",
+"266 413 OFFCURVE",
+"324 479 OFFCURVE",
+"378 547 CURVE",
+"408 580 LINE",
+"486 681 OFFCURVE",
+"557 787 OFFCURVE",
+"623 905 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"656 499 LINE",
+"558 354 OFFCURVE",
+"467 245 OFFCURVE",
+"323 121 CURVE",
+"371 64 LINE",
+"500 175 OFFCURVE",
+"604 289 OFFCURVE",
+"718 459 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"533 268 LINE",
+"477 475 OFFCURVE",
+"400 657 OFFCURVE",
+"275 864 CURVE",
+"212 827 LINE",
+"337 617 OFFCURVE",
+"415 426 OFFCURVE",
+"471 235 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"119 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -102 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 788;
+}
+);
+rightMetricsKey = u1B180;
+unicode = 1B1B9;
+},
+{
+glyphname = u1B1BA;
+lastChange = "2020-04-13 08:31:34 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"281 622 OFFCURVE",
+"346 731 OFFCURVE",
+"429 908 CURVE",
+"361 939 LINE",
+"279 767 OFFCURVE",
+"213 649 OFFCURVE",
+"100 494 CURVE",
+"157 376 OFFCURVE",
+"195 286 OFFCURVE",
+"232 184 CURVE",
+"316 175 LINE",
+"360 228 OFFCURVE",
+"397 285 OFFCURVE",
+"427 334 CURVE SMOOTH",
+"468 402 OFFCURVE",
+"491 448 OFFCURVE",
+"517 504 CURVE",
+"521 504 LINE",
+"561 398 OFFCURVE",
+"600 293 OFFCURVE",
+"634 173 CURVE",
+"629 242 LINE",
+"546 88 OFFCURVE",
+"467 -31 OFFCURVE",
+"368 -158 CURVE",
+"427 -203 LINE",
+"543 -53 OFFCURVE",
+"612 54 OFFCURVE",
+"698 219 CURVE",
+"659 349 OFFCURVE",
+"622 450 OFFCURVE",
+"572 566 CURVE",
+"480 573 LINE",
+"447 516 OFFCURVE",
+"422 471 OFFCURVE",
+"387 408 CURVE SMOOTH",
+"354 349 OFFCURVE",
+"326 297 OFFCURVE",
+"286 240 CURVE",
+"281 241 LINE",
+"250 333 OFFCURVE",
+"221 412 OFFCURVE",
+"164 532 CURVE",
+"167 461 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 798;
+}
+);
+unicode = 1B1BA;
+},
+{
+glyphname = u1B1BB;
+lastChange = "2020-04-13 08:31:31 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"387 855 LINE",
+"412 779 OFFCURVE",
+"431 723 OFFCURVE",
+"453 651 CURVE SMOOTH",
+"476 576 OFFCURVE",
+"497 501 OFFCURVE",
+"513 432 CURVE",
+"529 519 LINE",
+"430 406 OFFCURVE",
+"357 330 OFFCURVE",
+"260 244 CURVE",
+"298 175 LINE",
+"406 272 OFFCURVE",
+"487 355 OFFCURVE",
+"583 462 CURVE",
+"545 621 OFFCURVE",
+"497 781 OFFCURVE",
+"437 920 CURVE",
+"353 929 LINE",
+"273 822 OFFCURVE",
+"199 736 OFFCURVE",
+"110 642 CURVE",
+"214 404 OFFCURVE",
+"241 188 OFFCURVE",
+"241 -11 CURVE SMOOTH",
+"241 -78 OFFCURVE",
+"237 -146 OFFCURVE",
+"231 -196 CURVE",
+"303 -203 LINE",
+"311 -150 OFFCURVE",
+"315 -81 OFFCURVE",
+"315 -12 CURVE SMOOTH",
+"315 211 OFFCURVE",
+"286 413 OFFCURVE",
+"186 656 CURVE",
+"173 598 LINE",
+"275 706 OFFCURVE",
+"330 777 OFFCURVE",
+"382 856 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"463 744 LINE",
+"376 634 OFFCURVE",
+"304 558 OFFCURVE",
+"210 466 CURVE",
+"249 403 LINE",
+"348 497 OFFCURVE",
+"428 583 OFFCURVE",
+"507 679 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 703;
+}
+);
+unicode = 1B1BB;
+},
+{
+glyphname = u1B1BC;
+lastChange = "2020-04-13 08:31:29 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"461 -183 LINE",
+"549 -118 OFFCURVE",
+"654 -22 OFFCURVE",
+"733 58 CURVE",
+"706 159 OFFCURVE",
+"682 244 OFFCURVE",
+"647 337 CURVE",
+"569 351 LINE",
+"486 257 OFFCURVE",
+"400 174 OFFCURVE",
+"301 91 CURVE",
+"341 -2 OFFCURVE",
+"364 -77 OFFCURVE",
+"393 -165 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"441 -109 LINE",
+"424 -34 OFFCURVE",
+"405 33 OFFCURVE",
+"372 117 CURVE",
+"355 36 LINE",
+"402 78 OFFCURVE",
+"430 101 OFFCURVE",
+"467 137 CURVE SMOOTH",
+"514 182 OFFCURVE",
+"553 225 OFFCURVE",
+"593 279 CURVE",
+"598 278 LINE",
+"614 211 OFFCURVE",
+"630 154 OFFCURVE",
+"661 42 CURVE",
+"682 116 LINE",
+"636 69 OFFCURVE",
+"595 29 OFFCURVE",
+"566 3 CURVE SMOOTH",
+"529 -31 OFFCURVE",
+"490 -67 OFFCURVE",
+"446 -110 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"515 939 LINE",
+"433 831 OFFCURVE",
+"364 747 OFFCURVE",
+"293 670 CURVE",
+"268 647 LINE",
+"210 585 OFFCURVE",
+"150 527 OFFCURVE",
+"80 463 CURVE",
+"130 409 LINE",
+"191 466 OFFCURVE",
+"248 519 OFFCURVE",
+"302 576 CURVE",
+"331 602 LINE",
+"410 685 OFFCURVE",
+"488 777 OFFCURVE",
+"576 894 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"572 616 LINE",
+"462 486 OFFCURVE",
+"353 376 OFFCURVE",
+"215 255 CURVE",
+"262 201 LINE",
+"396 316 OFFCURVE",
+"509 426 OFFCURVE",
+"628 568 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"436 375 LINE",
+"387 517 OFFCURVE",
+"324 671 OFFCURVE",
+"219 873 CURVE",
+"151 837 LINE",
+"263 626 OFFCURVE",
+"326 475 OFFCURVE",
+"379 315 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 823;
+}
+);
+leftMetricsKey = u1B180;
+unicode = 1B1BC;
+},
+{
+glyphname = u1B1BD;
+lastChange = "2020-04-13 08:31:25 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"168 667 OFFCURVE",
+"221 609 OFFCURVE",
+"259 556 CURVE",
+"278 524 LINE",
+"315 455 OFFCURVE",
+"328 391 OFFCURVE",
+"328 321 CURVE SMOOTH",
+"328 166 OFFCURVE",
+"270 72 OFFCURVE",
+"151 -70 CURVE",
+"204 -115 LINE",
+"331 33 OFFCURVE",
+"400 160 OFFCURVE",
+"400 323 CURVE SMOOTH",
+"400 413 OFFCURVE",
+"380 491 OFFCURVE",
+"331 576 CURVE",
+"304 610 LINE",
+"265 665 OFFCURVE",
+"218 720 OFFCURVE",
+"156 775 CURVE",
+"108 721 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"406 939 LINE",
+"357 725 OFFCURVE",
+"291 605 OFFCURVE",
+"124 429 CURVE",
+"178 381 LINE",
+"287 500 OFFCURVE",
+"369 621 OFFCURVE",
+"411 731 CURVE",
+"434 776 LINE",
+"450 821 OFFCURVE",
+"465 870 OFFCURVE",
+"477 924 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"377 -78 OFFCURVE",
+"360 14 OFFCURVE",
+"322 95 CURVE",
+"293 141 LINE",
+"265 190 OFFCURVE",
+"229 236 OFFCURVE",
+"185 283 CURVE",
+"135 236 LINE",
+"191 177 OFFCURVE",
+"232 118 OFFCURVE",
+"259 62 CURVE",
+"285 11 LINE",
+"305 -49 OFFCURVE",
+"315 -116 OFFCURVE",
+"319 -203 CURVE",
+"388 -198 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"384 731 LINE",
+"415 731 LINE",
+"474 607 OFFCURVE",
+"557 503 OFFCURVE",
+"688 388 CURVE",
+"736 442 LINE",
+"607 557 OFFCURVE",
+"532 651 OFFCURVE",
+"435 808 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"546 432 OFFCURVE",
+"549 482 OFFCURVE",
+"568 523 CURVE",
+"581 554 LINE",
+"614 623 OFFCURVE",
+"658 691 OFFCURVE",
+"721 760 CURVE",
+"669 807 LINE",
+"612 744 OFFCURVE",
+"569 686 OFFCURVE",
+"534 620 CURVE",
+"519 587 LINE",
+"487 517 OFFCURVE",
+"474 451 OFFCURVE",
+"474 387 CURVE SMOOTH",
+"474 227 OFFCURVE",
+"529 108 OFFCURVE",
+"660 2 CURVE",
+"709 52 LINE",
+"590 158 OFFCURVE",
+"546 246 OFFCURVE",
+"546 389 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 836;
+}
+);
+unicode = 1B1BD;
+},
+{
+glyphname = u1B1BE;
+lastChange = "2020-04-13 08:31:22 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"489 939 LINE",
+"489 559 OFFCURVE",
+"428 321 OFFCURVE",
+"307 142 CURVE",
+"369 101 LINE",
+"491 280 OFFCURVE",
+"565 536 OFFCURVE",
+"565 936 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"261 607 LINE",
+"242 470 OFFCURVE",
+"212 404 OFFCURVE",
+"145 330 CURVE",
+"196 283 LINE",
+"268 360 OFFCURVE",
+"310 450 OFFCURVE",
+"334 596 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"579 258 OFFCURVE",
+"595 333 OFFCURVE",
+"645 425 CURVE",
+"708 395 LINE",
+"665 315 OFFCURVE",
+"653 249 OFFCURVE",
+"653 177 CURVE SMOOTH",
+"653 89 OFFCURVE",
+"671 28 OFFCURVE",
+"714 -47 CURVE",
+"653 -80 LINE",
+"601 -3 OFFCURVE",
+"579 76 OFFCURVE",
+"579 177 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"119 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -102 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 824;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B178;
+unicode = 1B1BE;
+},
+{
+glyphname = u1B1BF;
+lastChange = "2020-04-11 15:37:52 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"725 398 LINE",
+"631 176 OFFCURVE",
+"531 28 OFFCURVE",
+"387 -133 CURVE",
+"444 -183 LINE",
+"585 -24 OFFCURVE",
+"697 137 OFFCURVE",
+"796 368 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 223 OFFCURVE",
+"163 240 OFFCURVE",
+"163 279 CURVE SMOOTH",
+"163 318 OFFCURVE",
+"140 335 OFFCURVE",
+"112 335 CURVE SMOOTH",
+"83 335 OFFCURVE",
+"60 318 OFFCURVE",
+"60 279 CURVE SMOOTH",
+"60 240 OFFCURVE",
+"83 223 OFFCURVE",
+"112 223 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"438 635 OFFCURVE",
+"461 652 OFFCURVE",
+"461 691 CURVE SMOOTH",
+"461 730 OFFCURVE",
+"438 747 OFFCURVE",
+"410 747 CURVE SMOOTH",
+"381 747 OFFCURVE",
+"358 730 OFFCURVE",
+"358 691 CURVE SMOOTH",
+"358 652 OFFCURVE",
+"381 635 OFFCURVE",
+"410 635 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"650 909 LINE",
+"586 685 OFFCURVE",
+"524 526 OFFCURVE",
+"474 424 CURVE SMOOTH",
+"446 366 OFFCURVE",
+"423 319 OFFCURVE",
+"393 259 CURVE",
+"389 259 LINE",
+"376 308 OFFCURVE",
+"364 348 OFFCURVE",
+"351 381 CURVE SMOOTH",
+"332 429 OFFCURVE",
+"291 516 OFFCURVE",
+"241 598 CURVE",
+"174 559 LINE",
+"248 433 OFFCURVE",
+"297 327 OFFCURVE",
+"341 189 CURVE",
+"424 177 LINE",
+"573 406 OFFCURVE",
+"650 632 OFFCURVE",
+"725 889 CURVE"
+);
+}
+);
+vertOrigin = 45;
+vertWidth = 1362;
+width = 896;
+}
+);
+leftMetricsKey = u1B193;
+unicode = 1B1BF;
+},
+{
+glyphname = u1B1C0;
+lastChange = "2020-04-13 08:32:28 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"495 -203 LINE",
+"505 -103 OFFCURVE",
+"508 -37 OFFCURVE",
+"508 81 CURVE SMOOTH",
+"508 351 OFFCURVE",
+"453 623 OFFCURVE",
+"328 939 CURVE",
+"259 913 LINE",
+"390 579 OFFCURVE",
+"432 333 OFFCURVE",
+"432 83 CURVE SMOOTH",
+"432 -31 OFFCURVE",
+"429 -111 OFFCURVE",
+"421 -196 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"559 909 LINE",
+"407 777 OFFCURVE",
+"252 662 OFFCURVE",
+"90 559 CURVE",
+"126 410 OFFCURVE",
+"145 303 OFFCURVE",
+"161 179 CURVE",
+"239 157 LINE",
+"406 263 OFFCURVE",
+"573 375 OFFCURVE",
+"736 506 CURVE",
+"708 650 OFFCURVE",
+"680 754 OFFCURVE",
+"643 885 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"583 835 LINE",
+"605 751 OFFCURVE",
+"623 677 OFFCURVE",
+"641 591 CURVE SMOOTH",
+"647 562 OFFCURVE",
+"654 533 OFFCURVE",
+"660 502 CURVE",
+"682 561 LINE",
+"604 498 OFFCURVE",
+"520 435 OFFCURVE",
+"436 377 CURVE SMOOTH",
+"357 323 OFFCURVE",
+"291 277 OFFCURVE",
+"228 232 CURVE",
+"223 233 LINE",
+"219 302 OFFCURVE",
+"208 378 OFFCURVE",
+"196 435 CURVE SMOOTH",
+"187 479 OFFCURVE",
+"177 524 OFFCURVE",
+"166 569 CURVE",
+"143 500 LINE",
+"224 553 OFFCURVE",
+"305 611 OFFCURVE",
+"385 671 CURVE SMOOTH",
+"459 727 OFFCURVE",
+"514 774 OFFCURVE",
+"578 836 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 826;
+}
+);
+unicode = 1B1C0;
+},
+{
+glyphname = u1B1C1;
+lastChange = "2020-04-11 15:36:40 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"810 525 OFFCURVE",
+"833 542 OFFCURVE",
+"833 581 CURVE SMOOTH",
+"833 620 OFFCURVE",
+"810 637 OFFCURVE",
+"782 637 CURVE SMOOTH",
+"753 637 OFFCURVE",
+"730 620 OFFCURVE",
+"730 581 CURVE SMOOTH",
+"730 542 OFFCURVE",
+"753 525 OFFCURVE",
+"782 525 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"160 296 OFFCURVE",
+"183 313 OFFCURVE",
+"183 352 CURVE SMOOTH",
+"183 391 OFFCURVE",
+"160 408 OFFCURVE",
+"132 408 CURVE SMOOTH",
+"103 408 OFFCURVE",
+"80 391 OFFCURVE",
+"80 352 CURVE SMOOTH",
+"80 313 OFFCURVE",
+"103 296 OFFCURVE",
+"132 296 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"270 570 OFFCURVE",
+"303 425 OFFCURVE",
+"303 266 CURVE SMOOTH",
+"303 89 OFFCURVE",
+"281 -41 OFFCURVE",
+"233 -181 CURVE",
+"304 -203 LINE",
+"355 -62 OFFCURVE",
+"377 75 OFFCURVE",
+"377 266 CURVE SMOOTH",
+"377 289 OFFCURVE",
+"376 311 OFFCURVE",
+"375 363 CURVE",
+"361 384 LINE",
+"356 501 OFFCURVE",
+"330 612 OFFCURVE",
+"252 784 CURVE",
+"183 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"580 654 OFFCURVE",
+"467 489 OFFCURVE",
+"365 383 CURVE",
+"337 390 LINE",
+"348 271 LINE",
+"523 441 OFFCURVE",
+"632 589 OFFCURVE",
+"711 924 CURVE",
+"636 939 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"513 530 LINE",
+"588 394 OFFCURVE",
+"628 279 OFFCURVE",
+"654 135 CURVE",
+"730 149 LINE",
+"700 318 OFFCURVE",
+"650 439 OFFCURVE",
+"557 593 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 913;
+}
+);
+leftMetricsKey = u1B176;
+rightMetricsKey = u1B177;
+unicode = 1B1C1;
+},
+{
+glyphname = u1B1C2;
+lastChange = "2020-04-13 08:32:32 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"530 268 LINE",
+"601 141 OFFCURVE",
+"666 -3 OFFCURVE",
+"710 -155 CURVE",
+"779 -131 LINE",
+"723 35 OFFCURVE",
+"662 178 OFFCURVE",
+"591 302 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"477 50 OFFCURVE",
+"468 141 OFFCURVE",
+"444 264 CURVE SMOOTH",
+"415 415 OFFCURVE",
+"374 561 OFFCURVE",
+"324 670 CURVE",
+"274 602 LINE",
+"348 420 OFFCURVE",
+"398 159 OFFCURVE",
+"414 -112 CURVE",
+"509 -148 LINE",
+"629 -26 OFFCURVE",
+"734 107 OFFCURVE",
+"826 251 CURVE",
+"763 290 LINE",
+"730 236 OFFCURVE",
+"695 185 OFFCURVE",
+"657 134 CURVE SMOOTH",
+"602 60 OFFCURVE",
+"551 4 OFFCURVE",
+"484 -71 CURVE",
+"479 -70 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"476 939 LINE",
+"362 743 OFFCURVE",
+"232 580 OFFCURVE",
+"60 428 CURVE",
+"110 370 LINE",
+"279 522 OFFCURVE",
+"427 700 OFFCURVE",
+"543 902 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"602 672 LINE",
+"468 472 OFFCURVE",
+"346 332 OFFCURVE",
+"178 186 CURVE",
+"228 129 LINE",
+"392 272 OFFCURVE",
+"522 416 OFFCURVE",
+"665 630 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 906;
+}
+);
+leftMetricsKey = u1B187;
+rightMetricsKey = u1B19E;
+unicode = 1B1C2;
+},
+{
+glyphname = u1B1C3;
+lastChange = "2020-04-13 08:32:51 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"616 842 LINE",
+"637 731 OFFCURVE",
+"644 643 OFFCURVE",
+"649 546 CURVE SMOOTH",
+"651 509 OFFCURVE",
+"652 471 OFFCURVE",
+"652 431 CURVE SMOOTH",
+"652 296 OFFCURVE",
+"649 207 OFFCURVE",
+"642 111 CURVE",
+"718 106 LINE",
+"726 208 OFFCURVE",
+"728 299 OFFCURVE",
+"728 431 CURVE SMOOTH",
+"728 584 OFFCURVE",
+"714 730 OFFCURVE",
+"678 906 CURVE",
+"593 925 LINE",
+"422 769 OFFCURVE",
+"275 655 OFFCURVE",
+"120 548 CURVE",
+"142 374 OFFCURVE",
+"150 260 OFFCURVE",
+"150 113 CURVE SMOOTH",
+"150 -8 OFFCURVE",
+"147 -96 OFFCURVE",
+"135 -194 CURVE",
+"209 -203 LINE",
+"221 -108 OFFCURVE",
+"224 0 OFFCURVE",
+"224 113 CURVE SMOOTH",
+"224 277 OFFCURVE",
+"214 404 OFFCURVE",
+"195 555 CURVE",
+"183 499 LINE",
+"256 550 OFFCURVE",
+"334 607 OFFCURVE",
+"416 672 CURVE SMOOTH",
+"491 732 OFFCURVE",
+"539 777 OFFCURVE",
+"611 843 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"253 444 LINE",
+"360 360 OFFCURVE",
+"473 250 OFFCURVE",
+"556 144 CURVE",
+"613 195 LINE",
+"519 313 OFFCURVE",
+"409 421 OFFCURVE",
+"299 506 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"506 666 LINE",
+"482 567 OFFCURVE",
+"456 469 OFFCURVE",
+"423 377 CURVE",
+"401 334 LINE",
+"365 238 OFFCURVE",
+"321 143 OFFCURVE",
+"268 46 CURVE",
+"334 11 LINE",
+"385 106 OFFCURVE",
+"426 198 OFFCURVE",
+"461 285 CURVE",
+"483 323 LINE",
+"521 425 OFFCURVE",
+"552 529 OFFCURVE",
+"581 649 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 868;
+}
+);
+leftMetricsKey = u1B1AB;
+rightMetricsKey = u1B1AB;
+unicode = 1B1C3;
+},
+{
+glyphname = u1B1C4;
+lastChange = "2020-04-13 08:33:50 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"472 305 OFFCURVE",
+"499 246 OFFCURVE",
+"594 198 CURVE",
+"675 219 LINE",
+"728 319 OFFCURVE",
+"747 382 OFFCURVE",
+"747 458 CURVE SMOOTH",
+"747 534 OFFCURVE",
+"718 594 OFFCURVE",
+"619 655 CURVE",
+"541 640 LINE",
+"489 524 OFFCURVE",
+"472 456 OFFCURVE",
+"472 387 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"593 597 LINE",
+"648 556 OFFCURVE",
+"675 510 OFFCURVE",
+"675 458 CURVE SMOOTH",
+"675 401 OFFCURVE",
+"663 340 OFFCURVE",
+"623 253 CURVE",
+"618 252 LINE",
+"563 291 OFFCURVE",
+"544 334 OFFCURVE",
+"544 387 CURVE SMOOTH",
+"544 443 OFFCURVE",
+"557 511 OFFCURVE",
+"588 596 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"135 344 LINE",
+"274 158 OFFCURVE",
+"360 -2 OFFCURVE",
+"435 -203 CURVE",
+"505 -177 LINE",
+"456 -55 OFFCURVE",
+"406 50 OFFCURVE",
+"332 182 CURVE",
+"320 182 LINE",
+"286 254 OFFCURVE",
+"240 329 OFFCURVE",
+"187 401 CURVE",
+"176 343 LINE",
+"227 419 OFFCURVE",
+"277 502 OFFCURVE",
+"305 574 CURVE",
+"319 574 LINE",
+"388 703 OFFCURVE",
+"420 802 OFFCURVE",
+"457 918 CURVE",
+"387 939 LINE",
+"358 844 OFFCURVE",
+"327 761 OFFCURVE",
+"292 683 CURVE",
+"270 643 LINE",
+"232 565 OFFCURVE",
+"188 492 OFFCURVE",
+"135 415 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"180 726 OFFCURVE",
+"234 665 OFFCURVE",
+"295 574 CURVE",
+"309 574 LINE",
+"348 499 OFFCURVE",
+"359 437 OFFCURVE",
+"359 380 CURVE SMOOTH",
+"359 323 OFFCURVE",
+"348 252 OFFCURVE",
+"324 182 CURVE",
+"314 182 LINE",
+"256 71 OFFCURVE",
+"213 0 OFFCURVE",
+"126 -105 CURVE",
+"186 -149 LINE",
+"245 -72 OFFCURVE",
+"289 -1 OFFCURVE",
+"329 69 CURVE",
+"355 106 LINE",
+"404 199 OFFCURVE",
+"429 284 OFFCURVE",
+"429 380 CURVE SMOOTH",
+"429 529 OFFCURVE",
+"361 638 OFFCURVE",
+"164 854 CURVE",
+"110 802 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 837;
+}
+);
+leftMetricsKey = u1B181;
+unicode = 1B1C4;
+},
+{
+glyphname = u1B1C5;
+lastChange = "2020-04-13 08:34:04 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"320 11 OFFCURVE",
+"343 28 OFFCURVE",
+"343 67 CURVE SMOOTH",
+"343 106 OFFCURVE",
+"320 123 OFFCURVE",
+"292 123 CURVE SMOOTH",
+"263 123 OFFCURVE",
+"240 106 OFFCURVE",
+"240 67 CURVE SMOOTH",
+"240 28 OFFCURVE",
+"263 11 OFFCURVE",
+"292 11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"579 385 OFFCURVE",
+"602 402 OFFCURVE",
+"602 441 CURVE SMOOTH",
+"602 480 OFFCURVE",
+"579 497 OFFCURVE",
+"551 497 CURVE SMOOTH",
+"522 497 OFFCURVE",
+"499 480 OFFCURVE",
+"499 441 CURVE SMOOTH",
+"499 402 OFFCURVE",
+"522 385 OFFCURVE",
+"551 385 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"547 68 LINE",
+"422 328 OFFCURVE",
+"315 527 OFFCURVE",
+"144 776 CURVE",
+"80 731 LINE",
+"248 490 OFFCURVE",
+"363 278 OFFCURVE",
+"480 30 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"572 939 LINE",
+"492 765 OFFCURVE",
+"409 614 OFFCURVE",
+"319 474 CURVE",
+"290 437 LINE",
+"226 340 OFFCURVE",
+"158 248 OFFCURVE",
+"84 157 CURVE",
+"145 111 LINE",
+"213 195 OFFCURVE",
+"277 280 OFFCURVE",
+"339 373 CURVE",
+"362 401 LINE",
+"461 550 OFFCURVE",
+"553 716 OFFCURVE",
+"642 909 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"675 367 LINE",
+"572 177 OFFCURVE",
+"449 -2 OFFCURVE",
+"313 -155 CURVE",
+"372 -203 LINE",
+"520 -33 OFFCURVE",
+"631 128 OFFCURVE",
+"743 331 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 813;
+}
+);
+leftMetricsKey = u1B180;
+rightMetricsKey = u1B180;
+unicode = 1B1C5;
+},
+{
+glyphname = u1B1C6;
+lastChange = "2020-04-11 15:32:52 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"308 17 OFFCURVE",
+"331 34 OFFCURVE",
+"331 73 CURVE SMOOTH",
+"331 112 OFFCURVE",
+"308 129 OFFCURVE",
+"280 129 CURVE SMOOTH",
+"251 129 OFFCURVE",
+"228 112 OFFCURVE",
+"228 73 CURVE SMOOTH",
+"228 34 OFFCURVE",
+"251 17 OFFCURVE",
+"280 17 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"584 405 OFFCURVE",
+"607 422 OFFCURVE",
+"607 461 CURVE SMOOTH",
+"607 500 OFFCURVE",
+"584 517 OFFCURVE",
+"556 517 CURVE SMOOTH",
+"527 517 OFFCURVE",
+"504 500 OFFCURVE",
+"504 461 CURVE SMOOTH",
+"504 422 OFFCURVE",
+"527 405 OFFCURVE",
+"556 405 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"274 432 LINE",
+"362 290 OFFCURVE",
+"433 170 OFFCURVE",
+"501 22 CURVE",
+"566 62 LINE",
+"493 217 OFFCURVE",
+"416 352 OFFCURVE",
+"316 505 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"552 939 LINE",
+"412 658 OFFCURVE",
+"213 362 OFFCURVE",
+"60 165 CURVE",
+"118 120 LINE",
+"269 310 OFFCURVE",
+"479 629 OFFCURVE",
+"621 910 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"690 367 LINE",
+"583 180 OFFCURVE",
+"449 -11 OFFCURVE",
+"322 -155 CURVE",
+"378 -203 LINE",
+"524 -34 OFFCURVE",
+"636 129 OFFCURVE",
+"756 331 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 826;
+}
+);
+leftMetricsKey = u1B183;
+rightMetricsKey = u1B183;
+unicode = 1B1C6;
+},
+{
+glyphname = u1B1C7;
+lastChange = "2020-04-13 08:40:29 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"271 895 LINE",
+"376 581 OFFCURVE",
+"416 361 OFFCURVE",
+"416 76 CURVE SMOOTH",
+"416 -26 OFFCURVE",
+"412 -107 OFFCURVE",
+"403 -194 CURVE",
+"477 -203 LINE",
+"484 -110 OFFCURVE",
+"492 -22 OFFCURVE",
+"492 83 CURVE SMOOTH",
+"492 355 OFFCURVE",
+"453 602 OFFCURVE",
+"342 922 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"705 162 OFFCURVE",
+"728 179 OFFCURVE",
+"728 218 CURVE SMOOTH",
+"728 257 OFFCURVE",
+"705 274 OFFCURVE",
+"677 274 CURVE SMOOTH",
+"648 274 OFFCURVE",
+"625 257 OFFCURVE",
+"625 218 CURVE SMOOTH",
+"625 179 OFFCURVE",
+"648 162 OFFCURVE",
+"677 162 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"251 -35 OFFCURVE",
+"274 -18 OFFCURVE",
+"274 21 CURVE SMOOTH",
+"274 60 OFFCURVE",
+"251 77 OFFCURVE",
+"223 77 CURVE SMOOTH",
+"194 77 OFFCURVE",
+"171 60 OFFCURVE",
+"171 21 CURVE SMOOTH",
+"171 -18 OFFCURVE",
+"194 -35 OFFCURVE",
+"223 -35 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"654 926 LINE",
+"562 851 OFFCURVE",
+"473 784 OFFCURVE",
+"381 724 CURVE",
+"356 711 LINE",
+"262 650 OFFCURVE",
+"165 595 OFFCURVE",
+"60 542 CURVE",
+"94 474 LINE",
+"192 523 OFFCURVE",
+"284 576 OFFCURVE",
+"375 633 CURVE",
+"400 645 LINE",
+"502 712 OFFCURVE",
+"602 786 OFFCURVE",
+"704 869 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"631 725 OFFCURVE",
+"647 684 OFFCURVE",
+"647 632 CURVE SMOOTH",
+"647 561 OFFCURVE",
+"606 502 OFFCURVE",
+"444 408 CURVE",
+"419 398 LINE",
+"348 359 OFFCURVE",
+"258 314 OFFCURVE",
+"142 261 CURVE",
+"174 192 LINE",
+"280 241 OFFCURVE",
+"366 284 OFFCURVE",
+"436 322 CURVE",
+"453 327 LINE",
+"677 453 OFFCURVE",
+"723 531 OFFCURVE",
+"723 632 CURVE SMOOTH",
+"723 711 OFFCURVE",
+"700 766 OFFCURVE",
+"621 864 CURVE",
+"582 793 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 848;
+}
+);
+leftMetricsKey = u1B1B3;
+rightMetricsKey = u1B1B3;
+unicode = 1B1C7;
+},
+{
+glyphname = u1B1C8;
+lastChange = "2020-04-13 08:34:29 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"502 649 LINE",
+"420 464 OFFCURVE",
+"339 307 OFFCURVE",
+"232 136 CURVE",
+"285 91 LINE",
+"397 267 OFFCURVE",
+"470 401 OFFCURVE",
+"544 563 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"364 887 LINE",
+"275 693 OFFCURVE",
+"183 514 OFFCURVE",
+"90 360 CURVE",
+"188 179 OFFCURVE",
+"263 17 OFFCURVE",
+"321 -143 CURVE",
+"412 -151 LINE",
+"526 23 OFFCURVE",
+"610 166 OFFCURVE",
+"704 351 CURVE",
+"628 526 OFFCURVE",
+"552 692 OFFCURVE",
+"453 882 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"409 817 LINE",
+"450 721 OFFCURVE",
+"485 656 OFFCURVE",
+"525 570 CURVE SMOOTH",
+"565 483 OFFCURVE",
+"605 392 OFFCURVE",
+"648 290 CURVE",
+"652 418 LINE",
+"612 334 OFFCURVE",
+"571 254 OFFCURVE",
+"528 178 CURVE SMOOTH",
+"476 85 OFFCURVE",
+"423 0 OFFCURVE",
+"374 -86 CURVE",
+"370 -86 LINE",
+"343 -1 OFFCURVE",
+"312 83 OFFCURVE",
+"271 170 CURVE SMOOTH",
+"235 246 OFFCURVE",
+"194 323 OFFCURVE",
+"150 403 CURVE",
+"157 325 LINE",
+"212 421 OFFCURVE",
+"259 507 OFFCURVE",
+"301 589 CURVE SMOOTH",
+"346 678 OFFCURVE",
+"371 730 OFFCURVE",
+"405 817 CURVE"
+);
+}
+);
+vertOrigin = 30;
+vertWidth = 1362;
+width = 794;
+}
+);
+leftMetricsKey = u1B1B4;
+rightMetricsKey = u1B1B4;
+unicode = 1B1C8;
+},
+{
+glyphname = u1B1C9;
+lastChange = "2020-04-13 08:34:48 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"276 157 LINE",
+"249 104 OFFCURVE",
+"224 59 OFFCURVE",
+"199 19 CURVE",
+"176 -10 LINE",
+"142 -59 OFFCURVE",
+"106 -104 OFFCURVE",
+"60 -154 CURVE",
+"112 -203 LINE",
+"158 -150 OFFCURVE",
+"192 -107 OFFCURVE",
+"222 -64 CURVE",
+"248 -31 LINE",
+"278 15 OFFCURVE",
+"305 63 OFFCURVE",
+"340 126 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"66 88 LINE",
+"158 -5 OFFCURVE",
+"219 -83 OFFCURVE",
+"282 -182 CURVE",
+"341 -143 LINE",
+"268 -34 OFFCURVE",
+"200 49 OFFCURVE",
+"116 138 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"521 754 OFFCURVE",
+"540 711 OFFCURVE",
+"540 667 CURVE SMOOTH",
+"540 571 OFFCURVE",
+"470 506 OFFCURVE",
+"149 332 CURVE",
+"186 266 LINE",
+"521 454 OFFCURVE",
+"616 536 OFFCURVE",
+"616 667 CURVE SMOOTH",
+"616 738 OFFCURVE",
+"590 795 OFFCURVE",
+"507 884 CURVE",
+"468 813 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"527 -33 LINE",
+"518 121 OFFCURVE",
+"498 278 OFFCURVE",
+"459 458 CURVE",
+"391 413 LINE",
+"428 229 OFFCURVE",
+"442 111 OFFCURVE",
+"451 -41 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"560 939 LINE",
+"407 796 OFFCURVE",
+"261 701 OFFCURVE",
+"73 584 CURVE",
+"112 521 LINE",
+"300 637 OFFCURVE",
+"446 733 OFFCURVE",
+"613 888 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 746;
+}
+);
+rightMetricsKey = u1B179;
+unicode = 1B1C9;
+},
+{
+glyphname = u1B1CA;
+lastChange = "2020-04-13 08:35:02 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"472 168 LINE",
+"513 207 OFFCURVE",
+"548 244 OFFCURVE",
+"581 282 CURVE SMOOTH",
+"615 321 OFFCURVE",
+"648 370 OFFCURVE",
+"678 431 CURVE",
+"683 430 LINE",
+"689 330 OFFCURVE",
+"698 256 OFFCURVE",
+"694 139 CURVE",
+"768 139 LINE",
+"769 266 OFFCURVE",
+"761 352 OFFCURVE",
+"736 484 CURVE",
+"649 499 LINE",
+"579 387 OFFCURVE",
+"520 314 OFFCURVE",
+"439 233 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"516 -200 LINE",
+"516 240 OFFCURVE",
+"458 454 OFFCURVE",
+"339 704 CURVE",
+"294 626 LINE",
+"401 399 OFFCURVE",
+"445 202 OFFCURVE",
+"440 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"477 939 LINE",
+"363 743 OFFCURVE",
+"232 578 OFFCURVE",
+"60 426 CURVE",
+"109 369 LINE",
+"278 521 OFFCURVE",
+"427 702 OFFCURVE",
+"543 904 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"582 727 LINE",
+"525 634 OFFCURVE",
+"469 558 OFFCURVE",
+"408 489 CURVE",
+"380 461 LINE",
+"311 383 OFFCURVE",
+"235 312 OFFCURVE",
+"145 231 CURVE",
+"193 175 LINE",
+"274 248 OFFCURVE",
+"346 315 OFFCURVE",
+"414 388 CURVE",
+"438 410 LINE",
+"510 490 OFFCURVE",
+"577 578 OFFCURVE",
+"646 689 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 888;
+}
+);
+leftMetricsKey = u1B187;
+unicode = 1B1CA;
+},
+{
+glyphname = u1B1CB;
+lastChange = "2020-04-13 08:35:18 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"233 177 OFFCURVE",
+"256 194 OFFCURVE",
+"256 233 CURVE SMOOTH",
+"256 272 OFFCURVE",
+"233 289 OFFCURVE",
+"205 289 CURVE SMOOTH",
+"176 289 OFFCURVE",
+"153 272 OFFCURVE",
+"153 233 CURVE SMOOTH",
+"153 194 OFFCURVE",
+"176 177 OFFCURVE",
+"205 177 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"150 -18 OFFCURVE",
+"173 -1 OFFCURVE",
+"173 38 CURVE SMOOTH",
+"173 77 OFFCURVE",
+"150 94 OFFCURVE",
+"122 94 CURVE SMOOTH",
+"93 94 OFFCURVE",
+"70 77 OFFCURVE",
+"70 38 CURVE SMOOTH",
+"70 -1 OFFCURVE",
+"93 -18 OFFCURVE",
+"122 -18 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"197 495 LINE",
+"336 303 OFFCURVE",
+"448 116 OFFCURVE",
+"562 -107 CURVE",
+"628 -74 LINE",
+"573 36 OFFCURVE",
+"519 129 OFFCURVE",
+"440 260 CURVE",
+"423 260 LINE",
+"386 354 OFFCURVE",
+"334 438 OFFCURVE",
+"236 576 CURVE",
+"248 499 LINE",
+"324 625 OFFCURVE",
+"362 704 OFFCURVE",
+"392 798 CURVE",
+"415 839 LINE",
+"424 864 OFFCURVE",
+"433 892 OFFCURVE",
+"442 918 CURVE",
+"369 939 LINE",
+"318 786 OFFCURVE",
+"267 678 OFFCURVE",
+"197 566 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"396 798 LINE",
+"448 718 OFFCURVE",
+"477 628 OFFCURVE",
+"477 536 CURVE SMOOTH",
+"477 451 OFFCURVE",
+"460 357 OFFCURVE",
+"427 260 CURVE",
+"415 260 LINE",
+"359 127 OFFCURVE",
+"290 16 OFFCURVE",
+"144 -155 CURVE",
+"200 -203 LINE",
+"477 122 OFFCURVE",
+"553 342 OFFCURVE",
+"553 536 CURVE SMOOTH",
+"553 662 OFFCURVE",
+"513 766 OFFCURVE",
+"408 889 CURVE",
+"365 798 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 738;
+}
+);
+leftMetricsKey = u1B1B8;
+rightMetricsKey = u1B17C;
+unicode = 1B1CB;
+},
+{
+glyphname = u1B1CC;
+lastChange = "2020-04-13 08:35:22 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"558 650 LINE",
+"431 512 OFFCURVE",
+"343 433 OFFCURVE",
+"201 335 CURVE",
+"239 275 LINE",
+"385 377 OFFCURVE",
+"486 457 OFFCURVE",
+"615 602 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"447 939 LINE",
+"356 789 OFFCURVE",
+"247 669 OFFCURVE",
+"120 550 CURVE",
+"162 417 OFFCURVE",
+"175 311 OFFCURVE",
+"175 187 CURVE SMOOTH",
+"175 51 OFFCURVE",
+"158 -64 OFFCURVE",
+"120 -182 CURVE",
+"191 -203 LINE",
+"235 -77 OFFCURVE",
+"251 46 OFFCURVE",
+"251 187 CURVE SMOOTH",
+"251 315 OFFCURVE",
+"234 431 OFFCURVE",
+"196 568 CURVE",
+"190 512 LINE",
+"310 626 OFFCURVE",
+"420 745 OFFCURVE",
+"515 903 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"369 -38 OFFCURVE",
+"396 -97 OFFCURVE",
+"491 -145 CURVE",
+"572 -124 LINE",
+"625 -24 OFFCURVE",
+"644 39 OFFCURVE",
+"644 115 CURVE SMOOTH",
+"644 191 OFFCURVE",
+"615 251 OFFCURVE",
+"516 312 CURVE",
+"438 297 LINE",
+"386 181 OFFCURVE",
+"369 113 OFFCURVE",
+"369 44 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"490 254 LINE",
+"545 213 OFFCURVE",
+"572 167 OFFCURVE",
+"572 115 CURVE SMOOTH",
+"572 58 OFFCURVE",
+"560 -3 OFFCURVE",
+"520 -90 CURVE",
+"515 -91 LINE",
+"460 -52 OFFCURVE",
+"441 -9 OFFCURVE",
+"441 44 CURVE SMOOTH",
+"441 100 OFFCURVE",
+"454 168 OFFCURVE",
+"485 253 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 744;
+}
+);
+leftMetricsKey = u1B17E;
+unicode = 1B1CC;
+},
+{
+glyphname = u1B1CD;
+lastChange = "2020-04-13 08:35:51 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"553 939 LINE",
+"420 710 OFFCURVE",
+"317 577 OFFCURVE",
+"159 416 CURVE",
+"213 363 LINE",
+"358 509 OFFCURVE",
+"482 664 OFFCURVE",
+"620 902 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"669 425 LINE",
+"574 275 OFFCURVE",
+"478 162 OFFCURVE",
+"356 56 CURVE",
+"404 2 LINE",
+"537 119 OFFCURVE",
+"638 237 OFFCURVE",
+"733 387 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"340 570 LINE",
+"416 419 OFFCURVE",
+"458 305 OFFCURVE",
+"502 149 CURVE",
+"564 191 LINE",
+"518 356 OFFCURVE",
+"470 472 OFFCURVE",
+"385 655 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"276 157 LINE",
+"249 104 OFFCURVE",
+"224 59 OFFCURVE",
+"199 19 CURVE",
+"176 -10 LINE",
+"142 -59 OFFCURVE",
+"106 -104 OFFCURVE",
+"60 -154 CURVE",
+"112 -203 LINE",
+"158 -150 OFFCURVE",
+"192 -107 OFFCURVE",
+"222 -64 CURVE",
+"248 -31 LINE",
+"278 15 OFFCURVE",
+"305 63 OFFCURVE",
+"340 126 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"66 88 LINE",
+"158 -5 OFFCURVE",
+"219 -83 OFFCURVE",
+"282 -182 CURVE",
+"341 -143 LINE",
+"268 -34 OFFCURVE",
+"200 49 OFFCURVE",
+"116 138 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 803;
+}
+);
+leftMetricsKey = u1B1C9;
+rightMetricsKey = u1B180;
+unicode = 1B1CD;
+},
+{
+glyphname = u1B1CE;
+lastChange = "2020-04-11 15:47:27 +0000";
+layers = (
+{
+background = {
+paths = (
+{
+closed = 1;
+nodes = (
+"547 237 OFFCURVE",
+"513 277 OFFCURVE",
+"461 328 CURVE SMOOTH",
+"407 382 OFFCURVE",
+"351 435 OFFCURVE",
+"290 492 CURVE",
+"303 443 LINE",
+"386 584 OFFCURVE",
+"446 711 OFFCURVE",
+"513 891 CURVE",
+"431 919 LINE",
+"374 755 OFFCURVE",
+"301 606 OFFCURVE",
+"209 447 CURVE",
+"349 322 OFFCURVE",
+"457 216 OFFCURVE",
+"557 101 CURVE",
+"646 105 LINE",
+"741 259 OFFCURVE",
+"802 380 OFFCURVE",
+"883 563 CURVE",
+"804 597 LINE",
+"765 509 OFFCURVE",
+"731 436 OFFCURVE",
+"697 370 CURVE SMOOTH",
+"659 297 OFFCURVE",
+"634 245 OFFCURVE",
+"599 176 CURVE",
+"595 176 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"298 -8 LINE",
+"364 82 OFFCURVE",
+"413 166 OFFCURVE",
+"465 280 CURVE",
+"398 325 LINE",
+"347 214 OFFCURVE",
+"305 143 OFFCURVE",
+"240 50 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"479 -147 LINE",
+"361 -13 OFFCURVE",
+"251 103 OFFCURVE",
+"117 228 CURVE",
+"60 163 LINE",
+"181 51 OFFCURVE",
+"307 -80 OFFCURVE",
+"414 -203 CURVE"
+);
+}
+);
+};
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"547 223 OFFCURVE",
+"509 266 OFFCURVE",
+"457 318 CURVE SMOOTH",
+"403 372 OFFCURVE",
+"347 425 OFFCURVE",
+"286 482 CURVE",
+"292 447 LINE",
+"375 588 OFFCURVE",
+"435 715 OFFCURVE",
+"502 895 CURVE",
+"431 919 LINE",
+"374 755 OFFCURVE",
+"301 606 OFFCURVE",
+"209 447 CURVE",
+"349 322 OFFCURVE",
+"457 216 OFFCURVE",
+"557 101 CURVE",
+"646 105 LINE",
+"741 259 OFFCURVE",
+"802 380 OFFCURVE",
+"883 563 CURVE",
+"813 593 LINE",
+"774 505 OFFCURVE",
+"740 432 OFFCURVE",
+"706 366 CURVE SMOOTH",
+"668 293 OFFCURVE",
+"634 231 OFFCURVE",
+"599 162 CURVE",
+"595 162 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"288 -3 LINE",
+"354 87 OFFCURVE",
+"403 171 OFFCURVE",
+"455 285 CURVE",
+"398 325 LINE",
+"347 214 OFFCURVE",
+"305 143 OFFCURVE",
+"240 50 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"469 -155 LINE",
+"351 -21 OFFCURVE",
+"245 93 OFFCURVE",
+"111 218 CURVE",
+"60 163 LINE",
+"181 51 OFFCURVE",
+"307 -80 OFFCURVE",
+"414 -203 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 923;
+}
+);
+unicode = 1B1CE;
+},
+{
+glyphname = u1B1CF;
+lastChange = "2020-04-13 08:36:16 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"245 333 LINE",
+"222 433 OFFCURVE",
+"186 515 OFFCURVE",
+"126 634 CURVE",
+"60 601 LINE",
+"119 488 OFFCURVE",
+"153 410 OFFCURVE",
+"192 286 CURVE",
+"286 270 LINE",
+"342 334 OFFCURVE",
+"392 399 OFFCURVE",
+"439 468 CURVE",
+"463 498 LINE",
+"539 615 OFFCURVE",
+"609 744 OFFCURVE",
+"693 908 CURVE",
+"623 939 LINE",
+"547 785 OFFCURVE",
+"486 671 OFFCURVE",
+"436 592 CURVE",
+"420 573 LINE",
+"403 549 OFFCURVE",
+"400 545 OFFCURVE",
+"397 541 CURVE SMOOTH",
+"346 468 OFFCURVE",
+"295 396 OFFCURVE",
+"250 332 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"482 -203 LINE",
+"508 -74 OFFCURVE",
+"517 33 OFFCURVE",
+"517 193 CURVE SMOOTH",
+"517 422 OFFCURVE",
+"453 634 OFFCURVE",
+"301 886 CURVE",
+"236 849 LINE",
+"389 594 OFFCURVE",
+"441 414 OFFCURVE",
+"441 193 CURVE SMOOTH",
+"441 44 OFFCURVE",
+"434 -64 OFFCURVE",
+"409 -190 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"688 408 OFFCURVE",
+"711 425 OFFCURVE",
+"711 464 CURVE SMOOTH",
+"711 503 OFFCURVE",
+"688 520 OFFCURVE",
+"660 520 CURVE SMOOTH",
+"631 520 OFFCURVE",
+"608 503 OFFCURVE",
+"608 464 CURVE SMOOTH",
+"608 425 OFFCURVE",
+"631 408 OFFCURVE",
+"660 408 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"714 163 OFFCURVE",
+"737 180 OFFCURVE",
+"737 219 CURVE SMOOTH",
+"737 258 OFFCURVE",
+"714 275 OFFCURVE",
+"686 275 CURVE SMOOTH",
+"657 275 OFFCURVE",
+"634 258 OFFCURVE",
+"634 219 CURVE SMOOTH",
+"634 180 OFFCURVE",
+"657 163 OFFCURVE",
+"686 163 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 857;
+}
+);
+rightMetricsKey = u1B1B5;
+unicode = 1B1CF;
+},
+{
+glyphname = u1B1D0;
+lastChange = "2020-04-13 08:36:21 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"229 145 OFFCURVE",
+"207 90 OFFCURVE",
+"207 32 CURVE SMOOTH",
+"207 -105 OFFCURVE",
+"294 -203 OFFCURVE",
+"482 -203 CURVE",
+"485 -131 LINE",
+"336 -131 OFFCURVE",
+"281 -68 OFFCURVE",
+"281 37 CURVE SMOOTH",
+"281 98 OFFCURVE",
+"304 141 OFFCURVE",
+"360 169 CURVE",
+"340 257 LINE",
+"206 257 OFFCURVE",
+"144 318 OFFCURVE",
+"144 432 CURVE SMOOTH",
+"144 502 OFFCURVE",
+"169 548 OFFCURVE",
+"229 593 CURVE",
+"186 648 LINE",
+"106 593 OFFCURVE",
+"70 515 OFFCURVE",
+"70 429 CURVE SMOOTH",
+"70 297 OFFCURVE",
+"149 200 OFFCURVE",
+"290 199 CURVE",
+"291 194 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"643 939 LINE",
+"510 710 OFFCURVE",
+"407 577 OFFCURVE",
+"249 416 CURVE",
+"303 363 LINE",
+"448 509 OFFCURVE",
+"572 664 OFFCURVE",
+"710 902 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"759 425 LINE",
+"664 275 OFFCURVE",
+"568 162 OFFCURVE",
+"446 56 CURVE",
+"494 2 LINE",
+"627 119 OFFCURVE",
+"728 237 OFFCURVE",
+"823 387 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"430 570 LINE",
+"506 419 OFFCURVE",
+"548 305 OFFCURVE",
+"592 149 CURVE",
+"654 191 LINE",
+"608 356 OFFCURVE",
+"560 472 OFFCURVE",
+"475 655 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 893;
+}
+);
+rightMetricsKey = u1B180;
+unicode = 1B1D0;
+},
+{
+glyphname = u1B1D1;
+lastChange = "2020-04-13 08:36:30 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"322 383 LINE",
+"410 282 OFFCURVE",
+"499 163 OFFCURVE",
+"596 10 CURVE",
+"657 49 LINE",
+"621 105 OFFCURVE",
+"593 144 OFFCURVE",
+"537 224 CURVE",
+"520 224 LINE",
+"480 300 OFFCURVE",
+"438 364 OFFCURVE",
+"371 441 CURVE",
+"365 392 LINE",
+"441 472 OFFCURVE",
+"489 529 OFFCURVE",
+"528 590 CURVE",
+"552 606 LINE",
+"568 627 OFFCURVE",
+"584 650 OFFCURVE",
+"600 674 CURVE",
+"537 714 LINE",
+"465 607 OFFCURVE",
+"403 536 OFFCURVE",
+"322 454 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"551 530 OFFCURVE",
+"562 483 OFFCURVE",
+"562 425 CURVE SMOOTH",
+"562 366 OFFCURVE",
+"550 293 OFFCURVE",
+"524 224 CURVE",
+"508 224 LINE",
+"454 114 OFFCURVE",
+"403 33 OFFCURVE",
+"327 -79 CURVE",
+"386 -119 LINE",
+"452 -24 OFFCURVE",
+"497 56 OFFCURVE",
+"535 126 CURVE",
+"562 165 LINE",
+"613 267 OFFCURVE",
+"634 347 OFFCURVE",
+"634 425 CURVE SMOOTH",
+"634 497 OFFCURVE",
+"618 554 OFFCURVE",
+"543 663 CURVE",
+"511 588 LINE",
+"533 589 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"447 939 LINE",
+"356 789 OFFCURVE",
+"247 669 OFFCURVE",
+"120 550 CURVE",
+"162 417 OFFCURVE",
+"175 311 OFFCURVE",
+"175 187 CURVE SMOOTH",
+"175 51 OFFCURVE",
+"158 -64 OFFCURVE",
+"120 -182 CURVE",
+"191 -203 LINE",
+"235 -77 OFFCURVE",
+"251 46 OFFCURVE",
+"251 187 CURVE SMOOTH",
+"251 315 OFFCURVE",
+"234 431 OFFCURVE",
+"196 568 CURVE",
+"190 512 LINE",
+"310 626 OFFCURVE",
+"420 745 OFFCURVE",
+"515 903 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 767;
+}
+);
+leftMetricsKey = u1B17E;
+rightMetricsKey = u1B17C;
+unicode = 1B1D1;
+},
+{
+glyphname = u1B1D2;
+lastChange = "2020-04-13 08:40:42 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"583 -4 OFFCURVE",
+"621 -82 OFFCURVE",
+"732 -141 CURVE",
+"770 -83 LINE",
+"684 -29 OFFCURVE",
+"657 20 OFFCURVE",
+"657 112 CURVE SMOOTH",
+"657 180 OFFCURVE",
+"682 238 OFFCURVE",
+"740 290 CURVE",
+"692 341 LINE",
+"611 265 OFFCURVE",
+"583 191 OFFCURVE",
+"583 111 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"819 56 OFFCURVE",
+"842 73 OFFCURVE",
+"842 112 CURVE SMOOTH",
+"842 151 OFFCURVE",
+"819 168 OFFCURVE",
+"791 168 CURVE SMOOTH",
+"762 168 OFFCURVE",
+"739 151 OFFCURVE",
+"739 112 CURVE SMOOTH",
+"739 73 OFFCURVE",
+"762 56 OFFCURVE",
+"791 56 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"271 895 LINE",
+"376 581 OFFCURVE",
+"416 361 OFFCURVE",
+"416 76 CURVE SMOOTH",
+"416 -26 OFFCURVE",
+"412 -107 OFFCURVE",
+"403 -194 CURVE",
+"477 -203 LINE",
+"484 -110 OFFCURVE",
+"492 -22 OFFCURVE",
+"492 83 CURVE SMOOTH",
+"492 355 OFFCURVE",
+"453 602 OFFCURVE",
+"342 922 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"654 926 LINE",
+"562 851 OFFCURVE",
+"473 784 OFFCURVE",
+"381 724 CURVE",
+"356 711 LINE",
+"262 650 OFFCURVE",
+"165 595 OFFCURVE",
+"60 542 CURVE",
+"94 474 LINE",
+"192 523 OFFCURVE",
+"284 576 OFFCURVE",
+"375 633 CURVE",
+"400 645 LINE",
+"502 712 OFFCURVE",
+"602 786 OFFCURVE",
+"704 869 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"631 725 OFFCURVE",
+"647 684 OFFCURVE",
+"647 632 CURVE SMOOTH",
+"647 561 OFFCURVE",
+"606 502 OFFCURVE",
+"444 408 CURVE",
+"419 398 LINE",
+"348 359 OFFCURVE",
+"258 314 OFFCURVE",
+"142 261 CURVE",
+"174 192 LINE",
+"280 241 OFFCURVE",
+"366 284 OFFCURVE",
+"436 322 CURVE",
+"453 327 LINE",
+"677 453 OFFCURVE",
+"723 531 OFFCURVE",
+"723 632 CURVE SMOOTH",
+"723 711 OFFCURVE",
+"700 766 OFFCURVE",
+"621 864 CURVE",
+"582 793 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 922;
+}
+);
+leftMetricsKey = u1B1B3;
+rightMetricsKey = u1B177;
+unicode = 1B1D2;
+},
+{
+glyphname = u1B1D3;
+lastChange = "2020-04-13 08:40:20 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"547 222 OFFCURVE",
+"510 267 OFFCURVE",
+"462 315 CURVE SMOOTH",
+"408 369 OFFCURVE",
+"354 420 OFFCURVE",
+"290 479 CURVE",
+"293 447 LINE",
+"371 581 OFFCURVE",
+"433 701 OFFCURVE",
+"503 895 CURVE",
+"431 919 LINE",
+"374 755 OFFCURVE",
+"302 610 OFFCURVE",
+"209 447 CURVE",
+"352 320 OFFCURVE",
+"447 231 OFFCURVE",
+"556 101 CURVE",
+"645 106 LINE",
+"741 263 OFFCURVE",
+"812 396 OFFCURVE",
+"883 563 CURVE",
+"812 592 LINE",
+"781 519 OFFCURVE",
+"751 453 OFFCURVE",
+"719 391 CURVE SMOOTH",
+"677 310 OFFCURVE",
+"644 241 OFFCURVE",
+"596 161 CURVE",
+"592 161 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"293 -7 LINE",
+"345 63 OFFCURVE",
+"396 144 OFFCURVE",
+"451 243 CURVE",
+"474 278 LINE",
+"544 394 OFFCURVE",
+"603 517 OFFCURVE",
+"681 699 CURVE",
+"613 728 LINE",
+"541 559 OFFCURVE",
+"486 447 OFFCURVE",
+"419 336 CURVE",
+"402 301 LINE",
+"349 202 OFFCURVE",
+"295 122 OFFCURVE",
+"242 47 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"468 -152 LINE",
+"350 -18 OFFCURVE",
+"242 93 OFFCURVE",
+"108 218 CURVE",
+"60 163 LINE",
+"181 51 OFFCURVE",
+"307 -80 OFFCURVE",
+"414 -203 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 923;
+}
+);
+leftMetricsKey = u1B1CE;
+rightMetricsKey = u1B1CE;
+unicode = 1B1D3;
+},
+{
+glyphname = u1B1D4;
+lastChange = "2020-04-13 09:44:38 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"593 -33 LINE",
+"560 363 OFFCURVE",
+"488 586 OFFCURVE",
+"291 901 CURVE",
+"227 864 LINE",
+"403 575 OFFCURVE",
+"491 363 OFFCURVE",
+"517 -41 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"575 939 LINE",
+"519 840 OFFCURVE",
+"463 756 OFFCURVE",
+"400 677 CURVE",
+"368 644 LINE",
+"315 580 OFFCURVE",
+"257 518 OFFCURVE",
+"190 453 CURVE",
+"243 398 LINE",
+"309 464 OFFCURVE",
+"363 521 OFFCURVE",
+"412 579 CURVE",
+"438 602 LINE",
+"511 691 OFFCURVE",
+"573 782 OFFCURVE",
+"644 905 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"696 657 LINE",
+"638 566 OFFCURVE",
+"576 486 OFFCURVE",
+"504 407 CURVE",
+"480 388 LINE",
+"426 331 OFFCURVE",
+"366 273 OFFCURVE",
+"297 213 CURVE",
+"345 157 LINE",
+"401 207 OFFCURVE",
+"454 255 OFFCURVE",
+"503 305 CURVE",
+"529 325 LINE",
+"616 415 OFFCURVE",
+"692 508 OFFCURVE",
+"760 616 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 -95 OFFCURVE",
+"109 -143 OFFCURVE",
+"177 -183 CURVE",
+"248 -174 LINE",
+"316 -95 OFFCURVE",
+"334 -30 OFFCURVE",
+"334 31 CURVE SMOOTH",
+"334 91 OFFCURVE",
+"300 132 OFFCURVE",
+"232 170 CURVE",
+"158 160 LINE",
+"100 78 OFFCURVE",
+"80 11 OFFCURVE",
+"80 -38 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 116 LINE",
+"244 84 OFFCURVE",
+"259 49 OFFCURVE",
+"259 20 CURVE SMOOTH",
+"259 -23 OFFCURVE",
+"249 -68 OFFCURVE",
+"209 -132 CURVE",
+"204 -133 LINE",
+"169 -98 OFFCURVE",
+"154 -67 OFFCURVE",
+"154 -34 CURVE SMOOTH",
+"154 8 OFFCURVE",
+"167 52 OFFCURVE",
+"199 115 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 850;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B187;
+unicode = 1B1D4;
+},
+{
+glyphname = u1B1D5;
+lastChange = "2020-04-13 08:39:56 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"150 493 OFFCURVE",
+"173 510 OFFCURVE",
+"173 549 CURVE SMOOTH",
+"173 588 OFFCURVE",
+"150 605 OFFCURVE",
+"122 605 CURVE SMOOTH",
+"93 605 OFFCURVE",
+"70 588 OFFCURVE",
+"70 549 CURVE SMOOTH",
+"70 510 OFFCURVE",
+"93 493 OFFCURVE",
+"122 493 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"438 820 OFFCURVE",
+"461 837 OFFCURVE",
+"461 876 CURVE SMOOTH",
+"461 915 OFFCURVE",
+"438 932 OFFCURVE",
+"410 932 CURVE SMOOTH",
+"381 932 OFFCURVE",
+"358 915 OFFCURVE",
+"358 876 CURVE SMOOTH",
+"358 837 OFFCURVE",
+"381 820 OFFCURVE",
+"410 820 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"620 939 LINE",
+"533 786 OFFCURVE",
+"454 662 OFFCURVE",
+"370 547 CURVE",
+"352 530 LINE",
+"287 442 OFFCURVE",
+"220 358 OFFCURVE",
+"146 271 CURVE",
+"204 222 LINE",
+"271 300 OFFCURVE",
+"332 375 OFFCURVE",
+"392 455 CURVE",
+"414 477 LINE",
+"505 602 OFFCURVE",
+"593 737 OFFCURVE",
+"687 904 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"157 836 LINE",
+"368 472 OFFCURVE",
+"503 146 OFFCURVE",
+"618 -203 CURVE",
+"689 -178 LINE",
+"576 178 OFFCURVE",
+"434 498 OFFCURVE",
+"222 875 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"457 257 LINE",
+"372 118 OFFCURVE",
+"295 14 OFFCURVE",
+"194 -101 CURVE",
+"251 -150 LINE",
+"353 -33 OFFCURVE",
+"435 75 OFFCURVE",
+"517 210 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 779;
+}
+);
+leftMetricsKey = u1B18E;
+rightMetricsKey = u1B194;
+unicode = 1B1D5;
+},
+{
+glyphname = u1B1D6;
+lastChange = "2020-04-13 08:39:39 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"522 939 LINE",
+"459 840 OFFCURVE",
+"398 754 OFFCURVE",
+"333 671 CURVE",
+"303 640 LINE",
+"233 554 OFFCURVE",
+"158 472 OFFCURVE",
+"70 384 CURVE",
+"124 330 LINE",
+"209 415 OFFCURVE",
+"284 497 OFFCURVE",
+"355 584 CURVE",
+"375 603 LINE",
+"447 691 OFFCURVE",
+"515 787 OFFCURVE",
+"588 901 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"160 831 LINE",
+"389 496 OFFCURVE",
+"539 199 OFFCURVE",
+"685 -129 CURVE",
+"754 -98 LINE",
+"600 255 OFFCURVE",
+"448 536 OFFCURVE",
+"223 874 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"432 466 LINE",
+"341 339 OFFCURVE",
+"257 232 OFFCURVE",
+"125 99 CURVE",
+"179 45 LINE",
+"301 172 OFFCURVE",
+"390 278 OFFCURVE",
+"486 420 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"280 -115 OFFCURVE",
+"309 -163 OFFCURVE",
+"377 -203 CURVE",
+"448 -194 LINE",
+"516 -115 OFFCURVE",
+"534 -50 OFFCURVE",
+"534 11 CURVE SMOOTH",
+"534 71 OFFCURVE",
+"500 112 OFFCURVE",
+"432 150 CURVE",
+"358 140 LINE",
+"300 58 OFFCURVE",
+"280 -9 OFFCURVE",
+"280 -58 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"404 96 LINE",
+"444 64 OFFCURVE",
+"459 29 OFFCURVE",
+"459 0 CURVE SMOOTH",
+"459 -43 OFFCURVE",
+"449 -88 OFFCURVE",
+"409 -152 CURVE",
+"404 -153 LINE",
+"369 -118 OFFCURVE",
+"354 -87 OFFCURVE",
+"354 -54 CURVE SMOOTH",
+"354 -12 OFFCURVE",
+"367 32 OFFCURVE",
+"399 95 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 844;
+}
+);
+leftMetricsKey = u1B194;
+rightMetricsKey = u1B194;
+unicode = 1B1D6;
+},
+{
+glyphname = u1B1D7;
+lastChange = "2020-04-13 08:39:25 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"156 229 LINE",
+"219 169 OFFCURVE",
+"242 112 OFFCURVE",
+"242 34 CURVE SMOOTH",
+"242 -46 OFFCURVE",
+"221 -101 OFFCURVE",
+"169 -160 CURVE",
+"222 -203 LINE",
+"285 -130 OFFCURVE",
+"316 -62 OFFCURVE",
+"316 32 CURVE SMOOTH",
+"316 131 OFFCURVE",
+"282 203 OFFCURVE",
+"206 278 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"130 -18 OFFCURVE",
+"153 -1 OFFCURVE",
+"153 38 CURVE SMOOTH",
+"153 77 OFFCURVE",
+"130 94 OFFCURVE",
+"102 94 CURVE SMOOTH",
+"73 94 OFFCURVE",
+"50 77 OFFCURVE",
+"50 38 CURVE SMOOTH",
+"50 -1 OFFCURVE",
+"73 -18 OFFCURVE",
+"102 -18 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"563 939 LINE",
+"430 710 OFFCURVE",
+"327 577 OFFCURVE",
+"169 416 CURVE",
+"223 363 LINE",
+"368 509 OFFCURVE",
+"492 664 OFFCURVE",
+"630 902 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"679 425 LINE",
+"584 275 OFFCURVE",
+"488 162 OFFCURVE",
+"366 56 CURVE",
+"414 2 LINE",
+"547 119 OFFCURVE",
+"648 237 OFFCURVE",
+"743 387 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"350 570 LINE",
+"426 419 OFFCURVE",
+"468 305 OFFCURVE",
+"512 149 CURVE",
+"574 191 LINE",
+"528 356 OFFCURVE",
+"480 472 OFFCURVE",
+"395 655 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 813;
+}
+);
+rightMetricsKey = u1B180;
+unicode = 1B1D7;
+},
+{
+glyphname = u1B1D8;
+lastChange = "2020-04-13 08:39:22 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"592 495 OFFCURVE",
+"615 512 OFFCURVE",
+"615 551 CURVE SMOOTH",
+"615 590 OFFCURVE",
+"592 607 OFFCURVE",
+"564 607 CURVE SMOOTH",
+"535 607 OFFCURVE",
+"512 590 OFFCURVE",
+"512 551 CURVE SMOOTH",
+"512 512 OFFCURVE",
+"535 495 OFFCURVE",
+"564 495 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"592 157 OFFCURVE",
+"615 174 OFFCURVE",
+"615 213 CURVE SMOOTH",
+"615 252 OFFCURVE",
+"592 269 OFFCURVE",
+"564 269 CURVE SMOOTH",
+"535 269 OFFCURVE",
+"512 252 OFFCURVE",
+"512 213 CURVE SMOOTH",
+"512 174 OFFCURVE",
+"535 157 OFFCURVE",
+"564 157 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"135 344 LINE",
+"274 158 OFFCURVE",
+"360 -2 OFFCURVE",
+"435 -203 CURVE",
+"505 -177 LINE",
+"456 -55 OFFCURVE",
+"406 50 OFFCURVE",
+"332 182 CURVE",
+"320 182 LINE",
+"286 254 OFFCURVE",
+"240 329 OFFCURVE",
+"187 401 CURVE",
+"176 343 LINE",
+"227 419 OFFCURVE",
+"277 502 OFFCURVE",
+"305 574 CURVE",
+"319 574 LINE",
+"388 703 OFFCURVE",
+"420 802 OFFCURVE",
+"457 918 CURVE",
+"384 939 LINE",
+"355 843 OFFCURVE",
+"326 759 OFFCURVE",
+"292 681 CURVE",
+"270 644 LINE",
+"232 566 OFFCURVE",
+"188 492 OFFCURVE",
+"135 415 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"180 726 OFFCURVE",
+"234 665 OFFCURVE",
+"295 574 CURVE",
+"309 574 LINE",
+"348 499 OFFCURVE",
+"359 437 OFFCURVE",
+"359 380 CURVE SMOOTH",
+"359 323 OFFCURVE",
+"348 252 OFFCURVE",
+"324 182 CURVE",
+"314 182 LINE",
+"256 71 OFFCURVE",
+"213 0 OFFCURVE",
+"126 -105 CURVE",
+"186 -149 LINE",
+"248 -66 OFFCURVE",
+"295 6 OFFCURVE",
+"333 73 CURVE",
+"357 110 LINE",
+"405 201 OFFCURVE",
+"429 286 OFFCURVE",
+"429 380 CURVE SMOOTH",
+"429 529 OFFCURVE",
+"361 638 OFFCURVE",
+"164 854 CURVE",
+"110 802 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 735;
+}
+);
+leftMetricsKey = u1B181;
+rightMetricsKey = u1B1B5;
+unicode = 1B1D8;
+},
+{
+glyphname = u1B1D9;
+lastChange = "2020-04-13 08:38:46 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"434 244 OFFCURVE",
+"456 162 OFFCURVE",
+"456 42 CURVE SMOOTH",
+"456 -37 OFFCURVE",
+"446 -106 OFFCURVE",
+"428 -188 CURVE",
+"498 -203 LINE",
+"523 -119 OFFCURVE",
+"532 -45 OFFCURVE",
+"532 42 CURVE SMOOTH",
+"532 171 OFFCURVE",
+"491 296 OFFCURVE",
+"374 435 CURVE SMOOTH",
+"258 573 OFFCURVE",
+"237 620 OFFCURVE",
+"237 723 CURVE SMOOTH",
+"237 771 OFFCURVE",
+"248 820 OFFCURVE",
+"270 878 CURVE",
+"203 899 LINE",
+"174 829 OFFCURVE",
+"163 774 OFFCURVE",
+"163 714 CURVE SMOOTH",
+"163 625 OFFCURVE",
+"185 545 OFFCURVE",
+"319 383 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"146 -42 LINE",
+"158 129 OFFCURVE",
+"188 215 OFFCURVE",
+"349 391 CURVE",
+"373 403 LINE",
+"511 543 OFFCURVE",
+"580 650 OFFCURVE",
+"610 795 CURVE",
+"628 849 LINE",
+"633 873 OFFCURVE",
+"639 902 OFFCURVE",
+"643 930 CURVE",
+"577 939 LINE",
+"540 721 OFFCURVE",
+"478 600 OFFCURVE",
+"328 457 CURVE",
+"303 443 LINE",
+"139 258 OFFCURVE",
+"88 171 OFFCURVE",
+"70 -37 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"589 794 LINE",
+"615 795 LINE",
+"671 718 OFFCURVE",
+"694 650 OFFCURVE",
+"694 566 CURVE SMOOTH",
+"694 511 OFFCURVE",
+"681 458 OFFCURVE",
+"660 409 CURVE",
+"725 388 LINE",
+"754 444 OFFCURVE",
+"766 495 OFFCURVE",
+"766 564 CURVE SMOOTH",
+"766 680 OFFCURVE",
+"724 772 OFFCURVE",
+"615 893 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 836;
+}
+);
+unicode = 1B1D9;
+},
+{
+glyphname = u1B1DA;
+lastChange = "2020-04-13 08:38:43 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"409 10 OFFCURVE",
+"432 27 OFFCURVE",
+"432 66 CURVE SMOOTH",
+"432 105 OFFCURVE",
+"409 122 OFFCURVE",
+"381 122 CURVE SMOOTH",
+"352 122 OFFCURVE",
+"329 105 OFFCURVE",
+"329 66 CURVE SMOOTH",
+"329 27 OFFCURVE",
+"352 10 OFFCURVE",
+"381 10 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"577 653 LINE",
+"536 601 OFFCURVE",
+"495 556 OFFCURVE",
+"454 515 CURVE",
+"437 503 LINE",
+"368 437 OFFCURVE",
+"294 380 OFFCURVE",
+"201 319 CURVE",
+"238 257 LINE",
+"323 310 OFFCURVE",
+"397 364 OFFCURVE",
+"466 426 CURVE",
+"484 438 LINE",
+"536 488 OFFCURVE",
+"586 543 OFFCURVE",
+"636 606 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"321 716 LINE",
+"434 476 OFFCURVE",
+"477 297 OFFCURVE",
+"511 87 CURVE",
+"584 98 LINE",
+"545 332 OFFCURVE",
+"498 514 OFFCURVE",
+"374 778 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"447 939 LINE",
+"356 789 OFFCURVE",
+"247 669 OFFCURVE",
+"120 550 CURVE",
+"162 417 OFFCURVE",
+"175 311 OFFCURVE",
+"175 187 CURVE SMOOTH",
+"175 51 OFFCURVE",
+"158 -64 OFFCURVE",
+"120 -182 CURVE",
+"191 -203 LINE",
+"235 -77 OFFCURVE",
+"251 46 OFFCURVE",
+"251 187 CURVE SMOOTH",
+"251 315 OFFCURVE",
+"234 431 OFFCURVE",
+"196 568 CURVE",
+"190 512 LINE",
+"310 626 OFFCURVE",
+"420 745 OFFCURVE",
+"515 903 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 726;
+}
+);
+leftMetricsKey = u1B1A5;
+rightMetricsKey = u1B1A5;
+unicode = 1B1DA;
+},
+{
+glyphname = u1B1DB;
+lastChange = "2020-04-13 08:38:31 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"278 268 OFFCURVE",
+"301 285 OFFCURVE",
+"301 324 CURVE SMOOTH",
+"301 363 OFFCURVE",
+"278 380 OFFCURVE",
+"250 380 CURVE SMOOTH",
+"221 380 OFFCURVE",
+"198 363 OFFCURVE",
+"198 324 CURVE SMOOTH",
+"198 285 OFFCURVE",
+"221 268 OFFCURVE",
+"250 268 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"565 583 OFFCURVE",
+"588 600 OFFCURVE",
+"588 639 CURVE SMOOTH",
+"588 678 OFFCURVE",
+"565 695 OFFCURVE",
+"537 695 CURVE SMOOTH",
+"508 695 OFFCURVE",
+"485 678 OFFCURVE",
+"485 639 CURVE SMOOTH",
+"485 600 OFFCURVE",
+"508 583 OFFCURVE",
+"537 583 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"563 -198 LINE",
+"539 195 OFFCURVE",
+"477 409 OFFCURVE",
+"349 692 CURVE",
+"297 624 LINE",
+"415 363 OFFCURVE",
+"467 130 OFFCURVE",
+"487 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"477 939 LINE",
+"363 743 OFFCURVE",
+"232 578 OFFCURVE",
+"60 426 CURVE",
+"111 370 LINE",
+"283 522 OFFCURVE",
+"427 698 OFFCURVE",
+"543 902 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"683 608 LINE",
+"608 505 OFFCURVE",
+"530 415 OFFCURVE",
+"447 332 CURVE",
+"428 318 LINE",
+"353 246 OFFCURVE",
+"273 179 OFFCURVE",
+"187 117 CURVE",
+"232 58 LINE",
+"307 112 OFFCURVE",
+"379 171 OFFCURVE",
+"449 235 CURVE",
+"472 252 LINE",
+"566 342 OFFCURVE",
+"656 444 OFFCURVE",
+"744 563 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 834;
+}
+);
+leftMetricsKey = u1B189;
+rightMetricsKey = u1B189;
+unicode = 1B1DB;
+},
+{
+glyphname = u1B1DC;
+lastChange = "2020-04-13 08:38:18 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"643 939 LINE",
+"552 789 OFFCURVE",
+"453 669 OFFCURVE",
+"326 550 CURVE",
+"396 392 OFFCURVE",
+"417 299 OFFCURVE",
+"417 167 CURVE SMOOTH",
+"417 37 OFFCURVE",
+"390 -60 OFFCURVE",
+"341 -177 CURVE",
+"410 -203 LINE",
+"463 -84 OFFCURVE",
+"491 32 OFFCURVE",
+"491 167 CURVE SMOOTH",
+"491 299 OFFCURVE",
+"465 414 OFFCURVE",
+"399 568 CURVE",
+"385 511 LINE",
+"505 623 OFFCURVE",
+"614 743 OFFCURVE",
+"710 902 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"758 315 LINE",
+"736 497 OFFCURVE",
+"696 614 OFFCURVE",
+"599 777 CURVE",
+"557 705 LINE",
+"635 563 OFFCURVE",
+"665 469 OFFCURVE",
+"683 307 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 55 OFFCURVE",
+"109 7 OFFCURVE",
+"177 -33 CURVE",
+"248 -24 LINE",
+"316 55 OFFCURVE",
+"334 120 OFFCURVE",
+"334 181 CURVE SMOOTH",
+"334 241 OFFCURVE",
+"300 282 OFFCURVE",
+"232 320 CURVE",
+"158 310 LINE",
+"100 228 OFFCURVE",
+"80 161 OFFCURVE",
+"80 112 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 266 LINE",
+"244 234 OFFCURVE",
+"259 199 OFFCURVE",
+"259 170 CURVE SMOOTH",
+"259 127 OFFCURVE",
+"249 82 OFFCURVE",
+"209 18 CURVE",
+"204 17 LINE",
+"169 52 OFFCURVE",
+"154 83 OFFCURVE",
+"154 116 CURVE SMOOTH",
+"154 158 OFFCURVE",
+"167 202 OFFCURVE",
+"199 265 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 858;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B17E;
+unicode = 1B1DC;
+},
+{
+glyphname = u1B1DD;
+lastChange = "2020-04-13 08:38:15 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"438 713 LINE",
+"381 606 OFFCURVE",
+"328 529 OFFCURVE",
+"248 422 CURVE",
+"290 353 LINE",
+"365 454 OFFCURVE",
+"431 548 OFFCURVE",
+"489 649 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"353 842 LINE",
+"396 765 OFFCURVE",
+"423 719 OFFCURVE",
+"465 647 CURVE SMOOTH",
+"486 611 OFFCURVE",
+"527 533 OFFCURVE",
+"573 440 CURVE",
+"578 544 LINE",
+"513 434 OFFCURVE",
+"443 327 OFFCURVE",
+"368 216 CURVE",
+"337 179 LINE",
+"263 72 OFFCURVE",
+"183 -39 OFFCURVE",
+"94 -158 CURVE",
+"153 -203 LINE",
+"234 -96 OFFCURVE",
+"309 7 OFFCURVE",
+"379 108 CURVE",
+"406 139 LINE",
+"488 258 OFFCURVE",
+"564 374 OFFCURVE",
+"635 489 CURVE",
+"553 649 OFFCURVE",
+"478 779 OFFCURVE",
+"391 910 CURVE",
+"304 908 LINE",
+"244 791 OFFCURVE",
+"180 688 OFFCURVE",
+"90 559 CURVE",
+"271 274 OFFCURVE",
+"366 102 OFFCURVE",
+"488 -161 CURVE",
+"557 -130 LINE",
+"433 138 OFFCURVE",
+"326 329 OFFCURVE",
+"150 607 CURVE",
+"156 520 LINE",
+"192 573 OFFCURVE",
+"215 606 OFFCURVE",
+"245 653 CURVE SMOOTH",
+"286 717 OFFCURVE",
+"319 774 OFFCURVE",
+"349 842 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 745;
+}
+);
+unicode = 1B1DD;
+},
+{
+glyphname = u1B1DE;
+lastChange = "2020-04-13 08:37:59 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"417 809 OFFCURVE",
+"440 826 OFFCURVE",
+"440 865 CURVE SMOOTH",
+"440 904 OFFCURVE",
+"417 921 OFFCURVE",
+"389 921 CURVE SMOOTH",
+"360 921 OFFCURVE",
+"337 904 OFFCURVE",
+"337 865 CURVE SMOOTH",
+"337 826 OFFCURVE",
+"360 809 OFFCURVE",
+"389 809 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"160 477 OFFCURVE",
+"183 494 OFFCURVE",
+"183 533 CURVE SMOOTH",
+"183 572 OFFCURVE",
+"160 589 OFFCURVE",
+"132 589 CURVE SMOOTH",
+"103 589 OFFCURVE",
+"80 572 OFFCURVE",
+"80 533 CURVE SMOOTH",
+"80 494 OFFCURVE",
+"103 477 OFFCURVE",
+"132 477 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"594 939 LINE",
+"510 797 OFFCURVE",
+"431 676 OFFCURVE",
+"350 564 CURVE",
+"332 546 LINE",
+"273 467 OFFCURVE",
+"214 392 OFFCURVE",
+"151 318 CURVE",
+"207 270 LINE",
+"264 337 OFFCURVE",
+"317 402 OFFCURVE",
+"369 472 CURVE",
+"390 493 LINE",
+"476 611 OFFCURVE",
+"561 740 OFFCURVE",
+"660 904 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"745 270 LINE",
+"643 110 OFFCURVE",
+"542 -18 OFFCURVE",
+"410 -148 CURVE",
+"460 -203 LINE",
+"603 -57 OFFCURVE",
+"701 61 OFFCURVE",
+"810 230 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"628 43 LINE",
+"510 312 OFFCURVE",
+"404 524 OFFCURVE",
+"209 857 CURVE",
+"146 818 LINE",
+"347 481 OFFCURVE",
+"451 260 OFFCURVE",
+"568 0 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"656 571 LINE",
+"596 482 OFFCURVE",
+"536 397 OFFCURVE",
+"474 316 CURVE",
+"453 296 LINE",
+"395 223 OFFCURVE",
+"336 153 OFFCURVE",
+"274 85 CURVE",
+"329 35 LINE",
+"385 97 OFFCURVE",
+"439 160 OFFCURVE",
+"492 226 CURVE",
+"515 249 LINE",
+"584 337 OFFCURVE",
+"651 430 OFFCURVE",
+"719 532 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 890;
+}
+);
+rightMetricsKey = u1B197;
+unicode = 1B1DE;
+},
+{
+glyphname = u1B1DF;
+lastChange = "2020-04-13 08:37:40 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"369 913 LINE",
+"277 714 OFFCURVE",
+"209 599 OFFCURVE",
+"99 443 CURVE",
+"158 397 LINE",
+"274 558 OFFCURVE",
+"347 683 OFFCURVE",
+"440 887 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"596 504 LINE",
+"522 361 OFFCURVE",
+"442 245 OFFCURVE",
+"355 135 CURVE",
+"414 86 LINE",
+"507 204 OFFCURVE",
+"585 321 OFFCURVE",
+"665 470 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 494 OFFCURVE",
+"501 511 OFFCURVE",
+"501 550 CURVE SMOOTH",
+"501 589 OFFCURVE",
+"478 606 OFFCURVE",
+"450 606 CURVE SMOOTH",
+"421 606 OFFCURVE",
+"398 589 OFFCURVE",
+"398 550 CURVE SMOOTH",
+"398 511 OFFCURVE",
+"421 494 OFFCURVE",
+"450 494 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"354 292 OFFCURVE",
+"377 309 OFFCURVE",
+"377 348 CURVE SMOOTH",
+"377 387 OFFCURVE",
+"354 404 OFFCURVE",
+"326 404 CURVE SMOOTH",
+"297 404 OFFCURVE",
+"274 387 OFFCURVE",
+"274 348 CURVE SMOOTH",
+"274 309 OFFCURVE",
+"297 292 OFFCURVE",
+"326 292 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"118 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -102 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 743;
+}
+);
+leftMetricsKey = u1B1B9;
+unicode = 1B1DF;
+},
+{
+glyphname = u1B1E0;
+lastChange = "2020-04-13 08:37:36 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"490 939 LINE",
+"441 760 OFFCURVE",
+"395 670 OFFCURVE",
+"310 551 CURVE",
+"347 487 LINE",
+"446 612 OFFCURVE",
+"512 740 OFFCURVE",
+"562 920 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"641 700 LINE",
+"548 512 OFFCURVE",
+"466 411 OFFCURVE",
+"360 326 CURVE",
+"388 253 LINE",
+"505 347 OFFCURVE",
+"613 475 OFFCURVE",
+"707 669 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"160 211 OFFCURVE",
+"183 228 OFFCURVE",
+"183 267 CURVE SMOOTH",
+"183 306 OFFCURVE",
+"160 323 OFFCURVE",
+"132 323 CURVE SMOOTH",
+"103 323 OFFCURVE",
+"80 306 OFFCURVE",
+"80 267 CURVE SMOOTH",
+"80 228 OFFCURVE",
+"103 211 OFFCURVE",
+"132 211 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"613 129 OFFCURVE",
+"636 146 OFFCURVE",
+"636 185 CURVE SMOOTH",
+"636 224 OFFCURVE",
+"613 241 OFFCURVE",
+"585 241 CURVE SMOOTH",
+"556 241 OFFCURVE",
+"533 224 OFFCURVE",
+"533 185 CURVE SMOOTH",
+"533 146 OFFCURVE",
+"556 129 OFFCURVE",
+"585 129 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"595 -101 OFFCURVE",
+"618 -84 OFFCURVE",
+"618 -45 CURVE SMOOTH",
+"618 -6 OFFCURVE",
+"595 11 OFFCURVE",
+"567 11 CURVE SMOOTH",
+"538 11 OFFCURVE",
+"515 -6 OFFCURVE",
+"515 -45 CURVE SMOOTH",
+"515 -84 OFFCURVE",
+"538 -101 OFFCURVE",
+"567 -101 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"379 -203 LINE",
+"399 -102 OFFCURVE",
+"409 0 OFFCURVE",
+"409 126 CURVE SMOOTH",
+"409 379 OFFCURVE",
+"355 594 OFFCURVE",
+"203 846 CURVE",
+"140 807 LINE",
+"294 552 OFFCURVE",
+"333 371 OFFCURVE",
+"333 126 CURVE SMOOTH",
+"333 11 OFFCURVE",
+"322 -83 OFFCURVE",
+"304 -191 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 797;
+}
+);
+leftMetricsKey = u1B176;
+unicode = 1B1E0;
+},
+{
+glyphname = u1B1E1;
+lastChange = "2020-04-13 08:37:33 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"741 698 OFFCURVE",
+"764 715 OFFCURVE",
+"764 754 CURVE SMOOTH",
+"764 793 OFFCURVE",
+"741 810 OFFCURVE",
+"713 810 CURVE SMOOTH",
+"684 810 OFFCURVE",
+"661 793 OFFCURVE",
+"661 754 CURVE SMOOTH",
+"661 715 OFFCURVE",
+"684 698 OFFCURVE",
+"713 698 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"160 603 OFFCURVE",
+"183 620 OFFCURVE",
+"183 659 CURVE SMOOTH",
+"183 698 OFFCURVE",
+"160 715 OFFCURVE",
+"132 715 CURVE SMOOTH",
+"103 715 OFFCURVE",
+"80 698 OFFCURVE",
+"80 659 CURVE SMOOTH",
+"80 620 OFFCURVE",
+"103 603 OFFCURVE",
+"132 603 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"553 559 LINE",
+"524 454 OFFCURVE",
+"494 364 OFFCURVE",
+"458 278 CURVE",
+"437 238 LINE",
+"378 108 OFFCURVE",
+"304 -14 OFFCURVE",
+"200 -161 CURVE",
+"260 -203 LINE",
+"360 -59 OFFCURVE",
+"430 55 OFFCURVE",
+"486 174 CURVE",
+"503 203 LINE",
+"545 296 OFFCURVE",
+"580 395 OFFCURVE",
+"614 515 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 448 LINE",
+"428 233 OFFCURVE",
+"522 84 OFFCURVE",
+"618 -119 CURVE",
+"687 -86 LINE",
+"573 144 OFFCURVE",
+"472 298 OFFCURVE",
+"314 512 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"387 939 LINE",
+"330 640 OFFCURVE",
+"254 479 OFFCURVE",
+"98 260 CURVE",
+"157 216 LINE",
+"321 444 OFFCURVE",
+"401 612 OFFCURVE",
+"463 927 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"384 732 LINE",
+"519 594 OFFCURVE",
+"637 445 OFFCURVE",
+"749 273 CURVE",
+"811 315 LINE",
+"694 490 OFFCURVE",
+"579 637 OFFCURVE",
+"421 796 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 901;
+}
+);
+leftMetricsKey = u1B185;
+rightMetricsKey = u1B185;
+unicode = 1B1E1;
+},
+{
+glyphname = u1B1E2;
+lastChange = "2020-04-13 08:37:19 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"437 -64 LINE",
+"430 17 OFFCURVE",
+"421 83 OFFCURVE",
+"405 175 CURVE SMOOTH",
+"392 249 OFFCURVE",
+"376 326 OFFCURVE",
+"355 410 CURVE",
+"282 391 LINE",
+"332 202 OFFCURVE",
+"356 62 OFFCURVE",
+"376 -106 CURVE",
+"468 -136 LINE",
+"517 -86 OFFCURVE",
+"563 -36 OFFCURVE",
+"606 18 CURVE",
+"632 45 LINE",
+"671 96 OFFCURVE",
+"709 151 OFFCURVE",
+"747 210 CURVE",
+"684 250 LINE",
+"657 206 OFFCURVE",
+"629 164 OFFCURVE",
+"600 123 CURVE",
+"575 94 LINE",
+"531 34 OFFCURVE",
+"490 -12 OFFCURVE",
+"442 -65 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"486 278 LINE",
+"556 129 OFFCURVE",
+"598 12 OFFCURVE",
+"629 -138 CURVE",
+"701 -124 LINE",
+"663 30 OFFCURVE",
+"619 158 OFFCURVE",
+"551 307 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"133 178 LINE",
+"162 54 OFFCURVE",
+"178 -54 OFFCURVE",
+"185 -203 CURVE",
+"256 -199 LINE",
+"249 -49 OFFCURVE",
+"232 63 OFFCURVE",
+"201 196 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"365 939 LINE",
+"294 694 OFFCURVE",
+"222 562 OFFCURVE",
+"80 398 CURVE",
+"137 348 LINE",
+"286 526 OFFCURVE",
+"362 655 OFFCURVE",
+"441 923 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"364 784 LINE",
+"488 642 OFFCURVE",
+"575 526 OFFCURVE",
+"645 383 CURVE",
+"712 420 LINE",
+"623 586 OFFCURVE",
+"541 694 OFFCURVE",
+"413 838 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 837;
+}
+);
+leftMetricsKey = u1B185;
+rightMetricsKey = u1B185;
+unicode = 1B1E2;
+},
+{
+glyphname = u1B1E3;
+lastChange = "2020-04-13 08:37:03 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"156 206 OFFCURVE",
+"179 223 OFFCURVE",
+"179 262 CURVE SMOOTH",
+"179 301 OFFCURVE",
+"156 318 OFFCURVE",
+"128 318 CURVE SMOOTH",
+"99 318 OFFCURVE",
+"76 301 OFFCURVE",
+"76 262 CURVE SMOOTH",
+"76 223 OFFCURVE",
+"99 206 OFFCURVE",
+"128 206 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"150 -4 OFFCURVE",
+"173 13 OFFCURVE",
+"173 52 CURVE SMOOTH",
+"173 91 OFFCURVE",
+"150 108 OFFCURVE",
+"122 108 CURVE SMOOTH",
+"93 108 OFFCURVE",
+"70 91 OFFCURVE",
+"70 52 CURVE SMOOTH",
+"70 13 OFFCURVE",
+"93 -4 OFFCURVE",
+"122 -4 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"537 939 LINE",
+"446 789 OFFCURVE",
+"347 669 OFFCURVE",
+"220 550 CURVE",
+"290 392 OFFCURVE",
+"311 299 OFFCURVE",
+"311 167 CURVE SMOOTH",
+"311 37 OFFCURVE",
+"284 -60 OFFCURVE",
+"235 -177 CURVE",
+"304 -203 LINE",
+"357 -84 OFFCURVE",
+"385 32 OFFCURVE",
+"385 167 CURVE SMOOTH",
+"385 299 OFFCURVE",
+"359 414 OFFCURVE",
+"293 568 CURVE",
+"279 511 LINE",
+"399 623 OFFCURVE",
+"508 743 OFFCURVE",
+"604 902 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"677 653 LINE",
+"632 597 OFFCURVE",
+"589 549 OFFCURVE",
+"545 505 CURVE",
+"526 492 LINE",
+"462 432 OFFCURVE",
+"395 380 OFFCURVE",
+"316 327 CURVE",
+"338 257 LINE",
+"415 304 OFFCURVE",
+"482 353 OFFCURVE",
+"545 408 CURVE",
+"563 419 LINE",
+"623 474 OFFCURVE",
+"680 535 OFFCURVE",
+"736 606 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"421 716 LINE",
+"516 476 OFFCURVE",
+"555 297 OFFCURVE",
+"577 87 CURVE",
+"651 93 LINE",
+"624 327 OFFCURVE",
+"580 514 OFFCURVE",
+"474 778 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 826;
+}
+);
+leftMetricsKey = u1B1B8;
+rightMetricsKey = u1B1A5;
+unicode = 1B1E3;
+},
+{
+glyphname = u1B1E4;
+lastChange = "2020-04-13 08:36:50 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"493 939 LINE",
+"353 778 OFFCURVE",
+"226 662 OFFCURVE",
+"60 541 CURVE",
+"104 479 LINE",
+"273 603 OFFCURVE",
+"397 713 OFFCURVE",
+"553 892 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"594 727 LINE",
+"529 658 OFFCURVE",
+"466 597 OFFCURVE",
+"398 540 CURVE",
+"368 519 LINE",
+"297 461 OFFCURVE",
+"221 407 OFFCURVE",
+"134 352 CURVE",
+"174 290 LINE",
+"259 344 OFFCURVE",
+"332 395 OFFCURVE",
+"402 450 CURVE",
+"424 464 LINE",
+"500 527 OFFCURVE",
+"571 594 OFFCURVE",
+"647 677 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"682 512 LINE",
+"614 443 OFFCURVE",
+"542 382 OFFCURVE",
+"463 324 CURVE",
+"438 310 LINE",
+"363 257 OFFCURVE",
+"281 207 OFFCURVE",
+"191 158 CURVE",
+"228 95 LINE",
+"308 138 OFFCURVE",
+"386 185 OFFCURVE",
+"461 236 CURVE",
+"485 248 LINE",
+"572 310 OFFCURVE",
+"655 380 OFFCURVE",
+"735 461 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"339 -105 OFFCURVE",
+"362 -88 OFFCURVE",
+"362 -49 CURVE SMOOTH",
+"362 -10 OFFCURVE",
+"339 7 OFFCURVE",
+"311 7 CURVE SMOOTH",
+"282 7 OFFCURVE",
+"259 -10 OFFCURVE",
+"259 -49 CURVE SMOOTH",
+"259 -88 OFFCURVE",
+"282 -105 OFFCURVE",
+"311 -105 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"741 101 OFFCURVE",
+"764 118 OFFCURVE",
+"764 157 CURVE SMOOTH",
+"764 196 OFFCURVE",
+"741 213 OFFCURVE",
+"713 213 CURVE SMOOTH",
+"684 213 OFFCURVE",
+"661 196 OFFCURVE",
+"661 157 CURVE SMOOTH",
+"661 118 OFFCURVE",
+"684 101 OFFCURVE",
+"713 101 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"578 -195 LINE",
+"552 195 OFFCURVE",
+"450 494 OFFCURVE",
+"331 744 CURVE",
+"284 676 LINE",
+"384 443 OFFCURVE",
+"481 170 OFFCURVE",
+"502 -203 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 884;
+}
+);
+leftMetricsKey = u1B187;
+rightMetricsKey = u1B1A8;
+unicode = 1B1E4;
+},
+{
+glyphname = u1B1E5;
+lastChange = "2020-04-13 08:41:03 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"614 665 LINE",
+"567 604 OFFCURVE",
+"519 548 OFFCURVE",
+"468 495 CURVE",
+"434 464 LINE",
+"377 406 OFFCURVE",
+"318 351 OFFCURVE",
+"257 299 CURVE",
+"303 243 LINE",
+"361 291 OFFCURVE",
+"412 338 OFFCURVE",
+"460 387 CURVE",
+"486 408 LINE",
+"548 472 OFFCURVE",
+"606 539 OFFCURVE",
+"671 619 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"537 939 LINE",
+"424 771 OFFCURVE",
+"309 645 OFFCURVE",
+"155 502 CURVE",
+"207 445 LINE",
+"353 584 OFFCURVE",
+"483 722 OFFCURVE",
+"602 898 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"658 377 LINE",
+"551 250 OFFCURVE",
+"452 153 OFFCURVE",
+"330 60 CURVE",
+"375 0 LINE",
+"514 110 OFFCURVE",
+"607 205 OFFCURVE",
+"716 332 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"370 634 LINE",
+"421 472 OFFCURVE",
+"452 318 OFFCURVE",
+"470 157 CURVE",
+"539 187 LINE",
+"520 357 OFFCURVE",
+"484 515 OFFCURVE",
+"429 709 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"119 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -102 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 796;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B197;
+unicode = 1B1E5;
+},
+{
+glyphname = u1B1E6;
+lastChange = "2020-04-13 08:41:20 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"671 396 LINE",
+"628 288 OFFCURVE",
+"580 192 OFFCURVE",
+"530 106 CURVE SMOOTH",
+"475 11 OFFCURVE",
+"433 -51 OFFCURVE",
+"382 -119 CURVE",
+"378 -119 LINE",
+"347 -30 OFFCURVE",
+"313 33 OFFCURVE",
+"279 93 CURVE SMOOTH",
+"266 116 OFFCURVE",
+"251 141 OFFCURVE",
+"235 167 CURVE",
+"172 127 LINE",
+"242 15 OFFCURVE",
+"281 -60 OFFCURVE",
+"325 -162 CURVE",
+"423 -173 LINE",
+"541 -36 OFFCURVE",
+"645 137 OFFCURVE",
+"741 370 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"466 939 LINE",
+"368 662 OFFCURVE",
+"281 505 OFFCURVE",
+"105 262 CURVE",
+"167 218 LINE",
+"347 470 OFFCURVE",
+"433 617 OFFCURVE",
+"538 915 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"74 665 LINE",
+"153 628 OFFCURVE",
+"231 586 OFFCURVE",
+"308 540 CURVE",
+"343 523 LINE",
+"424 472 OFFCURVE",
+"504 417 OFFCURVE",
+"582 357 CURVE",
+"625 420 LINE",
+"540 482 OFFCURVE",
+"460 539 OFFCURVE",
+"377 591 CURVE",
+"346 605 LINE",
+"272 650 OFFCURVE",
+"194 692 OFFCURVE",
+"107 733 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"150 -135 OFFCURVE",
+"173 -118 OFFCURVE",
+"173 -79 CURVE SMOOTH",
+"173 -40 OFFCURVE",
+"150 -23 OFFCURVE",
+"122 -23 CURVE SMOOTH",
+"93 -23 OFFCURVE",
+"70 -40 OFFCURVE",
+"70 -79 CURVE SMOOTH",
+"70 -118 OFFCURVE",
+"93 -135 OFFCURVE",
+"122 -135 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"429 156 OFFCURVE",
+"452 173 OFFCURVE",
+"452 212 CURVE SMOOTH",
+"452 251 OFFCURVE",
+"429 268 OFFCURVE",
+"401 268 CURVE SMOOTH",
+"372 268 OFFCURVE",
+"349 251 OFFCURVE",
+"349 212 CURVE SMOOTH",
+"349 173 OFFCURVE",
+"372 156 OFFCURVE",
+"401 156 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 821;
+}
+);
+leftMetricsKey = u1B17A;
+rightMetricsKey = u1B188;
+unicode = 1B1E6;
+},
+{
+glyphname = u1B1E7;
+lastChange = "2020-04-13 08:48:33 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"624 665 LINE",
+"577 604 OFFCURVE",
+"529 548 OFFCURVE",
+"478 495 CURVE",
+"444 464 LINE",
+"387 406 OFFCURVE",
+"328 351 OFFCURVE",
+"267 299 CURVE",
+"313 243 LINE",
+"371 291 OFFCURVE",
+"422 338 OFFCURVE",
+"470 387 CURVE",
+"496 408 LINE",
+"557 473 OFFCURVE",
+"615 540 OFFCURVE",
+"681 619 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"547 939 LINE",
+"434 771 OFFCURVE",
+"319 645 OFFCURVE",
+"165 502 CURVE",
+"217 445 LINE",
+"363 584 OFFCURVE",
+"493 722 OFFCURVE",
+"612 898 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"668 377 LINE",
+"561 250 OFFCURVE",
+"462 153 OFFCURVE",
+"340 60 CURVE",
+"385 0 LINE",
+"524 110 OFFCURVE",
+"617 205 OFFCURVE",
+"726 332 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"380 634 LINE",
+"431 472 OFFCURVE",
+"462 318 OFFCURVE",
+"480 157 CURVE",
+"549 187 LINE",
+"530 357 OFFCURVE",
+"494 515 OFFCURVE",
+"439 709 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"276 157 LINE",
+"249 104 OFFCURVE",
+"224 59 OFFCURVE",
+"199 19 CURVE",
+"176 -10 LINE",
+"142 -59 OFFCURVE",
+"106 -104 OFFCURVE",
+"60 -154 CURVE",
+"112 -203 LINE",
+"157 -150 OFFCURVE",
+"192 -107 OFFCURVE",
+"222 -64 CURVE",
+"248 -31 LINE",
+"278 15 OFFCURVE",
+"305 63 OFFCURVE",
+"340 126 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"66 88 LINE",
+"158 -5 OFFCURVE",
+"219 -83 OFFCURVE",
+"282 -182 CURVE",
+"341 -143 LINE",
+"268 -34 OFFCURVE",
+"200 49 OFFCURVE",
+"116 138 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 806;
+}
+);
+leftMetricsKey = u1B1C9;
+rightMetricsKey = u1B197;
+unicode = 1B1E7;
+},
+{
+glyphname = u1B1E8;
+lastChange = "2020-04-13 08:42:07 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"681 321 OFFCURVE",
+"704 338 OFFCURVE",
+"704 377 CURVE SMOOTH",
+"704 416 OFFCURVE",
+"681 433 OFFCURVE",
+"653 433 CURVE SMOOTH",
+"624 433 OFFCURVE",
+"601 416 OFFCURVE",
+"601 377 CURVE SMOOTH",
+"601 338 OFFCURVE",
+"624 321 OFFCURVE",
+"653 321 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"566 17 LINE",
+"527 308 OFFCURVE",
+"470 501 OFFCURVE",
+"350 743 CURVE",
+"298 682 LINE",
+"403 459 OFFCURVE",
+"454 296 OFFCURVE",
+"493 8 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"440 939 LINE",
+"344 785 OFFCURVE",
+"239 658 OFFCURVE",
+"112 529 CURVE",
+"165 477 LINE",
+"297 612 OFFCURVE",
+"398 728 OFFCURVE",
+"503 898 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"603 722 LINE",
+"546 641 OFFCURVE",
+"491 569 OFFCURVE",
+"433 502 CURVE",
+"411 482 LINE",
+"357 422 OFFCURVE",
+"300 365 OFFCURVE",
+"238 308 CURVE",
+"288 251 LINE",
+"343 304 OFFCURVE",
+"392 354 OFFCURVE",
+"439 404 CURVE",
+"463 426 LINE",
+"529 499 OFFCURVE",
+"593 577 OFFCURVE",
+"665 678 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"155 230 LINE",
+"218 170 OFFCURVE",
+"242 113 OFFCURVE",
+"242 34 CURVE SMOOTH",
+"242 -46 OFFCURVE",
+"221 -101 OFFCURVE",
+"167 -160 CURVE",
+"222 -203 LINE",
+"285 -130 OFFCURVE",
+"316 -62 OFFCURVE",
+"316 32 CURVE SMOOTH",
+"316 131 OFFCURVE",
+"282 203 OFFCURVE",
+"206 278 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"130 -18 OFFCURVE",
+"153 -1 OFFCURVE",
+"153 38 CURVE SMOOTH",
+"153 77 OFFCURVE",
+"130 94 OFFCURVE",
+"102 94 CURVE SMOOTH",
+"73 94 OFFCURVE",
+"50 77 OFFCURVE",
+"50 38 CURVE SMOOTH",
+"50 -1 OFFCURVE",
+"73 -18 OFFCURVE",
+"102 -18 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 784;
+}
+);
+leftMetricsKey = u1B1D7;
+rightMetricsKey = u1B177;
+unicode = 1B1E8;
+},
+{
+glyphname = u1B1E9;
+lastChange = "2020-04-13 08:42:10 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"251 913 LINE",
+"209 706 OFFCURVE",
+"149 525 OFFCURVE",
+"70 350 CURVE",
+"136 319 LINE",
+"218 503 OFFCURVE",
+"274 665 OFFCURVE",
+"324 899 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"241 141 OFFCURVE",
+"264 158 OFFCURVE",
+"264 197 CURVE SMOOTH",
+"264 236 OFFCURVE",
+"241 253 OFFCURVE",
+"213 253 CURVE SMOOTH",
+"184 253 OFFCURVE",
+"161 236 OFFCURVE",
+"161 197 CURVE SMOOTH",
+"161 158 OFFCURVE",
+"184 141 OFFCURVE",
+"213 141 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"489 735 OFFCURVE",
+"512 752 OFFCURVE",
+"512 791 CURVE SMOOTH",
+"512 830 OFFCURVE",
+"489 847 OFFCURVE",
+"461 847 CURVE SMOOTH",
+"432 847 OFFCURVE",
+"409 830 OFFCURVE",
+"409 791 CURVE SMOOTH",
+"409 752 OFFCURVE",
+"432 735 OFFCURVE",
+"461 735 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"328 536 OFFCURVE",
+"374 397 OFFCURVE",
+"374 239 CURVE SMOOTH",
+"374 65 OFFCURVE",
+"350 -50 OFFCURVE",
+"297 -179 CURVE",
+"365 -203 LINE",
+"419 -73 OFFCURVE",
+"448 51 OFFCURVE",
+"448 239 CURVE SMOOTH",
+"448 271 OFFCURVE",
+"446 302 OFFCURVE",
+"442 332 CURVE",
+"424 384 LINE",
+"416 445 OFFCURVE",
+"403 490 OFFCURVE",
+"376 544 CURVE SMOOTH",
+"347 604 OFFCURVE",
+"307 660 OFFCURVE",
+"259 714 CURVE",
+"215 656 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"632 785 OFFCURVE",
+"592 659 OFFCURVE",
+"533 555 CURVE SMOOTH",
+"488 474 OFFCURVE",
+"459 429 OFFCURVE",
+"428 384 CURVE",
+"396 384 LINE",
+"400 271 LINE",
+"582 441 OFFCURVE",
+"661 602 OFFCURVE",
+"740 921 CURVE",
+"666 939 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"578 530 LINE",
+"639 397 OFFCURVE",
+"676 284 OFFCURVE",
+"696 138 CURVE",
+"772 149 LINE",
+"742 318 OFFCURVE",
+"698 449 OFFCURVE",
+"611 593 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 872;
+}
+);
+rightMetricsKey = u1B186;
+unicode = 1B1E9;
+},
+{
+glyphname = u1B1EA;
+lastChange = "2020-04-13 08:42:50 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"278 407 LINE",
+"266 533 OFFCURVE",
+"222 648 OFFCURVE",
+"140 762 CURVE",
+"80 720 LINE",
+"177 585 OFFCURVE",
+"210 474 OFFCURVE",
+"210 355 CURVE SMOOTH",
+"210 171 OFFCURVE",
+"176 62 OFFCURVE",
+"96 -61 CURVE",
+"158 -100 LINE",
+"242 29 OFFCURVE",
+"278 153 OFFCURVE",
+"278 346 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"627 640 LINE",
+"545 464 OFFCURVE",
+"459 315 OFFCURVE",
+"374 180 CURVE",
+"416 109 LINE",
+"512 259 OFFCURVE",
+"587 389 OFFCURVE",
+"656 534 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"479 848 LINE",
+"406 678 OFFCURVE",
+"330 536 OFFCURVE",
+"240 387 CURVE",
+"331 208 OFFCURVE",
+"394 72 OFFCURVE",
+"454 -101 CURVE",
+"547 -105 LINE",
+"648 39 OFFCURVE",
+"725 172 OFFCURVE",
+"812 339 CURVE",
+"743 507 OFFCURVE",
+"673 662 OFFCURVE",
+"578 846 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 785 LINE",
+"575 690 OFFCURVE",
+"602 632 OFFCURVE",
+"641 549 CURVE SMOOTH",
+"673 480 OFFCURVE",
+"713 385 OFFCURVE",
+"754 276 CURVE",
+"765 409 LINE",
+"721 322 OFFCURVE",
+"679 246 OFFCURVE",
+"639 176 CURVE SMOOTH",
+"598 104 OFFCURVE",
+"553 40 OFFCURVE",
+"507 -36 CURVE",
+"503 -36 LINE",
+"481 38 OFFCURVE",
+"455 106 OFFCURVE",
+"422 180 CURVE SMOOTH",
+"388 256 OFFCURVE",
+"349 337 OFFCURVE",
+"302 430 CURVE",
+"293 335 LINE",
+"342 413 OFFCURVE",
+"383 484 OFFCURVE",
+"421 556 CURVE SMOOTH",
+"461 632 OFFCURVE",
+"490 690 OFFCURVE",
+"526 785 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 902;
+}
+);
+rightMetricsKey = u1B1B4;
+unicode = 1B1EA;
+},
+{
+glyphname = u1B1EB;
+lastChange = "2020-04-13 08:43:05 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"436 939 LINE",
+"382 831 OFFCURVE",
+"328 735 OFFCURVE",
+"269 641 CURVE",
+"246 612 LINE",
+"196 534 OFFCURVE",
+"141 456 OFFCURVE",
+"80 372 CURVE",
+"140 326 LINE",
+"194 400 OFFCURVE",
+"241 467 OFFCURVE",
+"282 532 CURVE",
+"304 558 LINE",
+"376 671 OFFCURVE",
+"437 779 OFFCURVE",
+"504 907 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"728 500 LINE",
+"629 343 OFFCURVE",
+"568 261 OFFCURVE",
+"466 134 CURVE",
+"513 74 LINE",
+"612 197 OFFCURVE",
+"673 277 OFFCURVE",
+"761 411 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"399 301 LINE",
+"445 362 OFFCURVE",
+"482 414 OFFCURVE",
+"517 465 CURVE SMOOTH",
+"564 533 OFFCURVE",
+"598 583 OFFCURVE",
+"638 665 CURVE",
+"642 665 LINE",
+"674 576 OFFCURVE",
+"705 500 OFFCURVE",
+"738 418 CURVE SMOOTH",
+"773 332 OFFCURVE",
+"808 240 OFFCURVE",
+"833 167 CURVE",
+"843 256 LINE",
+"803 193 OFFCURVE",
+"767 140 OFFCURVE",
+"732 93 CURVE SMOOTH",
+"680 23 OFFCURVE",
+"636 -32 OFFCURVE",
+"588 -98 CURVE",
+"584 -98 LINE",
+"561 -16 OFFCURVE",
+"533 55 OFFCURVE",
+"501 137 CURVE SMOOTH",
+"412 364 OFFCURVE",
+"304 610 OFFCURVE",
+"158 897 CURVE",
+"93 863 LINE",
+"283 489 OFFCURVE",
+"411 176 OFFCURVE",
+"531 -153 CURVE",
+"619 -163 LINE",
+"731 -35 OFFCURVE",
+"795 44 OFFCURVE",
+"902 201 CURVE",
+"836 387 OFFCURVE",
+"774 540 OFFCURVE",
+"691 726 CURVE",
+"602 734 LINE",
+"512 587 OFFCURVE",
+"451 491 OFFCURVE",
+"364 380 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 992;
+}
+);
+leftMetricsKey = u1B180;
+rightMetricsKey = u1B1B4;
+unicode = 1B1EB;
+},
+{
+glyphname = u1B1EC;
+lastChange = "2020-04-13 08:43:14 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"708 102 OFFCURVE",
+"731 119 OFFCURVE",
+"731 158 CURVE SMOOTH",
+"731 197 OFFCURVE",
+"708 214 OFFCURVE",
+"680 214 CURVE SMOOTH",
+"651 214 OFFCURVE",
+"628 197 OFFCURVE",
+"628 158 CURVE SMOOTH",
+"628 119 OFFCURVE",
+"651 102 OFFCURVE",
+"680 102 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"663 319 OFFCURVE",
+"689 331 OFFCURVE",
+"689 375 CURVE SMOOTH",
+"689 414 OFFCURVE",
+"666 431 OFFCURVE",
+"638 431 CURVE SMOOTH",
+"609 431 OFFCURVE",
+"586 414 OFFCURVE",
+"586 375 CURVE SMOOTH",
+"586 336 OFFCURVE",
+"609 319 OFFCURVE",
+"638 319 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"577 653 LINE",
+"533 598 OFFCURVE",
+"491 551 OFFCURVE",
+"448 508 CURVE",
+"425 491 LINE",
+"359 430 OFFCURVE",
+"289 377 OFFCURVE",
+"201 319 CURVE",
+"238 257 LINE",
+"316 305 OFFCURVE",
+"385 355 OFFCURVE",
+"448 411 CURVE",
+"470 425 LINE",
+"527 478 OFFCURVE",
+"582 537 OFFCURVE",
+"636 606 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"321 716 LINE",
+"416 476 OFFCURVE",
+"455 297 OFFCURVE",
+"477 87 CURVE",
+"551 93 LINE",
+"524 327 OFFCURVE",
+"480 514 OFFCURVE",
+"374 778 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"447 939 LINE",
+"356 789 OFFCURVE",
+"247 669 OFFCURVE",
+"120 550 CURVE",
+"162 417 OFFCURVE",
+"175 311 OFFCURVE",
+"175 187 CURVE SMOOTH",
+"175 51 OFFCURVE",
+"158 -64 OFFCURVE",
+"120 -182 CURVE",
+"191 -203 LINE",
+"235 -77 OFFCURVE",
+"251 46 OFFCURVE",
+"251 187 CURVE SMOOTH",
+"251 315 OFFCURVE",
+"234 431 OFFCURVE",
+"196 568 CURVE",
+"190 512 LINE",
+"310 626 OFFCURVE",
+"420 745 OFFCURVE",
+"515 903 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 851;
+}
+);
+leftMetricsKey = u1B1A5;
+rightMetricsKey = u1B1B5;
+unicode = 1B1EC;
+},
+{
+glyphname = u1B1ED;
+lastChange = "2020-04-13 08:44:00 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"382 434 LINE",
+"339 386 OFFCURVE",
+"295 342 OFFCURVE",
+"250 301 CURVE",
+"225 284 LINE",
+"176 240 OFFCURVE",
+"125 199 OFFCURVE",
+"70 159 CURVE",
+"115 105 LINE",
+"166 142 OFFCURVE",
+"213 180 OFFCURVE",
+"258 219 CURVE",
+"284 236 LINE",
+"337 284 OFFCURVE",
+"387 335 OFFCURVE",
+"437 389 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"474 219 LINE",
+"425 167 OFFCURVE",
+"382 125 OFFCURVE",
+"336 86 CURVE",
+"307 68 LINE",
+"260 29 OFFCURVE",
+"210 -6 OFFCURVE",
+"152 -44 CURVE",
+"191 -102 LINE",
+"242 -69 OFFCURVE",
+"289 -36 OFFCURVE",
+"337 2 CURVE",
+"359 14 LINE",
+"413 59 OFFCURVE",
+"467 109 OFFCURVE",
+"525 171 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"435 -185 LINE",
+"376 78 OFFCURVE",
+"305 265 OFFCURVE",
+"192 483 CURVE",
+"127 446 LINE",
+"246 223 OFFCURVE",
+"308 46 OFFCURVE",
+"363 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"737 101 LINE",
+"685 439 OFFCURVE",
+"626 616 OFFCURVE",
+"470 891 CURVE",
+"405 853 LINE",
+"560 580 OFFCURVE",
+"618 409 OFFCURVE",
+"662 92 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"682 939 LINE",
+"633 860 OFFCURVE",
+"586 793 OFFCURVE",
+"534 728 CURVE",
+"507 702 LINE",
+"458 643 OFFCURVE",
+"403 584 OFFCURVE",
+"337 517 CURVE",
+"390 465 LINE",
+"452 528 OFFCURVE",
+"503 582 OFFCURVE",
+"549 637 CURVE",
+"574 660 LINE",
+"633 733 OFFCURVE",
+"687 808 OFFCURVE",
+"748 905 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"798 713 LINE",
+"745 634 OFFCURVE",
+"693 567 OFFCURVE",
+"634 502 CURVE",
+"603 474 LINE",
+"553 420 OFFCURVE",
+"497 367 OFFCURVE",
+"430 309 CURVE",
+"478 252 LINE",
+"533 301 OFFCURVE",
+"583 348 OFFCURVE",
+"629 395 CURVE",
+"657 419 LINE",
+"730 496 OFFCURVE",
+"795 575 OFFCURVE",
+"859 671 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 949;
+}
+);
+rightMetricsKey = u1B187;
+unicode = 1B1ED;
+},
+{
+glyphname = u1B1EE;
+lastChange = "2020-04-13 08:43:58 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"577 837 LINE",
+"707 691 OFFCURVE",
+"752 614 OFFCURVE",
+"752 521 CURVE SMOOTH",
+"752 458 OFFCURVE",
+"738 415 OFFCURVE",
+"709 367 CURVE",
+"705 367 LINE",
+"672 410 OFFCURVE",
+"662 444 OFFCURVE",
+"662 493 CURVE SMOOTH",
+"662 537 OFFCURVE",
+"675 585 OFFCURVE",
+"738 652 CURVE",
+"706 691 LINE",
+"613 604 OFFCURVE",
+"590 545 OFFCURVE",
+"590 483 CURVE SMOOTH",
+"590 422 OFFCURVE",
+"609 373 OFFCURVE",
+"677 318 CURVE",
+"746 319 LINE",
+"797 386 OFFCURVE",
+"824 439 OFFCURVE",
+"824 521 CURVE SMOOTH",
+"824 609 OFFCURVE",
+"780 721 OFFCURVE",
+"615 889 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"434 244 OFFCURVE",
+"456 162 OFFCURVE",
+"456 42 CURVE SMOOTH",
+"456 -37 OFFCURVE",
+"446 -106 OFFCURVE",
+"428 -188 CURVE",
+"498 -203 LINE",
+"523 -119 OFFCURVE",
+"532 -45 OFFCURVE",
+"532 42 CURVE SMOOTH",
+"532 171 OFFCURVE",
+"491 296 OFFCURVE",
+"374 435 CURVE SMOOTH",
+"258 573 OFFCURVE",
+"237 620 OFFCURVE",
+"237 723 CURVE SMOOTH",
+"237 771 OFFCURVE",
+"248 820 OFFCURVE",
+"270 878 CURVE",
+"203 899 LINE",
+"174 829 OFFCURVE",
+"163 774 OFFCURVE",
+"163 714 CURVE SMOOTH",
+"163 625 OFFCURVE",
+"185 545 OFFCURVE",
+"319 383 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"146 -42 LINE",
+"158 129 OFFCURVE",
+"188 215 OFFCURVE",
+"349 391 CURVE",
+"373 403 LINE",
+"511 543 OFFCURVE",
+"582 665 OFFCURVE",
+"612 810 CURVE",
+"628 849 LINE",
+"633 873 OFFCURVE",
+"639 902 OFFCURVE",
+"643 930 CURVE",
+"577 939 LINE",
+"540 721 OFFCURVE",
+"478 600 OFFCURVE",
+"328 457 CURVE",
+"303 443 LINE",
+"139 258 OFFCURVE",
+"88 171 OFFCURVE",
+"70 -37 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 894;
+}
+);
+leftMetricsKey = u1B1D9;
+rightMetricsKey = u1B1D9;
+unicode = 1B1EE;
+},
+{
+glyphname = u1B1EF;
+lastChange = "2020-04-13 08:44:07 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"432 306 LINE",
+"514 141 OFFCURVE",
+"555 -9 OFFCURVE",
+"588 -203 CURVE",
+"662 -189 LINE",
+"621 41 OFFCURVE",
+"573 197 OFFCURVE",
+"481 361 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"544 544 LINE",
+"456 390 OFFCURVE",
+"369 288 OFFCURVE",
+"260 179 CURVE",
+"314 126 LINE",
+"429 245 OFFCURVE",
+"515 349 OFFCURVE",
+"611 508 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"506 149 LINE",
+"418 29 OFFCURVE",
+"363 -35 OFFCURVE",
+"287 -111 CURVE",
+"340 -162 LINE",
+"410 -93 OFFCURVE",
+"463 -26 OFFCURVE",
+"551 94 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"283 296 OFFCURVE",
+"306 313 OFFCURVE",
+"306 352 CURVE SMOOTH",
+"306 391 OFFCURVE",
+"283 408 OFFCURVE",
+"255 408 CURVE SMOOTH",
+"226 408 OFFCURVE",
+"203 391 OFFCURVE",
+"203 352 CURVE SMOOTH",
+"203 313 OFFCURVE",
+"226 296 OFFCURVE",
+"255 296 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"444 491 OFFCURVE",
+"467 508 OFFCURVE",
+"467 547 CURVE SMOOTH",
+"467 586 OFFCURVE",
+"444 603 OFFCURVE",
+"416 603 CURVE SMOOTH",
+"387 603 OFFCURVE",
+"364 586 OFFCURVE",
+"364 547 CURVE SMOOTH",
+"364 508 OFFCURVE",
+"387 491 OFFCURVE",
+"416 491 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"390 939 LINE",
+"266 700 OFFCURVE",
+"169 561 OFFCURVE",
+"60 434 CURVE",
+"118 386 LINE",
+"245 539 OFFCURVE",
+"333 665 OFFCURVE",
+"459 908 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 772;
+}
+);
+unicode = 1B1EF;
+},
+{
+glyphname = u1B1F0;
+lastChange = "2020-04-13 08:44:19 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"515 275 LINE",
+"449 490 OFFCURVE",
+"364 657 OFFCURVE",
+"228 886 CURVE",
+"164 847 LINE",
+"292 625 OFFCURVE",
+"383 462 OFFCURVE",
+"445 246 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"509 939 LINE",
+"445 840 OFFCURVE",
+"383 758 OFFCURVE",
+"318 682 CURVE",
+"293 658 LINE",
+"229 585 OFFCURVE",
+"160 515 OFFCURVE",
+"80 437 CURVE",
+"131 383 LINE",
+"207 458 OFFCURVE",
+"273 524 OFFCURVE",
+"335 593 CURVE",
+"359 615 LINE",
+"433 699 OFFCURVE",
+"502 788 OFFCURVE",
+"573 900 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"332 -40 OFFCURVE",
+"387 -104 OFFCURVE",
+"508 -163 CURVE",
+"589 -152 LINE",
+"665 -48 OFFCURVE",
+"699 41 OFFCURVE",
+"699 119 CURVE SMOOTH",
+"699 203 OFFCURVE",
+"633 273 OFFCURVE",
+"489 326 CURVE",
+"440 305 LINE",
+"358 201 OFFCURVE",
+"332 129 OFFCURVE",
+"332 52 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"487 254 LINE",
+"586 210 OFFCURVE",
+"623 164 OFFCURVE",
+"623 112 CURVE SMOOTH",
+"623 61 OFFCURVE",
+"601 -22 OFFCURVE",
+"539 -102 CURVE",
+"534 -103 LINE",
+"445 -53 OFFCURVE",
+"408 1 OFFCURVE",
+"408 55 CURVE SMOOTH",
+"408 105 OFFCURVE",
+"429 173 OFFCURVE",
+"482 253 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"280 223 OFFCURVE",
+"303 240 OFFCURVE",
+"303 279 CURVE SMOOTH",
+"303 318 OFFCURVE",
+"280 335 OFFCURVE",
+"252 335 CURVE SMOOTH",
+"223 335 OFFCURVE",
+"200 318 OFFCURVE",
+"200 279 CURVE SMOOTH",
+"200 240 OFFCURVE",
+"223 223 OFFCURVE",
+"252 223 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"603 522 OFFCURVE",
+"626 539 OFFCURVE",
+"626 578 CURVE SMOOTH",
+"626 617 OFFCURVE",
+"603 634 OFFCURVE",
+"575 634 CURVE SMOOTH",
+"546 634 OFFCURVE",
+"523 617 OFFCURVE",
+"523 578 CURVE SMOOTH",
+"523 539 OFFCURVE",
+"546 522 OFFCURVE",
+"575 522 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1312;
+width = 779;
+}
+);
+leftMetricsKey = u1B180;
+unicode = 1B1F0;
+},
+{
+glyphname = u1B1F1;
+lastChange = "2020-04-13 08:44:23 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"60 334 OFFCURVE",
+"87 286 OFFCURVE",
+"172 237 CURVE",
+"240 249 LINE",
+"302 341 OFFCURVE",
+"330 414 OFFCURVE",
+"330 478 CURVE SMOOTH",
+"330 544 OFFCURVE",
+"297 590 OFFCURVE",
+"217 640 CURVE",
+"154 634 LINE",
+"81 516 OFFCURVE",
+"60 457 OFFCURVE",
+"60 396 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"196 580 LINE",
+"238 540 OFFCURVE",
+"258 504 OFFCURVE",
+"258 468 CURVE SMOOTH",
+"258 426 OFFCURVE",
+"241 368 OFFCURVE",
+"200 295 CURVE",
+"196 295 LINE",
+"154 329 OFFCURVE",
+"133 362 OFFCURVE",
+"133 406 CURVE SMOOTH",
+"133 449 OFFCURVE",
+"151 503 OFFCURVE",
+"192 580 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"625 478 OFFCURVE",
+"650 423 OFFCURVE",
+"736 381 CURVE",
+"804 393 LINE",
+"870 485 OFFCURVE",
+"894 558 OFFCURVE",
+"894 622 CURVE SMOOTH",
+"894 688 OFFCURVE",
+"859 734 OFFCURVE",
+"781 784 CURVE",
+"718 778 LINE",
+"645 673 OFFCURVE",
+"625 601 OFFCURVE",
+"625 540 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"808 -72 LINE",
+"717 154 OFFCURVE",
+"619 320 OFFCURVE",
+"482 514 CURVE",
+"474 399 LINE",
+"576 248 OFFCURVE",
+"664 82 OFFCURVE",
+"737 -100 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"456 939 LINE",
+"464 443 OFFCURVE",
+"386 117 OFFCURVE",
+"200 -167 CURVE",
+"265 -203 LINE",
+"447 94 OFFCURVE",
+"530 443 OFFCURVE",
+"532 938 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"761 724 LINE",
+"803 684 OFFCURVE",
+"823 648 OFFCURVE",
+"823 612 CURVE SMOOTH",
+"823 570 OFFCURVE",
+"806 512 OFFCURVE",
+"765 439 CURVE",
+"761 439 LINE",
+"719 473 OFFCURVE",
+"698 506 OFFCURVE",
+"698 550 CURVE SMOOTH",
+"698 593 OFFCURVE",
+"716 647 OFFCURVE",
+"757 724 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 954;
+}
+);
+unicode = 1B1F1;
+},
+{
+glyphname = u1B1F2;
+lastChange = "2020-04-13 08:44:26 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"90 233 LINE",
+"164 94 OFFCURVE",
+"213 -37 OFFCURVE",
+"250 -203 CURVE",
+"322 -185 LINE",
+"282 -9 OFFCURVE",
+"231 131 OFFCURVE",
+"154 272 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"590 697 LINE",
+"503 538 OFFCURVE",
+"425 419 OFFCURVE",
+"332 295 CURVE",
+"385 246 LINE",
+"489 385 OFFCURVE",
+"558 488 OFFCURVE",
+"630 616 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"449 920 LINE",
+"381 777 OFFCURVE",
+"291 633 OFFCURVE",
+"200 507 CURVE",
+"291 328 OFFCURVE",
+"355 179 OFFCURVE",
+"415 16 CURVE",
+"507 9 LINE",
+"605 130 OFFCURVE",
+"694 262 OFFCURVE",
+"783 414 CURVE",
+"714 582 OFFCURVE",
+"645 732 OFFCURVE",
+"550 917 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"499 858 LINE",
+"537 781 OFFCURVE",
+"568 721 OFFCURVE",
+"603 645 CURVE SMOOTH",
+"644 556 OFFCURVE",
+"682 465 OFFCURVE",
+"722 361 CURVE",
+"733 482 LINE",
+"689 404 OFFCURVE",
+"646 333 OFFCURVE",
+"603 268 CURVE SMOOTH",
+"559 201 OFFCURVE",
+"512 135 OFFCURVE",
+"471 73 CURVE",
+"467 73 LINE",
+"443 152 OFFCURVE",
+"415 229 OFFCURVE",
+"379 309 CURVE SMOOTH",
+"346 383 OFFCURVE",
+"309 462 OFFCURVE",
+"264 550 CURVE",
+"258 458 LINE",
+"307 530 OFFCURVE",
+"331 564 OFFCURVE",
+"368 624 CURVE SMOOTH",
+"413 697 OFFCURVE",
+"453 766 OFFCURVE",
+"495 858 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 873;
+}
+);
+rightMetricsKey = u1B1B4;
+unicode = 1B1F2;
+},
+{
+glyphname = u1B1F3;
+lastChange = "2020-04-13 08:44:39 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"519 939 LINE",
+"467 847 OFFCURVE",
+"420 771 OFFCURVE",
+"373 704 CURVE SMOOTH",
+"326 638 OFFCURVE",
+"285 584 OFFCURVE",
+"245 527 CURVE",
+"240 527 LINE",
+"228 603 OFFCURVE",
+"207 662 OFFCURVE",
+"194 693 CURVE SMOOTH",
+"184 717 OFFCURVE",
+"174 741 OFFCURVE",
+"163 767 CURVE",
+"100 738 LINE",
+"138 647 OFFCURVE",
+"166 576 OFFCURVE",
+"194 480 CURVE",
+"271 468 LINE",
+"400 610 OFFCURVE",
+"481 719 OFFCURVE",
+"586 904 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"308 263 LINE",
+"419 116 OFFCURVE",
+"510 -18 OFFCURVE",
+"593 -154 CURVE",
+"654 -118 LINE",
+"613 -49 OFFCURVE",
+"584 -1 OFFCURVE",
+"511 107 CURVE",
+"494 107 LINE",
+"455 181 OFFCURVE",
+"404 258 OFFCURVE",
+"356 323 CURVE",
+"351 271 LINE",
+"418 342 OFFCURVE",
+"482 418 OFFCURVE",
+"527 491 CURVE",
+"557 520 LINE",
+"572 542 OFFCURVE",
+"588 565 OFFCURVE",
+"605 590 CURVE",
+"544 629 LINE",
+"464 505 OFFCURVE",
+"391 417 OFFCURVE",
+"308 334 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"554 439 OFFCURVE",
+"561 386 OFFCURVE",
+"561 334 CURVE SMOOTH",
+"561 277 OFFCURVE",
+"540 196 OFFCURVE",
+"498 107 CURVE",
+"482 107 LINE",
+"412 5 OFFCURVE",
+"353 -57 OFFCURVE",
+"263 -152 CURVE",
+"314 -203 LINE",
+"395 -118 OFFCURVE",
+"458 -39 OFFCURVE",
+"506 26 CURVE",
+"527 49 LINE",
+"604 160 OFFCURVE",
+"635 247 OFFCURVE",
+"635 334 CURVE SMOOTH",
+"635 411 OFFCURVE",
+"622 470 OFFCURVE",
+"556 567 CURVE",
+"499 491 LINE",
+"531 491 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"104 347 LINE",
+"139 232 OFFCURVE",
+"162 127 OFFCURVE",
+"179 13 CURVE",
+"252 26 LINE",
+"231 160 OFFCURVE",
+"209 252 OFFCURVE",
+"175 370 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 764;
+}
+);
+rightMetricsKey = u1B17C;
+unicode = 1B1F3;
+},
+{
+glyphname = u1B1F4;
+lastChange = "2020-04-13 08:45:36 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"228 471 LINE",
+"381 337 OFFCURVE",
+"509 211 OFFCURVE",
+"651 57 CURVE",
+"705 111 LINE",
+"563 265 OFFCURVE",
+"434 389 OFFCURVE",
+"278 530 CURVE",
+"267 473 LINE",
+"381 610 OFFCURVE",
+"442 704 OFFCURVE",
+"498 806 CURVE",
+"530 843 LINE",
+"542 861 OFFCURVE",
+"555 885 OFFCURVE",
+"567 905 CURVE",
+"502 939 LINE",
+"400 770 OFFCURVE",
+"319 652 OFFCURVE",
+"228 542 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"540 738 OFFCURVE",
+"548 676 OFFCURVE",
+"548 612 CURVE SMOOTH",
+"548 516 OFFCURVE",
+"527 439 OFFCURVE",
+"461 332 CURVE",
+"433 297 LINE",
+"387 230 OFFCURVE",
+"327 150 OFFCURVE",
+"244 48 CURVE",
+"298 -4 LINE",
+"378 96 OFFCURVE",
+"442 180 OFFCURVE",
+"491 255 CURVE",
+"515 284 LINE",
+"589 404 OFFCURVE",
+"624 503 OFFCURVE",
+"624 611 CURVE SMOOTH",
+"624 707 OFFCURVE",
+"602 775 OFFCURVE",
+"526 896 CURVE",
+"467 806 LINE",
+"502 806 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"275 231 OFFCURVE",
+"298 248 OFFCURVE",
+"298 287 CURVE SMOOTH",
+"298 326 OFFCURVE",
+"275 343 OFFCURVE",
+"247 343 CURVE SMOOTH",
+"218 343 OFFCURVE",
+"195 326 OFFCURVE",
+"195 287 CURVE SMOOTH",
+"195 248 OFFCURVE",
+"218 231 OFFCURVE",
+"247 231 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"532 -28 OFFCURVE",
+"555 -11 OFFCURVE",
+"555 28 CURVE SMOOTH",
+"555 67 OFFCURVE",
+"532 84 OFFCURVE",
+"504 84 CURVE SMOOTH",
+"475 84 OFFCURVE",
+"452 67 OFFCURVE",
+"452 28 CURVE SMOOTH",
+"452 -11 OFFCURVE",
+"475 -28 OFFCURVE",
+"504 -28 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"469 -152 LINE",
+"351 -18 OFFCURVE",
+"243 96 OFFCURVE",
+"109 221 CURVE",
+"60 163 LINE",
+"181 51 OFFCURVE",
+"307 -80 OFFCURVE",
+"414 -203 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 805;
+}
+);
+leftMetricsKey = u1B1CE;
+unicode = 1B1F4;
+},
+{
+glyphname = u1B1F5;
+lastChange = "2020-04-13 08:46:16 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"471 -148 LINE",
+"409 -87 OFFCURVE",
+"377 -39 OFFCURVE",
+"377 24 CURVE SMOOTH",
+"377 78 OFFCURVE",
+"409 112 OFFCURVE",
+"480 112 CURVE SMOOTH",
+"494 112 OFFCURVE",
+"508 111 OFFCURVE",
+"522 111 CURVE",
+"562 106 LINE",
+"617 93 OFFCURVE",
+"671 79 OFFCURVE",
+"723 56 CURVE",
+"751 121 LINE",
+"695 147 OFFCURVE",
+"629 166 OFFCURVE",
+"563 179 CURVE",
+"526 185 LINE",
+"514 186 OFFCURVE",
+"502 186 OFFCURVE",
+"489 186 CURVE SMOOTH",
+"375 186 OFFCURVE",
+"303 122 OFFCURVE",
+"303 24 CURVE SMOOTH",
+"303 -66 OFFCURVE",
+"349 -138 OFFCURVE",
+"445 -203 CURVE",
+"533 -186 LINE",
+"567 -77 OFFCURVE",
+"579 14 OFFCURVE",
+"579 144 CURVE SMOOTH",
+"579 320 OFFCURVE",
+"536 496 OFFCURVE",
+"404 714 CURVE",
+"352 661 LINE",
+"470 459 OFFCURVE",
+"505 308 OFFCURVE",
+"505 144 CURVE SMOOTH",
+"505 20 OFFCURVE",
+"498 -66 OFFCURVE",
+"476 -147 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"491 939 LINE",
+"384 761 OFFCURVE",
+"267 625 OFFCURVE",
+"144 509 CURVE",
+"194 452 LINE",
+"330 581 OFFCURVE",
+"440 710 OFFCURVE",
+"557 903 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"623 719 LINE",
+"573 650 OFFCURVE",
+"525 590 OFFCURVE",
+"478 536 CURVE",
+"450 508 LINE",
+"379 429 OFFCURVE",
+"310 365 OFFCURVE",
+"240 306 CURVE",
+"287 246 LINE",
+"356 304 OFFCURVE",
+"419 363 OFFCURVE",
+"481 429 CURVE",
+"508 455 LINE",
+"566 519 OFFCURVE",
+"625 591 OFFCURVE",
+"687 676 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"120 338 LINE",
+"143 216 OFFCURVE",
+"152 94 OFFCURVE",
+"152 -71 CURVE",
+"226 -70 LINE",
+"226 92 OFFCURVE",
+"217 222 OFFCURVE",
+"193 353 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"709 582 LINE",
+"734 449 OFFCURVE",
+"742 328 OFFCURVE",
+"741 188 CURVE",
+"815 190 LINE",
+"816 333 OFFCURVE",
+"807 459 OFFCURVE",
+"782 594 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 955;
+}
+);
+leftMetricsKey = u1B17E;
+rightMetricsKey = u1B1AB;
+unicode = 1B1F5;
+},
+{
+glyphname = u1B1F6;
+lastChange = "2020-04-13 08:46:19 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"600 939 LINE",
+"560 844 OFFCURVE",
+"516 756 OFFCURVE",
+"469 675 CURVE SMOOTH",
+"426 601 OFFCURVE",
+"388 541 OFFCURVE",
+"345 475 CURVE",
+"340 476 LINE",
+"324 543 OFFCURVE",
+"298 617 OFFCURVE",
+"273 673 CURVE SMOOTH",
+"256 711 OFFCURVE",
+"237 750 OFFCURVE",
+"215 792 CURVE",
+"150 756 LINE",
+"216 634 OFFCURVE",
+"252 536 OFFCURVE",
+"290 434 CURVE",
+"380 415 LINE",
+"496 567 OFFCURVE",
+"592 720 OFFCURVE",
+"670 912 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"535 85 OFFCURVE",
+"490 186 OFFCURVE",
+"407 322 CURVE",
+"321 314 LINE",
+"243 94 OFFCURVE",
+"180 -32 OFFCURVE",
+"102 -168 CURVE",
+"170 -203 LINE",
+"215 -123 OFFCURVE",
+"254 -44 OFFCURVE",
+"293 47 CURVE SMOOTH",
+"321 111 OFFCURVE",
+"346 174 OFFCURVE",
+"366 252 CURVE",
+"371 253 LINE",
+"407 189 OFFCURVE",
+"432 139 OFFCURVE",
+"459 71 CURVE SMOOTH",
+"479 20 OFFCURVE",
+"498 -32 OFFCURVE",
+"516 -90 CURVE",
+"587 -67 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"602 372 OFFCURVE",
+"625 389 OFFCURVE",
+"625 428 CURVE SMOOTH",
+"625 467 OFFCURVE",
+"602 484 OFFCURVE",
+"574 484 CURVE SMOOTH",
+"545 484 OFFCURVE",
+"522 467 OFFCURVE",
+"522 428 CURVE SMOOTH",
+"522 389 OFFCURVE",
+"545 372 OFFCURVE",
+"574 372 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"180 310 OFFCURVE",
+"203 327 OFFCURVE",
+"203 366 CURVE SMOOTH",
+"203 405 OFFCURVE",
+"180 422 OFFCURVE",
+"152 422 CURVE SMOOTH",
+"123 422 OFFCURVE",
+"100 405 OFFCURVE",
+"100 366 CURVE SMOOTH",
+"100 327 OFFCURVE",
+"123 310 OFFCURVE",
+"152 310 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 770;
+}
+);
+unicode = 1B1F6;
+},
+{
+glyphname = u1B1F7;
+lastChange = "2020-04-13 08:51:09 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"549 887 LINE",
+"516 744 OFFCURVE",
+"484 631 OFFCURVE",
+"448 531 CURVE SMOOTH",
+"413 435 OFFCURVE",
+"383 367 OFFCURVE",
+"341 278 CURVE",
+"337 278 LINE",
+"307 360 OFFCURVE",
+"279 422 OFFCURVE",
+"237 494 CURVE SMOOTH",
+"212 537 OFFCURVE",
+"187 577 OFFCURVE",
+"162 614 CURVE",
+"102 573 LINE",
+"174 465 OFFCURVE",
+"233 366 OFFCURVE",
+"291 234 CURVE",
+"385 226 LINE",
+"488 416 OFFCURVE",
+"551 571 OFFCURVE",
+"623 872 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 -103 OFFCURVE",
+"105 -148 OFFCURVE",
+"173 -182 CURVE",
+"244 -173 LINE",
+"307 -87 OFFCURVE",
+"325 -29 OFFCURVE",
+"325 34 CURVE SMOOTH",
+"325 88 OFFCURVE",
+"301 133 OFFCURVE",
+"228 171 CURVE",
+"154 161 LINE",
+"103 79 OFFCURVE",
+"80 15 OFFCURVE",
+"80 -37 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 116 LINE",
+"243 83 OFFCURVE",
+"255 57 OFFCURVE",
+"255 28 CURVE SMOOTH",
+"255 -15 OFFCURVE",
+"242 -63 OFFCURVE",
+"203 -130 CURVE",
+"198 -131 LINE",
+"165 -104 OFFCURVE",
+"150 -72 OFFCURVE",
+"150 -33 CURVE SMOOTH",
+"150 3 OFFCURVE",
+"163 50 OFFCURVE",
+"196 115 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"453 -4 OFFCURVE",
+"478 -49 OFFCURVE",
+"546 -83 CURVE",
+"617 -74 LINE",
+"680 12 OFFCURVE",
+"698 70 OFFCURVE",
+"698 133 CURVE SMOOTH",
+"698 187 OFFCURVE",
+"674 232 OFFCURVE",
+"601 270 CURVE",
+"527 260 LINE",
+"476 178 OFFCURVE",
+"453 114 OFFCURVE",
+"453 62 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"574 215 LINE",
+"616 182 OFFCURVE",
+"628 156 OFFCURVE",
+"628 127 CURVE SMOOTH",
+"628 84 OFFCURVE",
+"615 36 OFFCURVE",
+"576 -31 CURVE",
+"571 -32 LINE",
+"538 -5 OFFCURVE",
+"523 27 OFFCURVE",
+"523 66 CURVE SMOOTH",
+"523 102 OFFCURVE",
+"536 149 OFFCURVE",
+"569 214 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 758;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B1F1;
+unicode = 1B1F7;
+},
+{
+glyphname = u1B1F8;
+lastChange = "2020-04-13 08:51:06 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"402 939 LINE",
+"298 802 OFFCURVE",
+"191 683 OFFCURVE",
+"70 568 CURVE",
+"122 513 LINE",
+"251 635 OFFCURVE",
+"352 750 OFFCURVE",
+"464 895 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"303 727 LINE",
+"459 501 OFFCURVE",
+"571 293 OFFCURVE",
+"681 75 CURVE",
+"748 110 LINE",
+"639 323 OFFCURVE",
+"523 528 OFFCURVE",
+"358 782 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"505 772 LINE",
+"475 733 OFFCURVE",
+"443 693 OFFCURVE",
+"410 654 CURVE",
+"387 632 LINE",
+"304 534 OFFCURVE",
+"215 440 OFFCURVE",
+"132 360 CURVE",
+"182 309 LINE",
+"267 394 OFFCURVE",
+"349 481 OFFCURVE",
+"427 572 CURVE",
+"455 599 LINE",
+"492 642 OFFCURVE",
+"527 686 OFFCURVE",
+"562 730 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"490 480 LINE",
+"384 356 OFFCURVE",
+"299 260 OFFCURVE",
+"188 160 CURVE",
+"239 108 LINE",
+"354 217 OFFCURVE",
+"439 311 OFFCURVE",
+"526 419 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"330 -115 OFFCURVE",
+"359 -163 OFFCURVE",
+"427 -203 CURVE",
+"498 -194 LINE",
+"566 -115 OFFCURVE",
+"584 -50 OFFCURVE",
+"584 11 CURVE SMOOTH",
+"584 71 OFFCURVE",
+"550 112 OFFCURVE",
+"482 150 CURVE",
+"408 140 LINE",
+"350 58 OFFCURVE",
+"330 -9 OFFCURVE",
+"330 -58 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"454 96 LINE",
+"494 64 OFFCURVE",
+"509 29 OFFCURVE",
+"509 0 CURVE SMOOTH",
+"509 -43 OFFCURVE",
+"499 -88 OFFCURVE",
+"459 -152 CURVE",
+"454 -153 LINE",
+"419 -118 OFFCURVE",
+"404 -87 OFFCURVE",
+"404 -54 CURVE SMOOTH",
+"404 -12 OFFCURVE",
+"417 32 OFFCURVE",
+"449 95 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 828;
+}
+);
+leftMetricsKey = u1B18E;
+unicode = 1B1F8;
+},
+{
+glyphname = u1B1F9;
+lastChange = "2020-04-13 08:50:52 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"690 401 OFFCURVE",
+"713 418 OFFCURVE",
+"713 457 CURVE SMOOTH",
+"713 496 OFFCURVE",
+"690 513 OFFCURVE",
+"662 513 CURVE SMOOTH",
+"633 513 OFFCURVE",
+"610 496 OFFCURVE",
+"610 457 CURVE SMOOTH",
+"610 418 OFFCURVE",
+"633 401 OFFCURVE",
+"662 401 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"575 241 OFFCURVE",
+"598 258 OFFCURVE",
+"598 297 CURVE SMOOTH",
+"598 336 OFFCURVE",
+"575 353 OFFCURVE",
+"547 353 CURVE SMOOTH",
+"518 353 OFFCURVE",
+"495 336 OFFCURVE",
+"495 297 CURVE SMOOTH",
+"495 258 OFFCURVE",
+"518 241 OFFCURVE",
+"547 241 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"578 -109 LINE",
+"687 23 OFFCURVE",
+"750 134 OFFCURVE",
+"814 274 CURVE",
+"746 303 LINE",
+"727 262 OFFCURVE",
+"709 223 OFFCURVE",
+"690 187 CURVE SMOOTH",
+"647 105 OFFCURVE",
+"591 20 OFFCURVE",
+"547 -46 CURVE",
+"543 -46 LINE",
+"515 49 OFFCURVE",
+"490 117 OFFCURVE",
+"447 192 CURVE SMOOTH",
+"409 258 OFFCURVE",
+"364 322 OFFCURVE",
+"314 379 CURVE",
+"265 329 LINE",
+"371 191 OFFCURVE",
+"445 56 OFFCURVE",
+"491 -96 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"200 614 OFFCURVE",
+"227 471 OFFCURVE",
+"227 291 CURVE SMOOTH",
+"227 114 OFFCURVE",
+"208 -12 OFFCURVE",
+"146 -180 CURVE",
+"216 -203 LINE",
+"279 -32 OFFCURVE",
+"303 108 OFFCURVE",
+"303 291 CURVE SMOOTH",
+"303 481 OFFCURVE",
+"268 642 OFFCURVE",
+"188 820 CURVE",
+"120 792 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"617 939 LINE",
+"539 676 OFFCURVE",
+"429 513 OFFCURVE",
+"266 369 CURVE",
+"311 320 LINE",
+"505 481 OFFCURVE",
+"602 642 OFFCURVE",
+"688 917 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 894;
+}
+);
+leftMetricsKey = u1B186;
+rightMetricsKey = u1B19A;
+unicode = 1B1F9;
+},
+{
+glyphname = u1B1FA;
+lastChange = "2020-04-11 16:27:53 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"231 376 OFFCURVE",
+"254 393 OFFCURVE",
+"254 432 CURVE SMOOTH",
+"254 471 OFFCURVE",
+"231 488 OFFCURVE",
+"203 488 CURVE SMOOTH",
+"174 488 OFFCURVE",
+"151 471 OFFCURVE",
+"151 432 CURVE SMOOTH",
+"151 393 OFFCURVE",
+"174 376 OFFCURVE",
+"203 376 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"160 96 OFFCURVE",
+"183 113 OFFCURVE",
+"183 152 CURVE SMOOTH",
+"183 191 OFFCURVE",
+"160 208 OFFCURVE",
+"132 208 CURVE SMOOTH",
+"103 208 OFFCURVE",
+"80 191 OFFCURVE",
+"80 152 CURVE SMOOTH",
+"80 113 OFFCURVE",
+"103 96 OFFCURVE",
+"132 96 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"689 362 OFFCURVE",
+"712 379 OFFCURVE",
+"712 418 CURVE SMOOTH",
+"712 457 OFFCURVE",
+"689 474 OFFCURVE",
+"661 474 CURVE SMOOTH",
+"632 474 OFFCURVE",
+"609 457 OFFCURVE",
+"609 418 CURVE SMOOTH",
+"609 379 OFFCURVE",
+"632 362 OFFCURVE",
+"661 362 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"667 99 OFFCURVE",
+"690 116 OFFCURVE",
+"690 155 CURVE SMOOTH",
+"690 194 OFFCURVE",
+"667 211 OFFCURVE",
+"639 211 CURVE SMOOTH",
+"610 211 OFFCURVE",
+"587 194 OFFCURVE",
+"587 155 CURVE SMOOTH",
+"587 116 OFFCURVE",
+"610 99 OFFCURVE",
+"639 99 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"573 -138 OFFCURVE",
+"596 -121 OFFCURVE",
+"596 -82 CURVE SMOOTH",
+"596 -43 OFFCURVE",
+"573 -26 OFFCURVE",
+"545 -26 CURVE SMOOTH",
+"516 -26 OFFCURVE",
+"493 -43 OFFCURVE",
+"493 -82 CURVE SMOOTH",
+"493 -121 OFFCURVE",
+"516 -138 OFFCURVE",
+"545 -138 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"431 939 LINE",
+"430 472 OFFCURVE",
+"344 93 OFFCURVE",
+"207 -169 CURVE",
+"277 -203 LINE",
+"416 61 OFFCURVE",
+"506 443 OFFCURVE",
+"509 938 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 792;
+}
+);
+leftMetricsKey = u1B176;
+rightMetricsKey = u1B177;
+unicode = 1B1FA;
+},
+{
+glyphname = u1B1FB;
+lastChange = "2020-04-13 08:50:46 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"660 506 LINE",
+"631 449 OFFCURVE",
+"599 395 OFFCURVE",
+"564 344 CURVE",
+"546 324 LINE",
+"510 273 OFFCURVE",
+"471 226 OFFCURVE",
+"429 183 CURVE",
+"463 123 LINE",
+"508 170 OFFCURVE",
+"547 216 OFFCURVE",
+"584 264 CURVE",
+"603 284 LINE",
+"646 343 OFFCURVE",
+"684 405 OFFCURVE",
+"721 475 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"422 459 LINE",
+"513 350 OFFCURVE",
+"595 207 OFFCURVE",
+"644 87 CURVE",
+"696 131 LINE",
+"642 259 OFFCURVE",
+"574 378 OFFCURVE",
+"466 512 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"575 -112 LINE",
+"672 -3 OFFCURVE",
+"742 100 OFFCURVE",
+"814 240 CURVE",
+"749 271 LINE",
+"727 228 OFFCURVE",
+"704 186 OFFCURVE",
+"680 146 CURVE SMOOTH",
+"637 75 OFFCURVE",
+"592 17 OFFCURVE",
+"544 -49 CURVE",
+"539 -48 LINE",
+"521 24 OFFCURVE",
+"494 100 OFFCURVE",
+"456 170 CURVE SMOOTH",
+"417 242 OFFCURVE",
+"370 311 OFFCURVE",
+"316 373 CURVE",
+"265 329 LINE",
+"371 191 OFFCURVE",
+"445 56 OFFCURVE",
+"485 -92 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"617 939 LINE",
+"539 676 OFFCURVE",
+"429 513 OFFCURVE",
+"266 369 CURVE",
+"311 320 LINE",
+"505 481 OFFCURVE",
+"602 642 OFFCURVE",
+"688 917 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"200 614 OFFCURVE",
+"227 471 OFFCURVE",
+"227 291 CURVE SMOOTH",
+"227 114 OFFCURVE",
+"208 -12 OFFCURVE",
+"146 -180 CURVE",
+"216 -203 LINE",
+"279 -32 OFFCURVE",
+"303 108 OFFCURVE",
+"303 291 CURVE SMOOTH",
+"303 481 OFFCURVE",
+"268 642 OFFCURVE",
+"188 820 CURVE",
+"120 792 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 894;
+}
+);
+leftMetricsKey = u1B186;
+rightMetricsKey = u1B19A;
+unicode = 1B1FB;
+},
+{
+glyphname = u1B1FC;
+lastChange = "2020-04-13 08:50:30 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"180 34 OFFCURVE",
+"203 51 OFFCURVE",
+"203 90 CURVE SMOOTH",
+"203 129 OFFCURVE",
+"180 146 OFFCURVE",
+"152 146 CURVE SMOOTH",
+"123 146 OFFCURVE",
+"100 129 OFFCURVE",
+"100 90 CURVE SMOOTH",
+"100 51 OFFCURVE",
+"123 34 OFFCURVE",
+"152 34 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"283 -203 OFFCURVE",
+"306 -186 OFFCURVE",
+"306 -147 CURVE SMOOTH",
+"306 -108 OFFCURVE",
+"283 -91 OFFCURVE",
+"255 -91 CURVE SMOOTH",
+"226 -91 OFFCURVE",
+"203 -108 OFFCURVE",
+"203 -147 CURVE SMOOTH",
+"203 -186 OFFCURVE",
+"226 -203 OFFCURVE",
+"255 -203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"595 665 LINE",
+"548 604 OFFCURVE",
+"500 548 OFFCURVE",
+"449 495 CURVE",
+"415 464 LINE",
+"358 406 OFFCURVE",
+"299 351 OFFCURVE",
+"238 299 CURVE",
+"284 243 LINE",
+"342 291 OFFCURVE",
+"393 338 OFFCURVE",
+"441 387 CURVE",
+"467 408 LINE",
+"528 473 OFFCURVE",
+"586 540 OFFCURVE",
+"652 619 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"518 939 LINE",
+"405 771 OFFCURVE",
+"290 645 OFFCURVE",
+"136 502 CURVE",
+"188 445 LINE",
+"334 584 OFFCURVE",
+"464 722 OFFCURVE",
+"583 898 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"639 377 LINE",
+"532 250 OFFCURVE",
+"433 153 OFFCURVE",
+"311 60 CURVE",
+"356 0 LINE",
+"495 110 OFFCURVE",
+"588 205 OFFCURVE",
+"697 332 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"351 634 LINE",
+"402 472 OFFCURVE",
+"433 318 OFFCURVE",
+"451 157 CURVE",
+"520 187 LINE",
+"501 357 OFFCURVE",
+"465 515 OFFCURVE",
+"410 709 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 777;
+}
+);
+rightMetricsKey = u1B197;
+unicode = 1B1FC;
+},
+{
+glyphname = u1B1FD;
+lastChange = "2020-04-13 08:50:12 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"305 226 OFFCURVE",
+"328 243 OFFCURVE",
+"328 282 CURVE SMOOTH",
+"328 321 OFFCURVE",
+"305 338 OFFCURVE",
+"277 338 CURVE SMOOTH",
+"248 338 OFFCURVE",
+"225 321 OFFCURVE",
+"225 282 CURVE SMOOTH",
+"225 243 OFFCURVE",
+"248 226 OFFCURVE",
+"277 226 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"533 347 OFFCURVE",
+"556 364 OFFCURVE",
+"556 403 CURVE SMOOTH",
+"556 442 OFFCURVE",
+"533 459 OFFCURVE",
+"505 459 CURVE SMOOTH",
+"476 459 OFFCURVE",
+"453 442 OFFCURVE",
+"453 403 CURVE SMOOTH",
+"453 364 OFFCURVE",
+"476 347 OFFCURVE",
+"505 347 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"663 359 LINE",
+"503 247 OFFCURVE",
+"351 170 OFFCURVE",
+"177 93 CURVE",
+"209 27 LINE",
+"388 107 OFFCURVE",
+"535 180 OFFCURVE",
+"706 299 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 196 OFFCURVE",
+"627 167 OFFCURVE",
+"627 119 CURVE SMOOTH",
+"627 42 OFFCURVE",
+"560 -10 OFFCURVE",
+"253 -134 CURVE",
+"281 -203 LINE",
+"620 -64 OFFCURVE",
+"703 2 OFFCURVE",
+"703 119 CURVE SMOOTH",
+"703 179 OFFCURVE",
+"683 228 OFFCURVE",
+"624 308 CURVE",
+"574 251 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"521 939 LINE",
+"365 824 OFFCURVE",
+"223 741 OFFCURVE",
+"60 664 CURVE",
+"93 599 LINE",
+"256 678 OFFCURVE",
+"409 765 OFFCURVE",
+"566 881 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"484 777 OFFCURVE",
+"499 745 OFFCURVE",
+"499 700 CURVE SMOOTH",
+"499 629 OFFCURVE",
+"439 581 OFFCURVE",
+"112 425 CURVE",
+"145 359 LINE",
+"502 528 OFFCURVE",
+"575 589 OFFCURVE",
+"575 705 CURVE SMOOTH",
+"575 758 OFFCURVE",
+"554 808 OFFCURVE",
+"493 879 CURVE",
+"440 833 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 836;
+}
+);
+leftMetricsKey = u1B179;
+rightMetricsKey = u1B1A9;
+unicode = 1B1FD;
+},
+{
+glyphname = u1B1FE;
+lastChange = "2020-04-13 08:50:08 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"637 939 LINE",
+"566 828 OFFCURVE",
+"501 749 OFFCURVE",
+"409 657 CURVE",
+"473 513 OFFCURVE",
+"486 420 OFFCURVE",
+"486 302 CURVE SMOOTH",
+"486 231 OFFCURVE",
+"482 166 OFFCURVE",
+"474 95 CURVE",
+"544 88 LINE",
+"553 160 OFFCURVE",
+"558 224 OFFCURVE",
+"558 303 CURVE SMOOTH",
+"558 426 OFFCURVE",
+"539 536 OFFCURVE",
+"483 669 CURVE",
+"479 624 LINE",
+"547 690 OFFCURVE",
+"626 780 OFFCURVE",
+"702 900 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"753 494 LINE",
+"725 654 OFFCURVE",
+"693 728 OFFCURVE",
+"623 844 CURVE",
+"597 765 LINE",
+"637 681 OFFCURVE",
+"658 621 OFFCURVE",
+"680 483 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"353 591 LINE",
+"280 484 OFFCURVE",
+"227 430 OFFCURVE",
+"120 346 CURVE",
+"151 224 OFFCURVE",
+"163 144 OFFCURVE",
+"163 34 CURVE SMOOTH",
+"163 -68 OFFCURVE",
+"158 -132 OFFCURVE",
+"147 -194 CURVE",
+"218 -203 LINE",
+"231 -137 OFFCURVE",
+"237 -77 OFFCURVE",
+"237 34 CURVE SMOOTH",
+"237 144 OFFCURVE",
+"226 223 OFFCURVE",
+"191 354 CURVE",
+"192 309 LINE",
+"271 373 OFFCURVE",
+"332 430 OFFCURVE",
+"415 547 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"450 186 LINE",
+"434 305 OFFCURVE",
+"404 388 OFFCURVE",
+"351 485 CURVE",
+"307 426 LINE",
+"343 348 OFFCURVE",
+"362 277 OFFCURVE",
+"375 176 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 853;
+}
+);
+leftMetricsKey = u1B17E;
+rightMetricsKey = u1B17E;
+unicode = 1B1FE;
+},
+{
+glyphname = u1B1FF;
+lastChange = "2020-04-13 08:50:05 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"235 376 LINE",
+"187 241 OFFCURVE",
+"134 155 OFFCURVE",
+"40 34 CURVE",
+"96 -7 LINE",
+"175 93 OFFCURVE",
+"217 163 OFFCURVE",
+"251 245 CURVE",
+"261 245 LINE",
+"277 278 OFFCURVE",
+"294 329 OFFCURVE",
+"302 355 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"229 245 LINE",
+"255 245 LINE",
+"311 177 OFFCURVE",
+"358 117 OFFCURVE",
+"416 9 CURVE",
+"478 46 LINE",
+"408 167 OFFCURVE",
+"336 252 OFFCURVE",
+"272 314 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"232 91 LINE",
+"232 -17 OFFCURVE",
+"228 -107 OFFCURVE",
+"214 -194 CURVE",
+"286 -203 LINE",
+"298 -119 OFFCURVE",
+"302 -25 OFFCURVE",
+"302 91 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"670 101 LINE",
+"618 439 OFFCURVE",
+"559 616 OFFCURVE",
+"403 891 CURVE",
+"340 855 LINE",
+"495 582 OFFCURVE",
+"553 409 OFFCURVE",
+"597 92 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"612 939 LINE",
+"563 860 OFFCURVE",
+"516 795 OFFCURVE",
+"465 729 CURVE",
+"446 712 LINE",
+"396 652 OFFCURVE",
+"340 591 OFFCURVE",
+"272 523 CURVE",
+"324 468 LINE",
+"385 531 OFFCURVE",
+"436 586 OFFCURVE",
+"482 640 CURVE",
+"504 660 LINE",
+"563 732 OFFCURVE",
+"615 806 OFFCURVE",
+"677 902 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"728 713 LINE",
+"679 643 OFFCURVE",
+"622 571 OFFCURVE",
+"557 499 CURVE",
+"536 482 LINE",
+"484 425 OFFCURVE",
+"426 369 OFFCURVE",
+"365 315 CURVE",
+"413 258 LINE",
+"464 305 OFFCURVE",
+"515 354 OFFCURVE",
+"565 406 CURVE",
+"589 425 LINE",
+"663 505 OFFCURVE",
+"733 589 OFFCURVE",
+"789 671 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 879;
+}
+);
+rightMetricsKey = u1B187;
+unicode = 1B1FF;
+},
+{
+glyphname = u1B200;
+lastChange = "2020-04-13 08:49:34 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"118 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -102 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"675 572 LINE",
+"650 502 OFFCURVE",
+"625 441 OFFCURVE",
+"595 382 CURVE SMOOTH",
+"550 294 OFFCURVE",
+"508 224 OFFCURVE",
+"451 140 CURVE",
+"446 141 LINE",
+"435 234 OFFCURVE",
+"417 312 OFFCURVE",
+"391 410 CURVE SMOOTH",
+"351 559 OFFCURVE",
+"299 699 OFFCURVE",
+"229 845 CURVE",
+"160 812 LINE",
+"275 579 OFFCURVE",
+"338 364 OFFCURVE",
+"386 88 CURVE",
+"479 70 LINE",
+"601 230 OFFCURVE",
+"670 350 OFFCURVE",
+"747 545 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"454 518 LINE",
+"532 373 OFFCURVE",
+"611 196 OFFCURVE",
+"658 56 CURVE",
+"726 80 LINE",
+"668 255 OFFCURVE",
+"597 408 OFFCURVE",
+"517 552 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"465 939 LINE",
+"366 726 OFFCURVE",
+"248 560 OFFCURVE",
+"80 372 CURVE",
+"134 324 LINE",
+"309 514 OFFCURVE",
+"413 669 OFFCURVE",
+"533 907 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 847;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B1B1;
+unicode = 1B200;
+},
+{
+glyphname = u1B201;
+lastChange = "2020-04-13 08:49:00 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"133 627 LINE",
+"277 545 OFFCURVE",
+"392 466 OFFCURVE",
+"518 365 CURVE",
+"561 421 LINE",
+"503 466 OFFCURVE",
+"449 505 OFFCURVE",
+"369 561 CURVE",
+"350 560 LINE",
+"303 604 OFFCURVE",
+"250 639 OFFCURVE",
+"170 687 CURVE",
+"183 648 LINE",
+"254 705 OFFCURVE",
+"320 772 OFFCURVE",
+"366 826 CURVE",
+"399 856 LINE",
+"410 869 OFFCURVE",
+"421 881 OFFCURVE",
+"432 895 CURVE",
+"376 939 LINE",
+"290 834 OFFCURVE",
+"215 763 OFFCURVE",
+"133 698 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"471 763 OFFCURVE",
+"449 818 OFFCURVE",
+"388 896 CURVE",
+"335 826 LINE",
+"370 826 LINE",
+"388 781 OFFCURVE",
+"399 739 OFFCURVE",
+"399 703 CURVE SMOOTH",
+"399 662 OFFCURVE",
+"391 612 OFFCURVE",
+"354 560 CURVE",
+"344 560 LINE",
+"276 483 OFFCURVE",
+"199 412 OFFCURVE",
+"80 318 CURVE",
+"126 265 LINE",
+"237 358 OFFCURVE",
+"311 432 OFFCURVE",
+"365 494 CURVE",
+"391 520 LINE",
+"450 594 OFFCURVE",
+"471 649 OFFCURVE",
+"471 701 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"156 123 LINE",
+"273 40 OFFCURVE",
+"368 -32 OFFCURVE",
+"501 -162 CURVE",
+"549 -110 LINE",
+"493 -57 OFFCURVE",
+"448 -19 OFFCURVE",
+"367 47 CURVE",
+"352 47 LINE",
+"310 91 OFFCURVE",
+"257 135 OFFCURVE",
+"201 174 CURVE",
+"206 143 LINE",
+"281 206 OFFCURVE",
+"336 255 OFFCURVE",
+"371 302 CURVE",
+"404 331 LINE",
+"415 343 OFFCURVE",
+"427 357 OFFCURVE",
+"438 371 CURVE",
+"382 417 LINE",
+"299 319 OFFCURVE",
+"235 255 OFFCURVE",
+"156 194 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"482 242 OFFCURVE",
+"461 298 OFFCURVE",
+"385 381 CURVE",
+"349 302 LINE",
+"375 302 LINE",
+"398 256 OFFCURVE",
+"410 216 OFFCURVE",
+"410 178 CURVE SMOOTH",
+"410 144 OFFCURVE",
+"396 99 OFFCURVE",
+"356 47 CURVE",
+"348 47 LINE",
+"286 -24 OFFCURVE",
+"212 -81 OFFCURVE",
+"119 -148 CURVE",
+"166 -203 LINE",
+"252 -136 OFFCURVE",
+"320 -77 OFFCURVE",
+"374 -21 CURVE",
+"399 2 LINE",
+"452 62 OFFCURVE",
+"482 119 OFFCURVE",
+"482 178 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 641;
+}
+);
+unicode = 1B201;
+},
+{
+glyphname = u1B202;
+lastChange = "2020-04-13 08:48:45 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"758 750 LINE",
+"694 647 OFFCURVE",
+"637 579 OFFCURVE",
+"545 495 CURVE",
+"585 366 OFFCURVE",
+"598 270 OFFCURVE",
+"598 167 CURVE SMOOTH",
+"598 100 OFFCURVE",
+"592 40 OFFCURVE",
+"583 -18 CURVE",
+"656 -26 LINE",
+"669 44 OFFCURVE",
+"674 94 OFFCURVE",
+"674 168 CURVE SMOOTH",
+"674 261 OFFCURVE",
+"661 370 OFFCURVE",
+"614 514 CURVE",
+"608 452 LINE",
+"688 525 OFFCURVE",
+"754 604 OFFCURVE",
+"820 712 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"643 939 LINE",
+"552 789 OFFCURVE",
+"453 669 OFFCURVE",
+"326 550 CURVE",
+"396 392 OFFCURVE",
+"417 299 OFFCURVE",
+"417 167 CURVE SMOOTH",
+"417 37 OFFCURVE",
+"390 -60 OFFCURVE",
+"341 -177 CURVE",
+"410 -203 LINE",
+"463 -84 OFFCURVE",
+"491 32 OFFCURVE",
+"491 167 CURVE SMOOTH",
+"491 299 OFFCURVE",
+"465 414 OFFCURVE",
+"399 568 CURVE",
+"385 511 LINE",
+"505 623 OFFCURVE",
+"614 743 OFFCURVE",
+"710 902 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 55 OFFCURVE",
+"109 7 OFFCURVE",
+"177 -33 CURVE",
+"248 -24 LINE",
+"316 55 OFFCURVE",
+"334 120 OFFCURVE",
+"334 181 CURVE SMOOTH",
+"334 241 OFFCURVE",
+"300 282 OFFCURVE",
+"232 320 CURVE",
+"158 310 LINE",
+"100 228 OFFCURVE",
+"80 161 OFFCURVE",
+"80 112 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 266 LINE",
+"244 234 OFFCURVE",
+"259 199 OFFCURVE",
+"259 170 CURVE SMOOTH",
+"259 127 OFFCURVE",
+"249 82 OFFCURVE",
+"209 18 CURVE",
+"204 17 LINE",
+"169 52 OFFCURVE",
+"154 83 OFFCURVE",
+"154 116 CURVE SMOOTH",
+"154 158 OFFCURVE",
+"167 202 OFFCURVE",
+"199 265 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 900;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B18B;
+unicode = 1B202;
+},
+{
+glyphname = u1B203;
+lastChange = "2020-04-13 08:48:43 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"585 171 LINE",
+"482 425 OFFCURVE",
+"377 628 OFFCURVE",
+"183 872 CURVE",
+"125 823 LINE",
+"315 587 OFFCURVE",
+"421 381 OFFCURVE",
+"515 142 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"473 939 LINE",
+"418 850 OFFCURVE",
+"360 766 OFFCURVE",
+"296 685 CURVE",
+"275 664 LINE",
+"211 584 OFFCURVE",
+"140 506 OFFCURVE",
+"60 425 CURVE",
+"114 372 LINE",
+"193 452 OFFCURVE",
+"260 525 OFFCURVE",
+"322 601 CURVE",
+"342 621 LINE",
+"411 706 OFFCURVE",
+"473 796 OFFCURVE",
+"538 900 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"303 231 OFFCURVE",
+"326 248 OFFCURVE",
+"326 287 CURVE SMOOTH",
+"326 326 OFFCURVE",
+"303 343 OFFCURVE",
+"275 343 CURVE SMOOTH",
+"246 343 OFFCURVE",
+"223 326 OFFCURVE",
+"223 287 CURVE SMOOTH",
+"223 248 OFFCURVE",
+"246 231 OFFCURVE",
+"275 231 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"608 562 OFFCURVE",
+"631 579 OFFCURVE",
+"631 618 CURVE SMOOTH",
+"631 657 OFFCURVE",
+"608 674 OFFCURVE",
+"580 674 CURVE SMOOTH",
+"551 674 OFFCURVE",
+"528 657 OFFCURVE",
+"528 618 CURVE SMOOTH",
+"528 579 OFFCURVE",
+"551 562 OFFCURVE",
+"580 562 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"276 157 LINE",
+"249 104 OFFCURVE",
+"224 59 OFFCURVE",
+"199 19 CURVE",
+"176 -10 LINE",
+"142 -59 OFFCURVE",
+"106 -104 OFFCURVE",
+"60 -154 CURVE",
+"112 -203 LINE",
+"157 -150 OFFCURVE",
+"192 -107 OFFCURVE",
+"222 -64 CURVE",
+"248 -31 LINE",
+"278 15 OFFCURVE",
+"305 63 OFFCURVE",
+"340 126 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"66 88 LINE",
+"158 -5 OFFCURVE",
+"219 -83 OFFCURVE",
+"282 -182 CURVE",
+"341 -143 LINE",
+"268 -34 OFFCURVE",
+"200 49 OFFCURVE",
+"116 138 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 731;
+}
+);
+leftMetricsKey = u1B1C9;
+unicode = 1B203;
+},
+{
+glyphname = u1B204;
+lastChange = "2020-04-13 08:47:58 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"580 618 LINE",
+"533 517 OFFCURVE",
+"493 430 OFFCURVE",
+"449 355 CURVE SMOOTH",
+"411 291 OFFCURVE",
+"373 221 OFFCURVE",
+"331 152 CURVE",
+"327 152 LINE",
+"290 189 OFFCURVE",
+"245 225 OFFCURVE",
+"207 252 CURVE SMOOTH",
+"177 273 OFFCURVE",
+"145 295 OFFCURVE",
+"111 317 CURVE",
+"70 255 LINE",
+"153 204 OFFCURVE",
+"231 151 OFFCURVE",
+"300 96 CURVE",
+"380 110 LINE",
+"438 195 OFFCURVE",
+"488 268 OFFCURVE",
+"533 355 CURVE SMOOTH",
+"569 425 OFFCURVE",
+"607 505 OFFCURVE",
+"630 567 CURVE",
+"634 567 LINE",
+"683 528 OFFCURVE",
+"723 500 OFFCURVE",
+"772 462 CURVE SMOOTH",
+"802 439 OFFCURVE",
+"832 414 OFFCURVE",
+"864 387 CURVE",
+"912 443 LINE",
+"826 517 OFFCURVE",
+"743 579 OFFCURVE",
+"658 637 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"293 453 OFFCURVE",
+"381 392 OFFCURVE",
+"460 335 CURVE",
+"486 321 LINE",
+"560 267 OFFCURVE",
+"625 214 OFFCURVE",
+"681 164 CURVE",
+"687 205 LINE",
+"602 53 OFFCURVE",
+"553 -24 OFFCURVE",
+"449 -160 CURVE",
+"505 -203 LINE",
+"618 -56 OFFCURVE",
+"680 39 OFFCURVE",
+"762 196 CURVE",
+"688 261 OFFCURVE",
+"606 326 OFFCURVE",
+"522 388 CURVE",
+"496 402 LINE",
+"426 453 OFFCURVE",
+"355 502 OFFCURVE",
+"286 548 CURVE",
+"279 514 LINE",
+"361 632 OFFCURVE",
+"429 748 OFFCURVE",
+"507 906 CURVE",
+"440 939 LINE",
+"366 788 OFFCURVE",
+"302 676 OFFCURVE",
+"197 516 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 982;
+}
+);
+unicode = 1B204;
+},
+{
+glyphname = u1B205;
+lastChange = "2020-04-13 08:47:39 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"559 720 LINE",
+"508 671 OFFCURVE",
+"456 624 OFFCURVE",
+"401 577 CURVE",
+"358 545 LINE",
+"300 496 OFFCURVE",
+"238 449 OFFCURVE",
+"172 399 CURVE",
+"192 326 LINE",
+"259 376 OFFCURVE",
+"320 424 OFFCURVE",
+"380 472 CURVE",
+"414 499 LINE",
+"481 553 OFFCURVE",
+"546 609 OFFCURVE",
+"614 670 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 713 LINE",
+"340 581 OFFCURVE",
+"370 446 OFFCURVE",
+"387 310 CURVE",
+"389 266 LINE",
+"394 201 OFFCURVE",
+"397 135 OFFCURVE",
+"397 68 CURVE SMOOTH",
+"397 -28 OFFCURVE",
+"394 -107 OFFCURVE",
+"383 -193 CURVE",
+"458 -203 LINE",
+"470 -104 OFFCURVE",
+"473 -28 OFFCURVE",
+"473 75 CURVE SMOOTH",
+"473 155 OFFCURVE",
+"468 238 OFFCURVE",
+"458 321 CURVE",
+"451 368 LINE",
+"432 500 OFFCURVE",
+"398 642 OFFCURVE",
+"359 767 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"501 929 LINE",
+"362 797 OFFCURVE",
+"235 691 OFFCURVE",
+"100 586 CURVE",
+"132 439 OFFCURVE",
+"162 290 OFFCURVE",
+"176 159 CURVE",
+"253 134 LINE",
+"305 171 OFFCURVE",
+"358 209 OFFCURVE",
+"412 248 CURVE",
+"453 276 LINE",
+"521 326 OFFCURVE",
+"590 381 OFFCURVE",
+"669 446 CURVE",
+"647 600 OFFCURVE",
+"615 761 OFFCURVE",
+"575 914 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"520 851 LINE",
+"535 769 OFFCURVE",
+"549 693 OFFCURVE",
+"563 625 CURVE SMOOTH",
+"571 587 OFFCURVE",
+"581 521 OFFCURVE",
+"588 459 CURVE",
+"627 509 LINE",
+"561 452 OFFCURVE",
+"496 402 OFFCURVE",
+"434 354 CURVE",
+"397 329 LINE",
+"335 283 OFFCURVE",
+"291 251 OFFCURVE",
+"236 207 CURVE",
+"232 208 LINE",
+"229 291 OFFCURVE",
+"221 371 OFFCURVE",
+"209 433 CURVE SMOOTH",
+"197 496 OFFCURVE",
+"188 535 OFFCURVE",
+"174 595 CURVE",
+"150 531 LINE",
+"213 578 OFFCURVE",
+"279 631 OFFCURVE",
+"346 687 CURVE SMOOTH",
+"409 739 OFFCURVE",
+"456 785 OFFCURVE",
+"516 851 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 759;
+}
+);
+unicode = 1B205;
+},
+{
+glyphname = u1B206;
+lastChange = "2020-04-13 08:47:35 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"488 -34 LINE",
+"460 95 OFFCURVE",
+"420 230 OFFCURVE",
+"360 387 CURVE",
+"312 313 LINE",
+"361 185 OFFCURVE",
+"401 44 OFFCURVE",
+"423 -69 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"415 523 LINE",
+"353 407 OFFCURVE",
+"257 289 OFFCURVE",
+"170 205 CURVE",
+"222 154 LINE",
+"313 240 OFFCURVE",
+"409 359 OFFCURVE",
+"479 487 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"498 335 LINE",
+"467 286 OFFCURVE",
+"436 243 OFFCURVE",
+"404 203 CURVE",
+"381 181 LINE",
+"335 127 OFFCURVE",
+"287 80 OFFCURVE",
+"234 35 CURVE",
+"284 -22 LINE",
+"327 14 OFFCURVE",
+"368 52 OFFCURVE",
+"408 96 CURVE",
+"433 119 LINE",
+"476 169 OFFCURVE",
+"519 227 OFFCURVE",
+"561 295 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"597 178 LINE",
+"507 39 OFFCURVE",
+"421 -55 OFFCURVE",
+"296 -146 CURVE",
+"343 -203 LINE",
+"471 -108 OFFCURVE",
+"564 -13 OFFCURVE",
+"657 135 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"365 939 LINE",
+"294 694 OFFCURVE",
+"222 562 OFFCURVE",
+"80 398 CURVE",
+"137 348 LINE",
+"286 526 OFFCURVE",
+"362 655 OFFCURVE",
+"441 923 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"364 784 LINE",
+"488 642 OFFCURVE",
+"575 526 OFFCURVE",
+"645 383 CURVE",
+"712 420 LINE",
+"623 586 OFFCURVE",
+"541 694 OFFCURVE",
+"413 838 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 802;
+}
+);
+leftMetricsKey = u1B185;
+rightMetricsKey = u1B185;
+unicode = 1B206;
+},
+{
+glyphname = u1B207;
+lastChange = "2020-04-13 08:47:21 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"475 391 LINE",
+"441 165 OFFCURVE",
+"399 12 OFFCURVE",
+"289 -163 CURVE",
+"351 -200 LINE",
+"455 -28 OFFCURVE",
+"513 137 OFFCURVE",
+"549 383 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"475 240 LINE",
+"586 94 OFFCURVE",
+"644 -13 OFFCURVE",
+"707 -157 CURVE",
+"774 -126 LINE",
+"700 34 OFFCURVE",
+"636 146 OFFCURVE",
+"521 293 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"280 350 LINE",
+"399 520 OFFCURVE",
+"473 673 OFFCURVE",
+"529 904 CURVE",
+"455 919 LINE",
+"400 691 OFFCURVE",
+"334 558 OFFCURVE",
+"218 394 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"466 769 LINE",
+"580 633 OFFCURVE",
+"651 508 OFFCURVE",
+"714 372 CURVE",
+"779 407 LINE",
+"701 568 OFFCURVE",
+"632 679 OFFCURVE",
+"507 834 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"155 300 LINE",
+"218 240 OFFCURVE",
+"242 183 OFFCURVE",
+"242 104 CURVE SMOOTH",
+"242 24 OFFCURVE",
+"221 -31 OFFCURVE",
+"167 -90 CURVE",
+"222 -133 LINE",
+"285 -60 OFFCURVE",
+"316 8 OFFCURVE",
+"316 102 CURVE SMOOTH",
+"316 201 OFFCURVE",
+"282 273 OFFCURVE",
+"206 348 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"130 52 OFFCURVE",
+"153 69 OFFCURVE",
+"153 108 CURVE SMOOTH",
+"153 147 OFFCURVE",
+"130 164 OFFCURVE",
+"102 164 CURVE SMOOTH",
+"73 164 OFFCURVE",
+"50 147 OFFCURVE",
+"50 108 CURVE SMOOTH",
+"50 69 OFFCURVE",
+"73 52 OFFCURVE",
+"102 52 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 869;
+}
+);
+leftMetricsKey = u1B1D7;
+rightMetricsKey = u1B185;
+unicode = 1B207;
+},
+{
+glyphname = u1B208;
+lastChange = "2020-04-13 08:47:18 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"80 -95 OFFCURVE",
+"109 -143 OFFCURVE",
+"177 -183 CURVE",
+"248 -174 LINE",
+"316 -95 OFFCURVE",
+"334 -30 OFFCURVE",
+"334 31 CURVE SMOOTH",
+"334 91 OFFCURVE",
+"300 132 OFFCURVE",
+"232 170 CURVE",
+"158 160 LINE",
+"100 78 OFFCURVE",
+"80 11 OFFCURVE",
+"80 -38 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 116 LINE",
+"244 84 OFFCURVE",
+"259 49 OFFCURVE",
+"259 20 CURVE SMOOTH",
+"259 -23 OFFCURVE",
+"249 -68 OFFCURVE",
+"209 -132 CURVE",
+"204 -133 LINE",
+"169 -98 OFFCURVE",
+"154 -67 OFFCURVE",
+"154 -34 CURVE SMOOTH",
+"154 8 OFFCURVE",
+"167 52 OFFCURVE",
+"199 115 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"655 665 LINE",
+"608 604 OFFCURVE",
+"560 548 OFFCURVE",
+"509 495 CURVE",
+"475 464 LINE",
+"418 406 OFFCURVE",
+"359 351 OFFCURVE",
+"298 299 CURVE",
+"344 243 LINE",
+"402 291 OFFCURVE",
+"453 338 OFFCURVE",
+"501 387 CURVE",
+"527 408 LINE",
+"588 473 OFFCURVE",
+"646 540 OFFCURVE",
+"712 619 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"578 939 LINE",
+"465 771 OFFCURVE",
+"350 645 OFFCURVE",
+"196 502 CURVE",
+"248 445 LINE",
+"394 584 OFFCURVE",
+"524 722 OFFCURVE",
+"643 898 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"699 377 LINE",
+"592 250 OFFCURVE",
+"493 153 OFFCURVE",
+"371 60 CURVE",
+"416 0 LINE",
+"555 110 OFFCURVE",
+"648 205 OFFCURVE",
+"757 332 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"411 634 LINE",
+"462 472 OFFCURVE",
+"493 318 OFFCURVE",
+"511 157 CURVE",
+"580 187 LINE",
+"561 357 OFFCURVE",
+"525 515 OFFCURVE",
+"470 709 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 837;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B197;
+unicode = 1B208;
+},
+{
+glyphname = u1B209;
+lastChange = "2020-04-13 08:46:52 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"173 297 LINE",
+"164 182 OFFCURVE",
+"147 100 OFFCURVE",
+"109 -2 CURVE",
+"175 -27 LINE",
+"217 88 OFFCURVE",
+"231 162 OFFCURVE",
+"243 291 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"50 137 LINE",
+"90 128 OFFCURVE",
+"126 119 OFFCURVE",
+"160 109 CURVE",
+"193 103 LINE",
+"227 91 OFFCURVE",
+"260 77 OFFCURVE",
+"294 61 CURVE",
+"324 125 LINE",
+"286 142 OFFCURVE",
+"251 157 OFFCURVE",
+"216 169 CURVE",
+"175 178 LINE",
+"140 189 OFFCURVE",
+"105 197 OFFCURVE",
+"65 206 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"591 939 LINE",
+"500 789 OFFCURVE",
+"401 669 OFFCURVE",
+"274 550 CURVE",
+"344 392 OFFCURVE",
+"365 299 OFFCURVE",
+"365 167 CURVE SMOOTH",
+"365 37 OFFCURVE",
+"338 -60 OFFCURVE",
+"289 -177 CURVE",
+"358 -203 LINE",
+"411 -84 OFFCURVE",
+"439 32 OFFCURVE",
+"439 167 CURVE SMOOTH",
+"439 299 OFFCURVE",
+"413 414 OFFCURVE",
+"347 568 CURVE",
+"333 511 LINE",
+"453 623 OFFCURVE",
+"562 743 OFFCURVE",
+"658 902 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"731 653 LINE",
+"686 597 OFFCURVE",
+"643 549 OFFCURVE",
+"599 505 CURVE",
+"580 492 LINE",
+"516 432 OFFCURVE",
+"449 380 OFFCURVE",
+"370 327 CURVE",
+"392 257 LINE",
+"469 304 OFFCURVE",
+"536 353 OFFCURVE",
+"599 408 CURVE",
+"617 419 LINE",
+"677 474 OFFCURVE",
+"734 535 OFFCURVE",
+"790 606 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"475 716 LINE",
+"570 476 OFFCURVE",
+"609 297 OFFCURVE",
+"631 87 CURVE",
+"705 93 LINE",
+"678 327 OFFCURVE",
+"634 514 OFFCURVE",
+"528 778 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 880;
+}
+);
+leftMetricsKey = u1B1AC;
+rightMetricsKey = u1B1A5;
+unicode = 1B209;
+},
+{
+glyphname = u1B20A;
+lastChange = "2020-04-13 08:51:22 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"369 595 LINE",
+"483 504 OFFCURVE",
+"592 408 OFFCURVE",
+"689 307 CURVE",
+"743 358 LINE",
+"705 397 OFFCURVE",
+"676 423 OFFCURVE",
+"607 488 CURVE",
+"591 488 LINE",
+"541 540 OFFCURVE",
+"485 595 OFFCURVE",
+"418 646 CURVE",
+"418 614 LINE",
+"469 675 OFFCURVE",
+"522 749 OFFCURVE",
+"562 818 CURVE",
+"596 850 LINE",
+"607 867 OFFCURVE",
+"618 885 OFFCURVE",
+"629 903 CURVE",
+"566 939 LINE",
+"500 827 OFFCURVE",
+"433 740 OFFCURVE",
+"369 666 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"531 818 LINE",
+"566 818 LINE",
+"609 752 OFFCURVE",
+"626 706 OFFCURVE",
+"626 655 CURVE SMOOTH",
+"626 597 OFFCURVE",
+"618 559 OFFCURVE",
+"595 488 CURVE",
+"586 488 LINE",
+"542 383 OFFCURVE",
+"501 319 OFFCURVE",
+"442 227 CURVE",
+"503 186 LINE",
+"557 269 OFFCURVE",
+"592 338 OFFCURVE",
+"622 398 CURVE",
+"643 432 LINE",
+"683 522 OFFCURVE",
+"698 590 OFFCURVE",
+"698 656 CURVE SMOOTH",
+"698 725 OFFCURVE",
+"675 796 OFFCURVE",
+"578 887 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"100 224 LINE",
+"238 113 OFFCURVE",
+"346 15 OFFCURVE",
+"453 -109 CURVE",
+"509 -63 LINE",
+"458 -5 OFFCURVE",
+"416 42 OFFCURVE",
+"328 125 CURVE",
+"314 125 LINE",
+"267 179 OFFCURVE",
+"216 221 OFFCURVE",
+"146 278 CURVE",
+"147 234 LINE",
+"205 300 OFFCURVE",
+"267 383 OFFCURVE",
+"306 451 CURVE",
+"330 473 LINE",
+"340 487 OFFCURVE",
+"352 507 OFFCURVE",
+"362 523 CURVE",
+"298 560 LINE",
+"234 459 OFFCURVE",
+"168 371 OFFCURVE",
+"100 295 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"278 451 LINE",
+"310 451 LINE",
+"338 391 OFFCURVE",
+"352 339 OFFCURVE",
+"352 278 CURVE SMOOTH",
+"352 236 OFFCURVE",
+"342 189 OFFCURVE",
+"318 125 CURVE",
+"309 125 LINE",
+"253 18 OFFCURVE",
+"199 -51 OFFCURVE",
+"116 -161 CURVE",
+"177 -203 LINE",
+"248 -107 OFFCURVE",
+"297 -29 OFFCURVE",
+"335 38 CURVE",
+"359 73 LINE",
+"405 159 OFFCURVE",
+"424 223 OFFCURVE",
+"424 277 CURVE SMOOTH",
+"424 353 OFFCURVE",
+"400 426 OFFCURVE",
+"327 512 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 853;
+}
+);
+unicode = 1B20A;
+},
+{
+glyphname = u1B20B;
+lastChange = "2020-04-13 08:51:46 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"812 549 LINE",
+"788 504 OFFCURVE",
+"765 464 OFFCURVE",
+"743 427 CURVE SMOOTH",
+"704 361 OFFCURVE",
+"662 297 OFFCURVE",
+"619 239 CURVE",
+"614 240 LINE",
+"581 309 OFFCURVE",
+"546 370 OFFCURVE",
+"504 433 CURVE SMOOTH",
+"468 487 OFFCURVE",
+"431 539 OFFCURVE",
+"393 589 CURVE",
+"380 499 LINE",
+"483 648 OFFCURVE",
+"544 743 OFFCURVE",
+"622 895 CURVE",
+"553 926 LINE",
+"476 776 OFFCURVE",
+"415 684 OFFCURVE",
+"324 550 CURVE",
+"414 438 OFFCURVE",
+"498 311 OFFCURVE",
+"566 187 CURVE",
+"655 177 LINE",
+"748 287 OFFCURVE",
+"805 375 OFFCURVE",
+"879 513 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"366 424 LINE",
+"323 376 OFFCURVE",
+"284 337 OFFCURVE",
+"245 299 CURVE",
+"218 283 LINE",
+"173 243 OFFCURVE",
+"126 205 OFFCURVE",
+"70 164 CURVE",
+"116 105 LINE",
+"168 143 OFFCURVE",
+"212 179 OFFCURVE",
+"254 216 CURVE",
+"283 234 LINE",
+"329 276 OFFCURVE",
+"373 322 OFFCURVE",
+"422 374 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 226 LINE",
+"431 175 OFFCURVE",
+"388 134 OFFCURVE",
+"344 96 CURVE",
+"311 76 LINE",
+"262 36 OFFCURVE",
+"211 -1 OFFCURVE",
+"150 -40 CURVE",
+"192 -99 LINE",
+"242 -65 OFFCURVE",
+"290 -32 OFFCURVE",
+"337 6 CURVE",
+"367 22 LINE",
+"420 66 OFFCURVE",
+"473 116 OFFCURVE",
+"531 175 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"441 -186 LINE",
+"382 78 OFFCURVE",
+"311 229 OFFCURVE",
+"179 463 CURVE",
+"112 426 LINE",
+"248 187 OFFCURVE",
+"311 46 OFFCURVE",
+"366 -203 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 919;
+}
+);
+leftMetricsKey = u1B1ED;
+rightMetricsKey = u1B1CE;
+unicode = 1B20B;
+},
+{
+glyphname = u1B20C;
+lastChange = "2020-04-13 08:51:48 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"233 909 LINE",
+"260 849 OFFCURVE",
+"283 786 OFFCURVE",
+"302 727 CURVE",
+"314 691 LINE",
+"352 555 OFFCURVE",
+"374 428 OFFCURVE",
+"388 315 CURVE",
+"392 261 LINE",
+"397 191 OFFCURVE",
+"399 126 OFFCURVE",
+"399 68 CURVE SMOOTH",
+"399 -57 OFFCURVE",
+"395 -115 OFFCURVE",
+"385 -193 CURVE",
+"460 -203 LINE",
+"470 -124 OFFCURVE",
+"475 -57 OFFCURVE",
+"475 68 CURVE SMOOTH",
+"475 149 OFFCURVE",
+"471 234 OFFCURVE",
+"461 323 CURVE",
+"453 369 LINE",
+"435 483 OFFCURVE",
+"412 604 OFFCURVE",
+"377 731 CURVE",
+"362 776 LINE",
+"344 830 OFFCURVE",
+"324 885 OFFCURVE",
+"301 939 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"559 721 LINE",
+"507 671 OFFCURVE",
+"454 623 OFFCURVE",
+"399 576 CURVE",
+"363 549 LINE",
+"303 500 OFFCURVE",
+"239 451 OFFCURVE",
+"172 400 CURVE",
+"192 328 LINE",
+"258 378 OFFCURVE",
+"319 424 OFFCURVE",
+"377 472 CURVE",
+"417 502 LINE",
+"483 556 OFFCURVE",
+"547 611 OFFCURVE",
+"614 671 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"501 926 LINE",
+"447 875 OFFCURVE",
+"395 827 OFFCURVE",
+"343 783 CURVE",
+"309 756 LINE",
+"239 696 OFFCURVE",
+"171 641 OFFCURVE",
+"100 586 CURVE",
+"132 439 OFFCURVE",
+"162 290 OFFCURVE",
+"176 159 CURVE",
+"254 136 LINE",
+"303 169 OFFCURVE",
+"354 206 OFFCURVE",
+"406 244 CURVE",
+"448 272 LINE",
+"517 324 OFFCURVE",
+"588 380 OFFCURVE",
+"669 446 CURVE",
+"647 600 OFFCURVE",
+"615 758 OFFCURVE",
+"575 911 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"521 850 LINE",
+"539 762 OFFCURVE",
+"554 676 OFFCURVE",
+"566 617 CURVE SMOOTH",
+"574 576 OFFCURVE",
+"584 514 OFFCURVE",
+"590 456 CURVE",
+"630 512 LINE",
+"566 458 OFFCURVE",
+"504 407 OFFCURVE",
+"443 361 CURVE",
+"402 333 LINE",
+"355 297 OFFCURVE",
+"304 261 OFFCURVE",
+"242 209 CURVE",
+"237 210 LINE",
+"232 307 OFFCURVE",
+"219 380 OFFCURVE",
+"209 428 CURVE SMOOTH",
+"202 463 OFFCURVE",
+"188 531 OFFCURVE",
+"173 595 CURVE",
+"150 532 LINE",
+"209 576 OFFCURVE",
+"270 626 OFFCURVE",
+"333 679 CURVE",
+"371 708 LINE",
+"425 754 OFFCURVE",
+"462 794 OFFCURVE",
+"516 851 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 759;
+}
+);
+leftMetricsKey = u1B205;
+rightMetricsKey = u1B205;
+unicode = 1B20C;
+},
+{
+glyphname = u1B20D;
+lastChange = "2020-04-13 09:04:08 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"374 609 LINE",
+"442 389 OFFCURVE",
+"482 185 OFFCURVE",
+"509 -61 CURVE",
+"578 -34 LINE",
+"551 218 OFFCURVE",
+"504 433 OFFCURVE",
+"431 674 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"603 493 LINE",
+"565 446 OFFCURVE",
+"526 401 OFFCURVE",
+"484 359 CURVE",
+"461 344 LINE",
+"412 297 OFFCURVE",
+"361 252 OFFCURVE",
+"307 209 CURVE",
+"352 150 LINE",
+"398 187 OFFCURVE",
+"441 224 OFFCURVE",
+"482 263 CURVE",
+"508 280 LINE",
+"563 332 OFFCURVE",
+"613 386 OFFCURVE",
+"662 446 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"714 160 LINE",
+"592 34 OFFCURVE",
+"487 -48 OFFCURVE",
+"350 -142 CURVE",
+"390 -203 LINE",
+"521 -115 OFFCURVE",
+"644 -18 OFFCURVE",
+"769 110 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"677 696 LINE",
+"718 544 OFFCURVE",
+"741 408 OFFCURVE",
+"759 246 CURVE",
+"833 256 LINE",
+"814 431 OFFCURVE",
+"790 562 OFFCURVE",
+"749 715 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"120 323 LINE",
+"159 195 OFFCURVE",
+"188 66 OFFCURVE",
+"208 -70 CURVE",
+"281 -57 LINE",
+"258 86 OFFCURVE",
+"230 220 OFFCURVE",
+"190 348 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"547 939 LINE",
+"431 748 OFFCURVE",
+"317 602 OFFCURVE",
+"185 468 CURVE",
+"238 415 LINE",
+"378 562 OFFCURVE",
+"492 704 OFFCURVE",
+"616 906 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"603 493 LINE",
+"565 446 OFFCURVE",
+"526 401 OFFCURVE",
+"484 359 CURVE",
+"461 344 LINE",
+"412 297 OFFCURVE",
+"361 252 OFFCURVE",
+"307 209 CURVE",
+"352 150 LINE",
+"398 187 OFFCURVE",
+"441 224 OFFCURVE",
+"482 263 CURVE",
+"508 280 LINE",
+"563 332 OFFCURVE",
+"613 386 OFFCURVE",
+"662 446 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 973;
+}
+);
+leftMetricsKey = u1B17E;
+rightMetricsKey = u1B1AB;
+unicode = 1B20D;
+},
+{
+glyphname = u1B20E;
+lastChange = "2020-04-13 08:52:09 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"258 574 LINE",
+"311 496 OFFCURVE",
+"360 419 OFFCURVE",
+"405 340 CURVE",
+"434 296 LINE",
+"474 225 OFFCURVE",
+"511 152 OFFCURVE",
+"549 74 CURVE",
+"598 138 LINE",
+"562 215 OFFCURVE",
+"522 292 OFFCURVE",
+"478 369 CURVE",
+"446 417 LINE",
+"405 488 OFFCURVE",
+"359 559 OFFCURVE",
+"309 632 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"558 648 LINE",
+"468 462 OFFCURVE",
+"381 316 OFFCURVE",
+"265 158 CURVE",
+"310 98 LINE",
+"431 261 OFFCURVE",
+"512 396 OFFCURVE",
+"607 584 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"391 872 LINE",
+"297 670 OFFCURVE",
+"189 483 OFFCURVE",
+"90 340 CURVE",
+"212 160 OFFCURVE",
+"295 7 OFFCURVE",
+"361 -143 CURVE",
+"454 -150 LINE",
+"571 12 OFFCURVE",
+"682 176 OFFCURVE",
+"770 366 CURVE",
+"685 546 OFFCURVE",
+"604 690 OFFCURVE",
+"481 880 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"442 806 LINE",
+"496 709 OFFCURVE",
+"536 650 OFFCURVE",
+"579 573 CURVE SMOOTH",
+"627 487 OFFCURVE",
+"671 399 OFFCURVE",
+"716 298 CURVE",
+"721 433 LINE",
+"669 326 OFFCURVE",
+"617 232 OFFCURVE",
+"565 148 CURVE SMOOTH",
+"513 65 OFFCURVE",
+"458 -20 OFFCURVE",
+"415 -87 CURVE",
+"411 -87 LINE",
+"381 -5 OFFCURVE",
+"341 76 OFFCURVE",
+"295 157 CURVE SMOOTH",
+"253 230 OFFCURVE",
+"206 305 OFFCURVE",
+"153 383 CURVE",
+"146 285 LINE",
+"208 378 OFFCURVE",
+"263 467 OFFCURVE",
+"315 557 CURVE SMOOTH",
+"362 639 OFFCURVE",
+"395 706 OFFCURVE",
+"437 805 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 860;
+}
+);
+leftMetricsKey = u1B1B4;
+rightMetricsKey = u1B1B4;
+unicode = 1B20E;
+},
+{
+glyphname = u1B20F;
+lastChange = "2020-04-13 08:52:12 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"365 920 LINE",
+"289 686 OFFCURVE",
+"226 522 OFFCURVE",
+"147 370 CURVE",
+"162 298 LINE",
+"267 227 OFFCURVE",
+"395 124 OFFCURVE",
+"513 10 CURVE",
+"589 44 LINE",
+"564 366 OFFCURVE",
+"520 628 OFFCURVE",
+"453 924 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"150 85 OFFCURVE",
+"173 102 OFFCURVE",
+"173 141 CURVE SMOOTH",
+"173 180 OFFCURVE",
+"150 197 OFFCURVE",
+"122 197 CURVE SMOOTH",
+"93 197 OFFCURVE",
+"70 180 OFFCURVE",
+"70 141 CURVE SMOOTH",
+"70 102 OFFCURVE",
+"93 85 OFFCURVE",
+"122 85 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"313 -63 OFFCURVE",
+"336 -46 OFFCURVE",
+"336 -7 CURVE SMOOTH",
+"336 32 OFFCURVE",
+"313 49 OFFCURVE",
+"285 49 CURVE SMOOTH",
+"256 49 OFFCURVE",
+"233 32 OFFCURVE",
+"233 -7 CURVE SMOOTH",
+"233 -46 OFFCURVE",
+"256 -63 OFFCURVE",
+"285 -63 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"487 -203 OFFCURVE",
+"510 -186 OFFCURVE",
+"510 -147 CURVE SMOOTH",
+"510 -108 OFFCURVE",
+"487 -91 OFFCURVE",
+"459 -91 CURVE SMOOTH",
+"430 -91 OFFCURVE",
+"407 -108 OFFCURVE",
+"407 -147 CURVE SMOOTH",
+"407 -186 OFFCURVE",
+"430 -203 OFFCURVE",
+"459 -203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"407 848 LINE",
+"419 745 OFFCURVE",
+"436 652 OFFCURVE",
+"451 560 CURVE SMOOTH",
+"464 482 OFFCURVE",
+"476 406 OFFCURVE",
+"486 327 CURVE SMOOTH",
+"495 259 OFFCURVE",
+"503 167 OFFCURVE",
+"520 90 CURVE",
+"515 89 LINE",
+"462 150 OFFCURVE",
+"417 198 OFFCURVE",
+"364 241 CURVE SMOOTH",
+"318 279 OFFCURVE",
+"270 315 OFFCURVE",
+"209 359 CURVE",
+"208 319 LINE",
+"246 396 OFFCURVE",
+"277 464 OFFCURVE",
+"306 538 CURVE SMOOTH",
+"340 624 OFFCURVE",
+"374 725 OFFCURVE",
+"403 848 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 719;
+}
+);
+unicode = 1B20F;
+},
+{
+glyphname = u1B210;
+lastChange = "2020-04-13 08:52:15 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"160 263 OFFCURVE",
+"183 280 OFFCURVE",
+"183 319 CURVE SMOOTH",
+"183 358 OFFCURVE",
+"160 375 OFFCURVE",
+"132 375 CURVE SMOOTH",
+"103 375 OFFCURVE",
+"80 358 OFFCURVE",
+"80 319 CURVE SMOOTH",
+"80 280 OFFCURVE",
+"103 263 OFFCURVE",
+"132 263 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"788 342 OFFCURVE",
+"811 359 OFFCURVE",
+"811 398 CURVE SMOOTH",
+"811 437 OFFCURVE",
+"788 454 OFFCURVE",
+"760 454 CURVE SMOOTH",
+"731 454 OFFCURVE",
+"708 437 OFFCURVE",
+"708 398 CURVE SMOOTH",
+"708 359 OFFCURVE",
+"731 342 OFFCURVE",
+"760 342 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"504 939 LINE",
+"416 634 OFFCURVE",
+"314 384 OFFCURVE",
+"150 99 CURVE",
+"216 64 LINE",
+"259 139 OFFCURVE",
+"296 209 OFFCURVE",
+"330 277 CURVE",
+"344 327 LINE",
+"380 401 OFFCURVE",
+"406 460 OFFCURVE",
+"431 520 CURVE",
+"458 566 LINE",
+"501 677 OFFCURVE",
+"538 787 OFFCURVE",
+"577 919 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"202 769 LINE",
+"269 695 OFFCURVE",
+"329 624 OFFCURVE",
+"385 553 CURVE",
+"418 523 LINE",
+"466 459 OFFCURVE",
+"505 405 OFFCURVE",
+"544 349 CURVE",
+"566 305 LINE",
+"611 238 OFFCURVE",
+"656 167 OFFCURVE",
+"701 91 CURVE",
+"761 130 LINE",
+"595 409 OFFCURVE",
+"455 596 OFFCURVE",
+"255 818 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"659 673 LINE",
+"630 592 OFFCURVE",
+"598 507 OFFCURVE",
+"564 424 CURVE",
+"551 376 LINE",
+"525 313 OFFCURVE",
+"497 249 OFFCURVE",
+"460 172 CURVE",
+"440 146 LINE",
+"390 41 OFFCURVE",
+"336 -63 OFFCURVE",
+"277 -168 CURVE",
+"342 -203 LINE",
+"494 68 OFFCURVE",
+"621 346 OFFCURVE",
+"729 651 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"120 521 LINE",
+"316 301 OFFCURVE",
+"470 64 OFFCURVE",
+"598 -168 CURVE",
+"662 -135 LINE",
+"608 -36 OFFCURVE",
+"551 59 OFFCURVE",
+"491 151 CURVE",
+"473 172 LINE",
+"424 241 OFFCURVE",
+"386 296 OFFCURVE",
+"337 363 CURVE",
+"315 398 LINE",
+"270 457 OFFCURVE",
+"222 515 OFFCURVE",
+"173 573 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 891;
+}
+);
+leftMetricsKey = u1B176;
+rightMetricsKey = u1B177;
+unicode = 1B210;
+},
+{
+glyphname = u1B211;
+lastChange = "2020-04-13 08:52:20 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"552 585 LINE",
+"427 512 OFFCURVE",
+"314 455 OFFCURVE",
+"179 400 CURVE",
+"209 334 LINE",
+"348 392 OFFCURVE",
+"464 449 OFFCURVE",
+"591 525 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"520 438 OFFCURVE",
+"527 415 OFFCURVE",
+"527 390 CURVE SMOOTH",
+"527 342 OFFCURVE",
+"465 304 OFFCURVE",
+"218 215 CURVE",
+"244 147 LINE",
+"518 252 OFFCURVE",
+"601 287 OFFCURVE",
+"601 388 CURVE SMOOTH",
+"601 427 OFFCURVE",
+"584 471 OFFCURVE",
+"543 520 CURVE",
+"493 483 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"644 254 LINE",
+"508 174 OFFCURVE",
+"383 122 OFFCURVE",
+"231 66 CURVE",
+"256 -2 LINE",
+"408 54 OFFCURVE",
+"538 108 OFFCURVE",
+"682 193 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"612 110 OFFCURVE",
+"621 89 OFFCURVE",
+"621 64 CURVE SMOOTH",
+"621 2 OFFCURVE",
+"590 -36 OFFCURVE",
+"277 -135 CURVE",
+"301 -203 LINE",
+"621 -100 OFFCURVE",
+"695 -42 OFFCURVE",
+"695 57 CURVE SMOOTH",
+"695 98 OFFCURVE",
+"683 134 OFFCURVE",
+"624 201 CURVE",
+"580 156 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"427 939 LINE",
+"328 748 OFFCURVE",
+"225 625 OFFCURVE",
+"80 497 CURVE",
+"129 444 LINE",
+"274 574 OFFCURVE",
+"388 704 OFFCURVE",
+"493 910 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"419 818 LINE",
+"540 715 OFFCURVE",
+"643 606 OFFCURVE",
+"741 469 CURVE",
+"799 513 LINE",
+"696 653 OFFCURVE",
+"601 755 OFFCURVE",
+"457 879 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 889;
+}
+);
+leftMetricsKey = u1B185;
+rightMetricsKey = u1B185;
+unicode = 1B211;
+},
+{
+glyphname = u1B212;
+lastChange = "2020-04-13 08:52:22 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"705 789 LINE",
+"643 724 OFFCURVE",
+"606 679 OFFCURVE",
+"567 624 CURVE",
+"542 586 LINE",
+"500 511 OFFCURVE",
+"482 440 OFFCURVE",
+"482 349 CURVE SMOOTH",
+"482 174 OFFCURVE",
+"549 42 OFFCURVE",
+"698 -101 CURVE",
+"747 -55 LINE",
+"604 91 OFFCURVE",
+"552 180 OFFCURVE",
+"552 347 CURVE SMOOTH",
+"552 424 OFFCURVE",
+"563 484 OFFCURVE",
+"585 536 CURVE",
+"604 568 LINE",
+"636 621 OFFCURVE",
+"687 678 OFFCURVE",
+"753 744 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"574 -184 LINE",
+"574 -84 OFFCURVE",
+"581 -35 OFFCURVE",
+"596 25 CURVE",
+"619 83 LINE",
+"646 141 OFFCURVE",
+"684 203 OFFCURVE",
+"745 273 CURVE",
+"693 316 LINE",
+"644 260 OFFCURVE",
+"612 213 OFFCURVE",
+"585 162 CURVE",
+"558 109 LINE",
+"520 14 OFFCURVE",
+"507 -59 OFFCURVE",
+"504 -184 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"168 667 OFFCURVE",
+"221 609 OFFCURVE",
+"259 556 CURVE",
+"278 524 LINE",
+"315 455 OFFCURVE",
+"328 391 OFFCURVE",
+"328 321 CURVE SMOOTH",
+"328 166 OFFCURVE",
+"270 72 OFFCURVE",
+"151 -70 CURVE",
+"204 -115 LINE",
+"331 33 OFFCURVE",
+"400 160 OFFCURVE",
+"400 323 CURVE SMOOTH",
+"400 413 OFFCURVE",
+"380 491 OFFCURVE",
+"331 576 CURVE",
+"304 610 LINE",
+"265 665 OFFCURVE",
+"218 720 OFFCURVE",
+"156 775 CURVE",
+"108 721 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"406 939 LINE",
+"357 725 OFFCURVE",
+"291 605 OFFCURVE",
+"124 429 CURVE",
+"178 381 LINE",
+"287 500 OFFCURVE",
+"369 621 OFFCURVE",
+"411 731 CURVE",
+"434 776 LINE",
+"450 821 OFFCURVE",
+"465 870 OFFCURVE",
+"477 924 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"377 -78 OFFCURVE",
+"360 14 OFFCURVE",
+"322 95 CURVE",
+"293 141 LINE",
+"265 190 OFFCURVE",
+"229 236 OFFCURVE",
+"185 283 CURVE",
+"135 236 LINE",
+"191 177 OFFCURVE",
+"232 118 OFFCURVE",
+"259 62 CURVE",
+"285 11 LINE",
+"305 -49 OFFCURVE",
+"315 -116 OFFCURVE",
+"319 -203 CURVE",
+"388 -198 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"384 731 LINE",
+"415 731 LINE",
+"476 621 OFFCURVE",
+"558 523 OFFCURVE",
+"698 408 CURVE",
+"746 462 LINE",
+"608 577 OFFCURVE",
+"534 665 OFFCURVE",
+"435 808 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 853;
+}
+);
+leftMetricsKey = u1B1BD;
+rightMetricsKey = u1B1BD;
+unicode = 1B212;
+},
+{
+glyphname = u1B213;
+lastChange = "2020-04-13 08:52:38 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"472 -100 LINE",
+"456 14 OFFCURVE",
+"432 145 OFFCURVE",
+"396 296 CURVE",
+"322 278 LINE",
+"357 132 OFFCURVE",
+"382 2 OFFCURVE",
+"398 -107 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"553 221 LINE",
+"503 197 OFFCURVE",
+"452 175 OFFCURVE",
+"401 154 CURVE",
+"375 148 LINE",
+"316 125 OFFCURVE",
+"255 104 OFFCURVE",
+"193 84 CURVE",
+"214 14 LINE",
+"275 33 OFFCURVE",
+"332 52 OFFCURVE",
+"390 74 CURVE",
+"417 80 LINE",
+"473 103 OFFCURVE",
+"529 127 OFFCURVE",
+"588 156 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"635 33 LINE",
+"504 -31 OFFCURVE",
+"379 -81 OFFCURVE",
+"219 -131 CURVE",
+"241 -203 LINE",
+"414 -147 OFFCURVE",
+"538 -100 OFFCURVE",
+"670 -34 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 564 LINE",
+"299 472 OFFCURVE",
+"438 374 OFFCURVE",
+"598 249 CURVE",
+"640 306 LINE",
+"561 367 OFFCURVE",
+"493 416 OFFCURVE",
+"377 496 CURVE",
+"358 496 LINE",
+"303 544 OFFCURVE",
+"243 584 OFFCURVE",
+"178 624 CURVE",
+"179 574 LINE",
+"242 648 OFFCURVE",
+"303 732 OFFCURVE",
+"347 813 CURVE",
+"372 838 LINE",
+"384 858 OFFCURVE",
+"396 883 OFFCURVE",
+"409 905 CURVE",
+"346 939 LINE",
+"268 807 OFFCURVE",
+"214 731 OFFCURVE",
+"140 640 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"483 729 OFFCURVE",
+"458 799 OFFCURVE",
+"367 880 CURVE",
+"317 813 LINE",
+"351 813 LINE",
+"395 761 OFFCURVE",
+"407 716 OFFCURVE",
+"407 662 CURVE SMOOTH",
+"407 618 OFFCURVE",
+"395 554 OFFCURVE",
+"362 496 CURVE",
+"352 496 LINE",
+"292 395 OFFCURVE",
+"202 299 OFFCURVE",
+"80 174 CURVE",
+"132 121 LINE",
+"261 252 OFFCURVE",
+"341 349 OFFCURVE",
+"395 430 CURVE",
+"412 448 LINE",
+"464 530 OFFCURVE",
+"483 594.996 OFFCURVE",
+"483 662 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 750;
+}
+);
+leftMetricsKey = u1B201;
+rightMetricsKey = u1B201;
+unicode = 1B213;
+},
+{
+glyphname = u1B214;
+lastChange = "2020-04-13 08:52:56 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"259 167 LINE",
+"398 53 OFFCURVE",
+"491 -31 OFFCURVE",
+"604 -150 CURVE",
+"659 -102 LINE",
+"607 -48 OFFCURVE",
+"567 -10 OFFCURVE",
+"488 64 CURVE",
+"471 64 LINE",
+"423 117 OFFCURVE",
+"373 167 OFFCURVE",
+"308 221 CURVE",
+"304 179 LINE",
+"373 232 OFFCURVE",
+"445 291 OFFCURVE",
+"497 348 CURVE",
+"532 370 LINE",
+"548 385 OFFCURVE",
+"564 402 OFFCURVE",
+"582 421 CURVE",
+"528 474 LINE",
+"426 370 OFFCURVE",
+"345 303 OFFCURVE",
+"259 238 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"606 278 OFFCURVE",
+"587 332 OFFCURVE",
+"527 408 CURVE",
+"467 348 LINE",
+"501 348 LINE",
+"522 303 OFFCURVE",
+"530 265 OFFCURVE",
+"530 219 CURVE SMOOTH",
+"530 172 OFFCURVE",
+"514 125 OFFCURVE",
+"475 64 CURVE",
+"465 64 LINE",
+"397 -13 OFFCURVE",
+"323 -70 OFFCURVE",
+"222 -147 CURVE",
+"267 -203 LINE",
+"368 -126 OFFCURVE",
+"437 -64 OFFCURVE",
+"489 -10 CURVE",
+"513 11 LINE",
+"582 87 OFFCURVE",
+"606 147 OFFCURVE",
+"606 218 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"494 939 LINE",
+"410 850 OFFCURVE",
+"333 775 OFFCURVE",
+"253 706 CURVE",
+"237 697 LINE",
+"181 649 OFFCURVE",
+"123 604 OFFCURVE",
+"60 558 CURVE",
+"102 497 LINE",
+"161 540 OFFCURVE",
+"216 583 OFFCURVE",
+"271 629 CURVE",
+"288 639 LINE",
+"373 711 OFFCURVE",
+"457 792 OFFCURVE",
+"551 891 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"495 648 LINE",
+"386 544 OFFCURVE",
+"283 461 OFFCURVE",
+"158 368 CURVE",
+"201 308 LINE",
+"337 410 OFFCURVE",
+"428 482 OFFCURVE",
+"548 596 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"131 856 LINE",
+"220 682 OFFCURVE",
+"271 560 OFFCURVE",
+"307 445 CURVE",
+"369 490 LINE",
+"330 609 OFFCURVE",
+"293 708 OFFCURVE",
+"198 889 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 769;
+}
+);
+rightMetricsKey = u1B17C;
+unicode = 1B214;
+},
+{
+glyphname = u1B215;
+lastChange = "2020-04-13 08:53:10 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"252 634 LINE",
+"301 539 OFFCURVE",
+"342 449 OFFCURVE",
+"379 360 CURVE",
+"383 327 LINE",
+"426 220 OFFCURVE",
+"463 114 OFFCURVE",
+"502 2 CURVE",
+"560 33 LINE",
+"517 165 OFFCURVE",
+"477 279 OFFCURVE",
+"430 393 CURVE",
+"424 429 LINE",
+"388 513 OFFCURVE",
+"348 597 OFFCURVE",
+"300 691 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"281 622 OFFCURVE",
+"346 731 OFFCURVE",
+"429 908 CURVE",
+"361 939 LINE",
+"279 767 OFFCURVE",
+"213 649 OFFCURVE",
+"100 494 CURVE",
+"157 376 OFFCURVE",
+"195 286 OFFCURVE",
+"232 184 CURVE",
+"316 175 LINE",
+"360 228 OFFCURVE",
+"397 285 OFFCURVE",
+"427 334 CURVE SMOOTH",
+"468 402 OFFCURVE",
+"491 448 OFFCURVE",
+"517 504 CURVE",
+"521 504 LINE",
+"561 398 OFFCURVE",
+"600 293 OFFCURVE",
+"634 173 CURVE",
+"629 242 LINE",
+"546 88 OFFCURVE",
+"467 -31 OFFCURVE",
+"368 -158 CURVE",
+"427 -203 LINE",
+"543 -53 OFFCURVE",
+"612 54 OFFCURVE",
+"698 219 CURVE",
+"659 349 OFFCURVE",
+"622 450 OFFCURVE",
+"572 566 CURVE",
+"480 573 LINE",
+"447 516 OFFCURVE",
+"422 471 OFFCURVE",
+"387 408 CURVE SMOOTH",
+"354 349 OFFCURVE",
+"326 297 OFFCURVE",
+"286 240 CURVE",
+"281 241 LINE",
+"250 333 OFFCURVE",
+"221 412 OFFCURVE",
+"164 532 CURVE",
+"167 461 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 798;
+}
+);
+leftMetricsKey = u1B1BA;
+rightMetricsKey = u1B1BA;
+unicode = 1B215;
+},
+{
+glyphname = u1B216;
+lastChange = "2020-04-13 08:53:14 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"669 275 LINE",
+"604 222 OFFCURVE",
+"533 172 OFFCURVE",
+"460 124 CURVE",
+"409 96 LINE",
+"338 52 OFFCURVE",
+"266 12 OFFCURVE",
+"196 -25 CURVE",
+"228 -88 LINE",
+"293 -55 OFFCURVE",
+"356 -20 OFFCURVE",
+"417 16 CURVE",
+"461 39 LINE",
+"547 93 OFFCURVE",
+"634 154 OFFCURVE",
+"715 218 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"559 721 LINE",
+"508 671 OFFCURVE",
+"455 624 OFFCURVE",
+"400 578 CURVE",
+"362 549 LINE",
+"302 500 OFFCURVE",
+"239 451 OFFCURVE",
+"172 400 CURVE",
+"192 325 LINE",
+"259 376 OFFCURVE",
+"321 423 OFFCURVE",
+"381 472 CURVE",
+"424 505 LINE",
+"488 557 OFFCURVE",
+"550 611 OFFCURVE",
+"614 669 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"308 713 LINE",
+"348 559 OFFCURVE",
+"377 414 OFFCURVE",
+"389 304 CURVE",
+"391 259 LINE",
+"396 196 OFFCURVE",
+"399 132 OFFCURVE",
+"399 68 CURVE SMOOTH",
+"399 -28 OFFCURVE",
+"396 -107 OFFCURVE",
+"385 -193 CURVE",
+"460 -203 LINE",
+"472 -104 OFFCURVE",
+"475 -28 OFFCURVE",
+"475 75 CURVE SMOOTH",
+"475 152 OFFCURVE",
+"470 233 OFFCURVE",
+"461 314 CURVE",
+"453 360 LINE",
+"438 457 OFFCURVE",
+"408 614 OFFCURVE",
+"363 767 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"496 925 LINE",
+"362 797 OFFCURVE",
+"235 691 OFFCURVE",
+"100 586 CURVE",
+"132 439 OFFCURVE",
+"162 290 OFFCURVE",
+"176 159 CURVE",
+"253 136 LINE",
+"304 170 OFFCURVE",
+"356 207 OFFCURVE",
+"408 245 CURVE",
+"454 277 LINE",
+"521 327 OFFCURVE",
+"590 382 OFFCURVE",
+"669 446 CURVE",
+"647 600 OFFCURVE",
+"615 761 OFFCURVE",
+"578 910 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"521 851 LINE",
+"533 781 OFFCURVE",
+"550 697 OFFCURVE",
+"564 628 CURVE SMOOTH",
+"573 582 OFFCURVE",
+"582 519 OFFCURVE",
+"589 459 CURVE",
+"627 510 LINE",
+"561 454 OFFCURVE",
+"496 401 OFFCURVE",
+"434 354 CURVE",
+"392 326 LINE",
+"349 294 OFFCURVE",
+"295 254 OFFCURVE",
+"241 206 CURVE",
+"236 207 LINE",
+"232 283 OFFCURVE",
+"220 381 OFFCURVE",
+"209 435 CURVE SMOOTH",
+"198 489 OFFCURVE",
+"188 534 OFFCURVE",
+"174 595 CURVE",
+"150 534 LINE",
+"216 583 OFFCURVE",
+"285 638 OFFCURVE",
+"355 698 CURVE SMOOTH",
+"414 748 OFFCURVE",
+"457 788 OFFCURVE",
+"516 852 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 815;
+}
+);
+leftMetricsKey = u1B205;
+unicode = 1B216;
+},
+{
+glyphname = u1B217;
+lastChange = "2020-04-13 08:53:20 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"142 309 OFFCURVE",
+"107 222 OFFCURVE",
+"107 125 CURVE SMOOTH",
+"107 -21 OFFCURVE",
+"189 -119 OFFCURVE",
+"363 -167 CURVE",
+"385 -98 LINE",
+"237 -54 OFFCURVE",
+"183 5 OFFCURVE",
+"183 130 CURVE SMOOTH",
+"183 221 OFFCURVE",
+"214 301 OFFCURVE",
+"326 354 CURVE",
+"325 416 LINE",
+"209 458 OFFCURVE",
+"156 528 OFFCURVE",
+"156 642 CURVE SMOOTH",
+"156 730 OFFCURVE",
+"185 802 OFFCURVE",
+"284 874 CURVE",
+"241 929 LINE",
+"128 848 OFFCURVE",
+"80 751 OFFCURVE",
+"80 642 CURVE SMOOTH",
+"80 521 OFFCURVE",
+"133 424 OFFCURVE",
+"250 383 CURVE",
+"250 379 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"667 640 LINE",
+"585 464 OFFCURVE",
+"499 315 OFFCURVE",
+"414 180 CURVE",
+"456 109 LINE",
+"552 259 OFFCURVE",
+"627 389 OFFCURVE",
+"696 534 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"519 848 LINE",
+"446 678 OFFCURVE",
+"370 536 OFFCURVE",
+"280 387 CURVE",
+"371 208 OFFCURVE",
+"434 72 OFFCURVE",
+"494 -101 CURVE",
+"587 -105 LINE",
+"688 39 OFFCURVE",
+"765 172 OFFCURVE",
+"852 339 CURVE",
+"783 507 OFFCURVE",
+"713 662 OFFCURVE",
+"618 846 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"570 785 LINE",
+"615 690 OFFCURVE",
+"642 632 OFFCURVE",
+"681 549 CURVE SMOOTH",
+"713 480 OFFCURVE",
+"753 385 OFFCURVE",
+"794 276 CURVE",
+"805 409 LINE",
+"761 322 OFFCURVE",
+"719 246 OFFCURVE",
+"679 176 CURVE SMOOTH",
+"638 104 OFFCURVE",
+"593 40 OFFCURVE",
+"547 -36 CURVE",
+"543 -36 LINE",
+"521 38 OFFCURVE",
+"495 106 OFFCURVE",
+"462 180 CURVE SMOOTH",
+"428 256 OFFCURVE",
+"389 337 OFFCURVE",
+"342 430 CURVE",
+"333 335 LINE",
+"382 413 OFFCURVE",
+"423 484 OFFCURVE",
+"461 556 CURVE SMOOTH",
+"501 632 OFFCURVE",
+"530 690 OFFCURVE",
+"566 785 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 942;
+}
+);
+rightMetricsKey = u1B1B4;
+unicode = 1B217;
+},
+{
+glyphname = u1B218;
+lastChange = "2020-04-13 08:53:24 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"130 -18 OFFCURVE",
+"153 -1 OFFCURVE",
+"153 38 CURVE SMOOTH",
+"153 77 OFFCURVE",
+"130 94 OFFCURVE",
+"102 94 CURVE SMOOTH",
+"73 94 OFFCURVE",
+"50 77 OFFCURVE",
+"50 38 CURVE SMOOTH",
+"50 -1 OFFCURVE",
+"73 -18 OFFCURVE",
+"102 -18 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"636 707 LINE",
+"549 548 OFFCURVE",
+"471 429 OFFCURVE",
+"378 305 CURVE",
+"430 254 LINE",
+"534 393 OFFCURVE",
+"603 496 OFFCURVE",
+"675 624 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"485 920 LINE",
+"417 777 OFFCURVE",
+"327 633 OFFCURVE",
+"236 507 CURVE",
+"327 328 OFFCURVE",
+"391 179 OFFCURVE",
+"451 16 CURVE",
+"543 9 LINE",
+"641 131 OFFCURVE",
+"730 263 OFFCURVE",
+"819 414 CURVE",
+"750 582 OFFCURVE",
+"681 732 OFFCURVE",
+"586 917 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"535 858 LINE",
+"567 781 OFFCURVE",
+"606 711 OFFCURVE",
+"642 635 CURVE SMOOTH",
+"684 546 OFFCURVE",
+"721 455 OFFCURVE",
+"761 351 CURVE",
+"764 472 LINE",
+"720 394 OFFCURVE",
+"677 323 OFFCURVE",
+"634 258 CURVE SMOOTH",
+"590 191 OFFCURVE",
+"548 135 OFFCURVE",
+"507 73 CURVE",
+"503 73 LINE",
+"479 152 OFFCURVE",
+"448 229 OFFCURVE",
+"412 309 CURVE SMOOTH",
+"379 383 OFFCURVE",
+"342 462 OFFCURVE",
+"297 550 CURVE",
+"302 470 LINE",
+"351 542 OFFCURVE",
+"375 576 OFFCURVE",
+"412 636 CURVE SMOOTH",
+"457 709 OFFCURVE",
+"493 770 OFFCURVE",
+"531 858 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"155 230 LINE",
+"218 170 OFFCURVE",
+"242 113 OFFCURVE",
+"242 34 CURVE SMOOTH",
+"242 -46 OFFCURVE",
+"221 -101 OFFCURVE",
+"167 -160 CURVE",
+"222 -203 LINE",
+"285 -130 OFFCURVE",
+"316 -62 OFFCURVE",
+"316 32 CURVE SMOOTH",
+"316 131 OFFCURVE",
+"282 203 OFFCURVE",
+"206 278 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 909;
+}
+);
+leftMetricsKey = u1B1D7;
+rightMetricsKey = u1B1B4;
+unicode = 1B218;
+},
+{
+glyphname = u1B219;
+lastChange = "2020-04-13 08:53:38 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"50 176 LINE",
+"147 130 OFFCURVE",
+"217 79 OFFCURVE",
+"291 -22 CURVE",
+"346 23 LINE",
+"271 123 OFFCURVE",
+"185 191 OFFCURVE",
+"82 241 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"294 200 OFFCURVE",
+"317 217 OFFCURVE",
+"317 256 CURVE SMOOTH",
+"317 295 OFFCURVE",
+"294 312 OFFCURVE",
+"266 312 CURVE SMOOTH",
+"237 312 OFFCURVE",
+"214 295 OFFCURVE",
+"214 256 CURVE SMOOTH",
+"214 217 OFFCURVE",
+"237 200 OFFCURVE",
+"266 200 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"175 -73 OFFCURVE",
+"198 -56 OFFCURVE",
+"198 -17 CURVE SMOOTH",
+"198 22 OFFCURVE",
+"175 39 OFFCURVE",
+"147 39 CURVE SMOOTH",
+"118 39 OFFCURVE",
+"95 22 OFFCURVE",
+"95 -17 CURVE SMOOTH",
+"95 -56 OFFCURVE",
+"118 -73 OFFCURVE",
+"147 -73 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"613 939 LINE",
+"522 789 OFFCURVE",
+"423 669 OFFCURVE",
+"296 550 CURVE",
+"366 392 OFFCURVE",
+"387 299 OFFCURVE",
+"387 167 CURVE SMOOTH",
+"387 37 OFFCURVE",
+"360 -60 OFFCURVE",
+"311 -177 CURVE",
+"380 -203 LINE",
+"433 -84 OFFCURVE",
+"461 32 OFFCURVE",
+"461 167 CURVE SMOOTH",
+"461 299 OFFCURVE",
+"435 414 OFFCURVE",
+"369 568 CURVE",
+"355 511 LINE",
+"475 623 OFFCURVE",
+"584 743 OFFCURVE",
+"680 902 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"753 653 LINE",
+"708 597 OFFCURVE",
+"665 549 OFFCURVE",
+"621 505 CURVE",
+"602 492 LINE",
+"538 432 OFFCURVE",
+"471 380 OFFCURVE",
+"392 327 CURVE",
+"414 257 LINE",
+"491 304 OFFCURVE",
+"558 353 OFFCURVE",
+"621 408 CURVE",
+"639 419 LINE",
+"699 474 OFFCURVE",
+"756 535 OFFCURVE",
+"812 606 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"497 716 LINE",
+"592 476 OFFCURVE",
+"631 297 OFFCURVE",
+"653 87 CURVE",
+"727 93 LINE",
+"700 327 OFFCURVE",
+"656 514 OFFCURVE",
+"550 778 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 902;
+}
+);
+leftMetricsKey = u1B1AC;
+rightMetricsKey = u1B1A5;
+unicode = 1B219;
+},
+{
+glyphname = u1B21A;
+lastChange = "2020-04-13 08:53:43 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"710 341 LINE",
+"752 454 OFFCURVE",
+"784 572 OFFCURVE",
+"820 732 CURVE",
+"746 747 LINE",
+"730 675 OFFCURVE",
+"715 612 OFFCURVE",
+"699 553 CURVE SMOOTH",
+"681 486 OFFCURVE",
+"664 441 OFFCURVE",
+"648 385 CURVE",
+"643 384 LINE",
+"584 421 OFFCURVE",
+"522 454 OFFCURVE",
+"473 477 CURVE SMOOTH",
+"435 495 OFFCURVE",
+"361 527 OFFCURVE",
+"294 554 CURVE",
+"301 525 LINE",
+"336 646 OFFCURVE",
+"363 773 OFFCURVE",
+"383 902 CURVE",
+"309 912 LINE",
+"287 768 OFFCURVE",
+"260 646 OFFCURVE",
+"216 502 CURVE",
+"373 442 OFFCURVE",
+"512 380 OFFCURVE",
+"637 313 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"416 150 LINE",
+"450 249 OFFCURVE",
+"471 325 OFFCURVE",
+"498 451 CURVE",
+"427 475 LINE",
+"406 358 OFFCURVE",
+"383 277 OFFCURVE",
+"352 190 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"276 193 OFFCURVE",
+"323 170 OFFCURVE",
+"373 147 CURVE SMOOTH",
+"437 118 OFFCURVE",
+"501 87 OFFCURVE",
+"556 57 CURVE",
+"547 96 LINE",
+"529 -5 OFFCURVE",
+"515 -66 OFFCURVE",
+"482 -161 CURVE",
+"554 -184 LINE",
+"586 -92 OFFCURVE",
+"605 -13 OFFCURVE",
+"626 106 CURVE",
+"501 174 OFFCURVE",
+"352 241 OFFCURVE",
+"231 292 CURVE",
+"152 261 LINE",
+"131 146 OFFCURVE",
+"112 84 OFFCURVE",
+"80 -13 CURVE",
+"152 -38 LINE",
+"166 5 OFFCURVE",
+"173 27 OFFCURVE",
+"180 51 CURVE SMOOTH",
+"191 90 OFFCURVE",
+"205 152 OFFCURVE",
+"215 218 CURVE",
+"220 219 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 910;
+}
+);
+unicode = 1B21A;
+},
+{
+glyphname = u1B21B;
+lastChange = "2020-04-11 17:03:00 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"660 104 OFFCURVE",
+"683 121 OFFCURVE",
+"683 160 CURVE SMOOTH",
+"683 199 OFFCURVE",
+"660 216 OFFCURVE",
+"632 216 CURVE SMOOTH",
+"603 216 OFFCURVE",
+"580 199 OFFCURVE",
+"580 160 CURVE SMOOTH",
+"580 121 OFFCURVE",
+"603 104 OFFCURVE",
+"632 104 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"233 909 LINE",
+"260 849 OFFCURVE",
+"283 786 OFFCURVE",
+"302 727 CURVE",
+"314 691 LINE",
+"352 555 OFFCURVE",
+"374 428 OFFCURVE",
+"388 315 CURVE",
+"392 261 LINE",
+"397 191 OFFCURVE",
+"399 126 OFFCURVE",
+"399 68 CURVE SMOOTH",
+"399 -57 OFFCURVE",
+"395 -115 OFFCURVE",
+"385 -193 CURVE",
+"460 -203 LINE",
+"470 -124 OFFCURVE",
+"475 -57 OFFCURVE",
+"475 68 CURVE SMOOTH",
+"475 149 OFFCURVE",
+"471 234 OFFCURVE",
+"461 323 CURVE",
+"453 369 LINE",
+"435 483 OFFCURVE",
+"412 604 OFFCURVE",
+"377 731 CURVE",
+"362 776 LINE",
+"344 830 OFFCURVE",
+"324 885 OFFCURVE",
+"301 939 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"559 721 LINE",
+"507 671 OFFCURVE",
+"454 623 OFFCURVE",
+"399 576 CURVE",
+"363 549 LINE",
+"303 500 OFFCURVE",
+"239 451 OFFCURVE",
+"172 400 CURVE",
+"192 328 LINE",
+"258 378 OFFCURVE",
+"319 424 OFFCURVE",
+"377 472 CURVE",
+"417 502 LINE",
+"483 556 OFFCURVE",
+"547 611 OFFCURVE",
+"614 671 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"501 926 LINE",
+"447 875 OFFCURVE",
+"395 827 OFFCURVE",
+"343 783 CURVE",
+"309 756 LINE",
+"239 696 OFFCURVE",
+"171 641 OFFCURVE",
+"100 586 CURVE",
+"132 439 OFFCURVE",
+"162 290 OFFCURVE",
+"176 159 CURVE",
+"254 136 LINE",
+"303 169 OFFCURVE",
+"354 206 OFFCURVE",
+"406 244 CURVE",
+"448 272 LINE",
+"517 324 OFFCURVE",
+"588 380 OFFCURVE",
+"669 446 CURVE",
+"647 600 OFFCURVE",
+"615 758 OFFCURVE",
+"575 911 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"521 850 LINE",
+"539 762 OFFCURVE",
+"554 676 OFFCURVE",
+"566 617 CURVE SMOOTH",
+"574 576 OFFCURVE",
+"584 514 OFFCURVE",
+"590 456 CURVE",
+"630 512 LINE",
+"566 458 OFFCURVE",
+"504 407 OFFCURVE",
+"443 361 CURVE",
+"402 333 LINE",
+"355 297 OFFCURVE",
+"304 261 OFFCURVE",
+"242 209 CURVE",
+"237 210 LINE",
+"232 307 OFFCURVE",
+"219 380 OFFCURVE",
+"209 428 CURVE SMOOTH",
+"202 463 OFFCURVE",
+"188 531 OFFCURVE",
+"173 595 CURVE",
+"150 532 LINE",
+"209 576 OFFCURVE",
+"270 626 OFFCURVE",
+"333 679 CURVE",
+"371 708 LINE",
+"425 754 OFFCURVE",
+"462 794 OFFCURVE",
+"516 851 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 773;
+}
+);
+leftMetricsKey = u1B205;
+unicode = 1B21B;
+},
+{
+glyphname = u1B21C;
+lastChange = "2020-04-13 09:44:02 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"573 159 LINE",
+"525 431 OFFCURVE",
+"408 706 OFFCURVE",
+"275 911 CURVE",
+"212 870 LINE",
+"342 665 OFFCURVE",
+"456 404 OFFCURVE",
+"498 149 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"509 939 LINE",
+"463 867 OFFCURVE",
+"411 799 OFFCURVE",
+"353 734 CURVE",
+"324 706 LINE",
+"266 644 OFFCURVE",
+"203 585 OFFCURVE",
+"138 527 CURVE",
+"187 472 LINE",
+"252 529 OFFCURVE",
+"308 579 OFFCURVE",
+"362 636 CURVE",
+"391 663 LINE",
+"458 736 OFFCURVE",
+"518 812 OFFCURVE",
+"573 899 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"227 401 LINE",
+"262 330 OFFCURVE",
+"290 246 OFFCURVE",
+"313 152 CURVE",
+"386 172 LINE",
+"362 265 OFFCURVE",
+"331 362 OFFCURVE",
+"296 434 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"623 563 OFFCURVE",
+"646 580 OFFCURVE",
+"646 619 CURVE SMOOTH",
+"646 658 OFFCURVE",
+"623 675 OFFCURVE",
+"595 675 CURVE SMOOTH",
+"566 675 OFFCURVE",
+"543 658 OFFCURVE",
+"543 619 CURVE SMOOTH",
+"543 580 OFFCURVE",
+"566 563 OFFCURVE",
+"595 563 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"699 365 OFFCURVE",
+"722 382 OFFCURVE",
+"722 421 CURVE SMOOTH",
+"722 460 OFFCURVE",
+"699 477 OFFCURVE",
+"671 477 CURVE SMOOTH",
+"642 477 OFFCURVE",
+"619 460 OFFCURVE",
+"619 421 CURVE SMOOTH",
+"619 382 OFFCURVE",
+"642 365 OFFCURVE",
+"671 365 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"119 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -102 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 842;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B1B5;
+unicode = 1B21C;
+},
+{
+glyphname = u1B21D;
+lastChange = "2020-04-13 08:57:47 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"674 253 LINE",
+"615 423 OFFCURVE",
+"536 602 OFFCURVE",
+"407 849 CURVE",
+"341 813 LINE",
+"469 577 OFFCURVE",
+"558 373 OFFCURVE",
+"620 180 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"776 424 LINE",
+"667 255 OFFCURVE",
+"580 153 OFFCURVE",
+"455 40 CURVE",
+"505 -16 LINE",
+"631 99 OFFCURVE",
+"723 206 OFFCURVE",
+"840 386 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"593 809 OFFCURVE",
+"616 826 OFFCURVE",
+"616 865 CURVE SMOOTH",
+"616 904 OFFCURVE",
+"593 921 OFFCURVE",
+"565 921 CURVE SMOOTH",
+"536 921 OFFCURVE",
+"513 904 OFFCURVE",
+"513 865 CURVE SMOOTH",
+"513 826 OFFCURVE",
+"536 809 OFFCURVE",
+"565 809 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"349 488 OFFCURVE",
+"372 505 OFFCURVE",
+"372 544 CURVE SMOOTH",
+"372 583 OFFCURVE",
+"349 600 OFFCURVE",
+"321 600 CURVE SMOOTH",
+"292 600 OFFCURVE",
+"269 583 OFFCURVE",
+"269 544 CURVE SMOOTH",
+"269 505 OFFCURVE",
+"292 488 OFFCURVE",
+"321 488 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"229 145 OFFCURVE",
+"207 90 OFFCURVE",
+"207 32 CURVE SMOOTH",
+"207 -105 OFFCURVE",
+"294 -203 OFFCURVE",
+"482 -203 CURVE",
+"485 -131 LINE",
+"336 -131 OFFCURVE",
+"281 -68 OFFCURVE",
+"281 37 CURVE SMOOTH",
+"281 98 OFFCURVE",
+"304 141 OFFCURVE",
+"360 169 CURVE",
+"340 257 LINE",
+"206 257 OFFCURVE",
+"144 318 OFFCURVE",
+"144 432 CURVE SMOOTH",
+"144 502 OFFCURVE",
+"169 548 OFFCURVE",
+"229 593 CURVE",
+"186 648 LINE",
+"106 593 OFFCURVE",
+"70 515 OFFCURVE",
+"70 429 CURVE SMOOTH",
+"70 297 OFFCURVE",
+"149 200 OFFCURVE",
+"290 199 CURVE",
+"291 194 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"762 939 LINE",
+"683 787 OFFCURVE",
+"607 668 OFFCURVE",
+"527 565 CURVE",
+"497 535 LINE",
+"442 467 OFFCURVE",
+"385 406 OFFCURVE",
+"324 346 CURVE",
+"376 293 LINE",
+"429 344 OFFCURVE",
+"481 399 OFFCURVE",
+"532 460 CURVE",
+"554 479 LINE",
+"647 594 OFFCURVE",
+"737 731 OFFCURVE",
+"830 906 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 910;
+}
+);
+leftMetricsKey = u1B1D0;
+rightMetricsKey = u1B1C5;
+unicode = 1B21D;
+},
+{
+glyphname = u1B21E;
+lastChange = "2020-04-13 08:57:44 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"176 267 LINE",
+"204 267 LINE",
+"231 217 OFFCURVE",
+"256 165 OFFCURVE",
+"287 79 CURVE",
+"353 106 LINE",
+"317 194 OFFCURVE",
+"280 263 OFFCURVE",
+"226 343 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"166 402 LINE",
+"143 257 OFFCURVE",
+"125 175 OFFCURVE",
+"80 41 CURVE",
+"146 22 LINE",
+"176 112 OFFCURVE",
+"186 179 OFFCURVE",
+"200 267 CURVE",
+"222 317 LINE",
+"226 341 OFFCURVE",
+"232 365 OFFCURVE",
+"235 392 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"539 713 LINE",
+"482 606 OFFCURVE",
+"429 529 OFFCURVE",
+"349 422 CURVE",
+"391 353 LINE",
+"466 454 OFFCURVE",
+"532 548 OFFCURVE",
+"590 649 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"454 842 LINE",
+"497 765 OFFCURVE",
+"524 719 OFFCURVE",
+"566 647 CURVE SMOOTH",
+"587 611 OFFCURVE",
+"628 533 OFFCURVE",
+"674 440 CURVE",
+"679 544 LINE",
+"612 431 OFFCURVE",
+"541 320 OFFCURVE",
+"462 206 CURVE",
+"436 178 LINE",
+"362 71 OFFCURVE",
+"282 -39 OFFCURVE",
+"194 -158 CURVE",
+"253 -203 LINE",
+"333 -96 OFFCURVE",
+"408 7 OFFCURVE",
+"479 108 CURVE",
+"507 138 LINE",
+"589 257 OFFCURVE",
+"665 374 OFFCURVE",
+"736 489 CURVE",
+"654 649 OFFCURVE",
+"579 779 OFFCURVE",
+"492 910 CURVE",
+"405 908 LINE",
+"345 791 OFFCURVE",
+"281 688 OFFCURVE",
+"191 559 CURVE",
+"372 274 OFFCURVE",
+"467 102 OFFCURVE",
+"589 -161 CURVE",
+"658 -130 LINE",
+"534 138 OFFCURVE",
+"427 329 OFFCURVE",
+"251 607 CURVE",
+"257 520 LINE",
+"293 573 OFFCURVE",
+"316 606 OFFCURVE",
+"346 653 CURVE SMOOTH",
+"387 717 OFFCURVE",
+"420 774 OFFCURVE",
+"450 842 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 846;
+}
+);
+rightMetricsKey = u1B1DD;
+unicode = 1B21E;
+},
+{
+glyphname = u1B21F;
+lastChange = "2020-04-13 08:57:11 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"118 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -103 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"603 253 LINE",
+"544 423 OFFCURVE",
+"465 602 OFFCURVE",
+"336 849 CURVE",
+"270 813 LINE",
+"398 577 OFFCURVE",
+"487 373 OFFCURVE",
+"549 180 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"691 939 LINE",
+"612 787 OFFCURVE",
+"536 668 OFFCURVE",
+"456 565 CURVE",
+"426 535 LINE",
+"371 467 OFFCURVE",
+"314 406 OFFCURVE",
+"253 346 CURVE",
+"305 293 LINE",
+"358 344 OFFCURVE",
+"410 399 OFFCURVE",
+"461 460 CURVE",
+"483 479 LINE",
+"576 594 OFFCURVE",
+"666 731 OFFCURVE",
+"759 906 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"705 424 LINE",
+"596 255 OFFCURVE",
+"509 153 OFFCURVE",
+"384 40 CURVE",
+"434 -16 LINE",
+"560 99 OFFCURVE",
+"652 206 OFFCURVE",
+"769 386 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"522 809 OFFCURVE",
+"545 826 OFFCURVE",
+"545 865 CURVE SMOOTH",
+"545 904 OFFCURVE",
+"522 921 OFFCURVE",
+"494 921 CURVE SMOOTH",
+"465 921 OFFCURVE",
+"442 904 OFFCURVE",
+"442 865 CURVE SMOOTH",
+"442 826 OFFCURVE",
+"465 809 OFFCURVE",
+"494 809 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"278 488 OFFCURVE",
+"301 505 OFFCURVE",
+"301 544 CURVE SMOOTH",
+"301 583 OFFCURVE",
+"278 600 OFFCURVE",
+"250 600 CURVE SMOOTH",
+"221 600 OFFCURVE",
+"198 583 OFFCURVE",
+"198 544 CURVE SMOOTH",
+"198 505 OFFCURVE",
+"221 488 OFFCURVE",
+"250 488 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 839;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B1C5;
+unicode = 1B21F;
+},
+{
+glyphname = u1B220;
+lastChange = "2020-04-13 08:56:44 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"190 273 LINE",
+"148 156 OFFCURVE",
+"110 86 OFFCURVE",
+"40 -5 CURVE",
+"99 -48 LINE",
+"151 23 OFFCURVE",
+"182 78 OFFCURVE",
+"214 149 CURVE",
+"239 197 LINE",
+"246 214 OFFCURVE",
+"252 232 OFFCURVE",
+"259 251 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"188 149 LINE",
+"218 149 LINE",
+"252 96 OFFCURVE",
+"287 46 OFFCURVE",
+"330 -29 CURVE",
+"391 5 LINE",
+"343 88 OFFCURVE",
+"282 167 OFFCURVE",
+"214 241 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"186 11 LINE",
+"182 -72 OFFCURVE",
+"178 -118 OFFCURVE",
+"165 -195 CURVE",
+"238 -203 LINE",
+"247 -132 OFFCURVE",
+"251 -75 OFFCURVE",
+"254 8 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"675 665 LINE",
+"628 604 OFFCURVE",
+"580 548 OFFCURVE",
+"529 495 CURVE",
+"495 464 LINE",
+"438 406 OFFCURVE",
+"379 351 OFFCURVE",
+"318 299 CURVE",
+"364 243 LINE",
+"422 291 OFFCURVE",
+"473 338 OFFCURVE",
+"521 387 CURVE",
+"547 408 LINE",
+"608 473 OFFCURVE",
+"666 540 OFFCURVE",
+"732 619 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"598 939 LINE",
+"485 771 OFFCURVE",
+"370 645 OFFCURVE",
+"216 502 CURVE",
+"268 445 LINE",
+"414 584 OFFCURVE",
+"544 722 OFFCURVE",
+"663 898 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"719 377 LINE",
+"612 250 OFFCURVE",
+"513 153 OFFCURVE",
+"391 60 CURVE",
+"436 0 LINE",
+"575 110 OFFCURVE",
+"668 205 OFFCURVE",
+"777 332 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"431 634 LINE",
+"482 472 OFFCURVE",
+"513 318 OFFCURVE",
+"531 157 CURVE",
+"600 187 LINE",
+"581 357 OFFCURVE",
+"545 515 OFFCURVE",
+"490 709 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 857;
+}
+);
+leftMetricsKey = u1B1FF;
+rightMetricsKey = u1B197;
+unicode = 1B220;
+},
+{
+glyphname = u1B221;
+lastChange = "2020-04-13 08:56:21 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"206 823 OFFCURVE",
+"229 840 OFFCURVE",
+"229 879 CURVE SMOOTH",
+"229 918 OFFCURVE",
+"206 935 OFFCURVE",
+"178 935 CURVE SMOOTH",
+"149 935 OFFCURVE",
+"126 918 OFFCURVE",
+"126 879 CURVE SMOOTH",
+"126 840 OFFCURVE",
+"149 823 OFFCURVE",
+"178 823 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"133 627 LINE",
+"277 545 OFFCURVE",
+"392 466 OFFCURVE",
+"518 365 CURVE",
+"561 421 LINE",
+"503 466 OFFCURVE",
+"449 505 OFFCURVE",
+"369 561 CURVE",
+"350 560 LINE",
+"303 604 OFFCURVE",
+"250 639 OFFCURVE",
+"170 687 CURVE",
+"183 648 LINE",
+"254 705 OFFCURVE",
+"320 772 OFFCURVE",
+"366 826 CURVE",
+"399 856 LINE",
+"410 869 OFFCURVE",
+"421 881 OFFCURVE",
+"432 895 CURVE",
+"376 939 LINE",
+"290 834 OFFCURVE",
+"215 763 OFFCURVE",
+"133 698 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"471 763 OFFCURVE",
+"449 818 OFFCURVE",
+"388 896 CURVE",
+"335 826 LINE",
+"370 826 LINE",
+"388 781 OFFCURVE",
+"399 739 OFFCURVE",
+"399 703 CURVE SMOOTH",
+"399 662 OFFCURVE",
+"391 612 OFFCURVE",
+"354 560 CURVE",
+"344 560 LINE",
+"276 483 OFFCURVE",
+"199 412 OFFCURVE",
+"80 318 CURVE",
+"126 265 LINE",
+"237 358 OFFCURVE",
+"311 432 OFFCURVE",
+"365 494 CURVE",
+"391 520 LINE",
+"450 594 OFFCURVE",
+"471 649 OFFCURVE",
+"471 701 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"156 123 LINE",
+"273 40 OFFCURVE",
+"368 -32 OFFCURVE",
+"501 -162 CURVE",
+"549 -110 LINE",
+"493 -57 OFFCURVE",
+"448 -19 OFFCURVE",
+"367 47 CURVE",
+"352 47 LINE",
+"310 91 OFFCURVE",
+"257 135 OFFCURVE",
+"201 174 CURVE",
+"206 143 LINE",
+"281 206 OFFCURVE",
+"336 255 OFFCURVE",
+"371 302 CURVE",
+"404 331 LINE",
+"415 343 OFFCURVE",
+"427 357 OFFCURVE",
+"438 371 CURVE",
+"382 417 LINE",
+"299 319 OFFCURVE",
+"235 255 OFFCURVE",
+"156 194 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"482 242 OFFCURVE",
+"461 298 OFFCURVE",
+"385 381 CURVE",
+"349 302 LINE",
+"375 302 LINE",
+"398 256 OFFCURVE",
+"410 216 OFFCURVE",
+"410 178 CURVE SMOOTH",
+"410 144 OFFCURVE",
+"396 99 OFFCURVE",
+"356 47 CURVE",
+"348 47 LINE",
+"286 -24 OFFCURVE",
+"212 -81 OFFCURVE",
+"119 -148 CURVE",
+"166 -203 LINE",
+"252 -136 OFFCURVE",
+"320 -77 OFFCURVE",
+"374 -21 CURVE",
+"399 2 LINE",
+"452 62 OFFCURVE",
+"482 119 OFFCURVE",
+"482 178 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 641;
+}
+);
+leftMetricsKey = u1B201;
+rightMetricsKey = u1B201;
+unicode = 1B221;
+},
+{
+glyphname = u1B222;
+lastChange = "2020-04-13 08:56:05 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"674 939 LINE",
+"617 830 OFFCURVE",
+"565 742 OFFCURVE",
+"517 670 CURVE SMOOTH",
+"450 569 OFFCURVE",
+"407 514 OFFCURVE",
+"363 463 CURVE",
+"358 464 LINE",
+"337 538 OFFCURVE",
+"305 613 OFFCURVE",
+"276 674 CURVE SMOOTH",
+"265 697 OFFCURVE",
+"253 721 OFFCURVE",
+"240 745 CURVE",
+"173 710 LINE",
+"229 607 OFFCURVE",
+"260 539 OFFCURVE",
+"300 423 CURVE",
+"396 401 LINE",
+"495 503 OFFCURVE",
+"597 636 OFFCURVE",
+"739 906 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"425 719 OFFCURVE",
+"448 736 OFFCURVE",
+"448 775 CURVE SMOOTH",
+"448 814 OFFCURVE",
+"425 831 OFFCURVE",
+"397 831 CURVE SMOOTH",
+"368 831 OFFCURVE",
+"345 814 OFFCURVE",
+"345 775 CURVE SMOOTH",
+"345 736 OFFCURVE",
+"368 719 OFFCURVE",
+"397 719 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"150 462 OFFCURVE",
+"173 479 OFFCURVE",
+"173 518 CURVE SMOOTH",
+"173 557 OFFCURVE",
+"150 574 OFFCURVE",
+"122 574 CURVE SMOOTH",
+"93 574 OFFCURVE",
+"70 557 OFFCURVE",
+"70 518 CURVE SMOOTH",
+"70 479 OFFCURVE",
+"93 462 OFFCURVE",
+"122 462 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"369 346 LINE",
+"322 294 OFFCURVE",
+"280 250 OFFCURVE",
+"236 210 CURVE",
+"213 197 LINE",
+"171 160 OFFCURVE",
+"126 125 OFFCURVE",
+"74 86 CURVE",
+"119 29 LINE",
+"170 66 OFFCURVE",
+"214 102 OFFCURVE",
+"255 138 CURVE",
+"274 147 LINE",
+"324 192 OFFCURVE",
+"372 241 OFFCURVE",
+"424 298 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"482 194 LINE",
+"428 136 OFFCURVE",
+"380 90 OFFCURVE",
+"329 47 CURVE",
+"305 35 LINE",
+"259 -2 OFFCURVE",
+"211 -36 OFFCURVE",
+"155 -72 CURVE",
+"196 -132 LINE",
+"247 -98 OFFCURVE",
+"295 -64 OFFCURVE",
+"342 -26 CURVE",
+"371 -10 LINE",
+"424 35 OFFCURVE",
+"477 85 OFFCURVE",
+"535 144 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"453 -177 LINE",
+"372 40 OFFCURVE",
+"274 200 OFFCURVE",
+"153 364 CURVE",
+"98 317 LINE",
+"225 149 OFFCURVE",
+"313 0 OFFCURVE",
+"386 -203 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 759;
+}
+);
+leftMetricsKey = u1B1ED;
+unicode = 1B222;
+},
+{
+glyphname = u1B223;
+lastChange = "2020-04-13 08:55:45 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"556 74 OFFCURVE",
+"579 91 OFFCURVE",
+"579 130 CURVE SMOOTH",
+"579 169 OFFCURVE",
+"556 186 OFFCURVE",
+"528 186 CURVE SMOOTH",
+"499 186 OFFCURVE",
+"476 169 OFFCURVE",
+"476 130 CURVE SMOOTH",
+"476 91 OFFCURVE",
+"499 74 OFFCURVE",
+"528 74 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"810 525 OFFCURVE",
+"833 542 OFFCURVE",
+"833 581 CURVE SMOOTH",
+"833 620 OFFCURVE",
+"810 637 OFFCURVE",
+"782 637 CURVE SMOOTH",
+"753 637 OFFCURVE",
+"730 620 OFFCURVE",
+"730 581 CURVE SMOOTH",
+"730 542 OFFCURVE",
+"753 525 OFFCURVE",
+"782 525 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"160 296 OFFCURVE",
+"183 313 OFFCURVE",
+"183 352 CURVE SMOOTH",
+"183 391 OFFCURVE",
+"160 408 OFFCURVE",
+"132 408 CURVE SMOOTH",
+"103 408 OFFCURVE",
+"80 391 OFFCURVE",
+"80 352 CURVE SMOOTH",
+"80 313 OFFCURVE",
+"103 296 OFFCURVE",
+"132 296 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"452 755 OFFCURVE",
+"475 772 OFFCURVE",
+"475 811 CURVE SMOOTH",
+"475 850 OFFCURVE",
+"452 867 OFFCURVE",
+"424 867 CURVE SMOOTH",
+"395 867 OFFCURVE",
+"372 850 OFFCURVE",
+"372 811 CURVE SMOOTH",
+"372 772 OFFCURVE",
+"395 755 OFFCURVE",
+"424 755 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"270 570 OFFCURVE",
+"303 425 OFFCURVE",
+"303 266 CURVE SMOOTH",
+"303 89 OFFCURVE",
+"281 -41 OFFCURVE",
+"233 -181 CURVE",
+"304 -203 LINE",
+"355 -62 OFFCURVE",
+"377 75 OFFCURVE",
+"377 266 CURVE SMOOTH",
+"377 289 OFFCURVE",
+"376 311 OFFCURVE",
+"375 363 CURVE",
+"361 384 LINE",
+"356 501 OFFCURVE",
+"330 612 OFFCURVE",
+"252 784 CURVE",
+"183 754 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"580 654 OFFCURVE",
+"467 489 OFFCURVE",
+"365 383 CURVE",
+"337 390 LINE",
+"348 271 LINE",
+"523 441 OFFCURVE",
+"632 589 OFFCURVE",
+"711 924 CURVE",
+"636 939 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"513 530 LINE",
+"592 404 OFFCURVE",
+"648 279 OFFCURVE",
+"674 135 CURVE",
+"750 149 LINE",
+"720 318 OFFCURVE",
+"654 449 OFFCURVE",
+"557 593 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 913;
+}
+);
+leftMetricsKey = u1B176;
+rightMetricsKey = u1B1C1;
+unicode = 1B223;
+},
+{
+glyphname = u1B224;
+lastChange = "2020-04-13 08:55:43 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"228 27 LINE",
+"220 184 OFFCURVE",
+"203 309 OFFCURVE",
+"168 437 CURVE",
+"100 417 LINE",
+"131 301 OFFCURVE",
+"149 172 OFFCURVE",
+"157 24 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"336 -106 LINE",
+"401 -71 OFFCURVE",
+"465 -35 OFFCURVE",
+"527 4 CURVE",
+"551 13 LINE",
+"620 57 OFFCURVE",
+"688 105 OFFCURVE",
+"753 157 CURVE",
+"707 212 LINE",
+"655 169 OFFCURVE",
+"602 129 OFFCURVE",
+"546 91 CURVE",
+"522 82 LINE",
+"454 38 OFFCURVE",
+"381 -3 OFFCURVE",
+"303 -44 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"293 288 LINE",
+"446 395 OFFCURVE",
+"534 467 OFFCURVE",
+"683 623 CURVE",
+"627 669 LINE",
+"500 533 OFFCURVE",
+"394 445 OFFCURVE",
+"251 346 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"581 -199 LINE",
+"581 -46 OFFCURVE",
+"574 79 OFFCURVE",
+"543 273 CURVE",
+"482 208 LINE",
+"498 60 OFFCURVE",
+"505 -65 OFFCURVE",
+"505 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"625 365 OFFCURVE",
+"547 305 OFFCURVE",
+"294 152 CURVE",
+"332 91 LINE",
+"608 259 OFFCURVE",
+"701 338 OFFCURVE",
+"701 433 CURVE SMOOTH",
+"701 497 OFFCURVE",
+"669 549 OFFCURVE",
+"614 611 CURVE",
+"567 563 LINE",
+"610 508 OFFCURVE",
+"625 477 OFFCURVE",
+"625 433 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"624 939 LINE",
+"552 840 OFFCURVE",
+"485 759 OFFCURVE",
+"419 690 CURVE SMOOTH",
+"361 629 OFFCURVE",
+"306 572 OFFCURVE",
+"261 529 CURVE",
+"256 530 LINE",
+"245 602 OFFCURVE",
+"226 660 OFFCURVE",
+"214 695 CURVE SMOOTH",
+"206 719 OFFCURVE",
+"197 744 OFFCURVE",
+"188 770 CURVE",
+"120 744 LINE",
+"155 654 OFFCURVE",
+"180 581 OFFCURVE",
+"201 489 CURVE",
+"286 468 LINE",
+"439 591 OFFCURVE",
+"546 701 OFFCURVE",
+"687 897 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 843;
+}
+);
+leftMetricsKey = u1B1F3;
+unicode = 1B224;
+},
+{
+glyphname = u1B225;
+lastChange = "2020-04-13 08:55:31 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"256 241 OFFCURVE",
+"279 258 OFFCURVE",
+"279 297 CURVE SMOOTH",
+"279 336 OFFCURVE",
+"256 353 OFFCURVE",
+"228 353 CURVE SMOOTH",
+"199 353 OFFCURVE",
+"176 336 OFFCURVE",
+"176 297 CURVE SMOOTH",
+"176 258 OFFCURVE",
+"199 241 OFFCURVE",
+"228 241 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"535 -31 OFFCURVE",
+"558 -14 OFFCURVE",
+"558 25 CURVE SMOOTH",
+"558 64 OFFCURVE",
+"535 81 OFFCURVE",
+"507 81 CURVE SMOOTH",
+"478 81 OFFCURVE",
+"455 64 OFFCURVE",
+"455 25 CURVE SMOOTH",
+"455 -14 OFFCURVE",
+"478 -31 OFFCURVE",
+"507 -31 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"558 261 OFFCURVE",
+"504 324 OFFCURVE",
+"450 376 CURVE SMOOTH",
+"401 424 OFFCURVE",
+"352 470 OFFCURVE",
+"295 523 CURVE",
+"312 477 LINE",
+"382 603 OFFCURVE",
+"433 700 OFFCURVE",
+"503 894 CURVE",
+"431 919 LINE",
+"374 755 OFFCURVE",
+"313 633 OFFCURVE",
+"228 478 CURVE",
+"371 351 OFFCURVE",
+"461 262 OFFCURVE",
+"574 134 CURVE",
+"666 143 LINE",
+"754 285 OFFCURVE",
+"812 396 OFFCURVE",
+"883 563 CURVE",
+"813 592 LINE",
+"780 515 OFFCURVE",
+"751 451 OFFCURVE",
+"720 392 CURVE SMOOTH",
+"683 322 OFFCURVE",
+"651 263 OFFCURVE",
+"617 197 CURVE",
+"612 196 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"295 -3 LINE",
+"343 67 OFFCURVE",
+"415 179 OFFCURVE",
+"470 278 CURVE",
+"493 313 LINE",
+"559 429 OFFCURVE",
+"603 521 OFFCURVE",
+"681 703 CURVE",
+"612 731 LINE",
+"540 562 OFFCURVE",
+"500 478 OFFCURVE",
+"437 367 CURVE",
+"415 332 LINE",
+"362 233 OFFCURVE",
+"290 122 OFFCURVE",
+"241 47 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"471 -153 LINE",
+"353 -19 OFFCURVE",
+"245 95 OFFCURVE",
+"111 220 CURVE",
+"60 163 LINE",
+"181 51 OFFCURVE",
+"307 -80 OFFCURVE",
+"414 -203 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 923;
+}
+);
+leftMetricsKey = u1B1CE;
+rightMetricsKey = u1B1CE;
+unicode = 1B225;
+},
+{
+glyphname = u1B226;
+lastChange = "2020-04-13 08:55:27 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"329 306 LINE",
+"294 276 OFFCURVE",
+"255 246 OFFCURVE",
+"216 217 CURVE",
+"186 200 LINE",
+"142 169 OFFCURVE",
+"98 141 OFFCURVE",
+"60 118 CURVE",
+"96 57 LINE",
+"137 82 OFFCURVE",
+"175 106 OFFCURVE",
+"212 131 CURVE",
+"241 147 LINE",
+"285 179 OFFCURVE",
+"328 213 OFFCURVE",
+"376 253 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"300 13 LINE",
+"272 126 OFFCURVE",
+"243 217 OFFCURVE",
+"192 347 CURVE",
+"123 318 LINE",
+"180 180 OFFCURVE",
+"212 83 OFFCURVE",
+"235 -18 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"355 102 LINE",
+"286 45 OFFCURVE",
+"212 -1 OFFCURVE",
+"138 -43 CURVE",
+"172 -107 LINE",
+"253 -60 OFFCURVE",
+"325 -16 OFFCURVE",
+"401 46 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"666 939 LINE",
+"575 789 OFFCURVE",
+"476 669 OFFCURVE",
+"349 550 CURVE",
+"419 392 OFFCURVE",
+"440 299 OFFCURVE",
+"440 167 CURVE SMOOTH",
+"440 37 OFFCURVE",
+"413 -60 OFFCURVE",
+"364 -177 CURVE",
+"433 -203 LINE",
+"486 -84 OFFCURVE",
+"514 32 OFFCURVE",
+"514 167 CURVE SMOOTH",
+"514 299 OFFCURVE",
+"488 414 OFFCURVE",
+"422 568 CURVE",
+"408 511 LINE",
+"528 623 OFFCURVE",
+"637 743 OFFCURVE",
+"733 902 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"696 270 LINE",
+"686 339 OFFCURVE",
+"668 395 OFFCURVE",
+"630 485 CURVE",
+"567 459 LINE",
+"600 383 OFFCURVE",
+"627 307 OFFCURVE",
+"649 221 CURVE",
+"738 218 LINE",
+"802 308 OFFCURVE",
+"824 394 OFFCURVE",
+"824 476 CURVE SMOOTH",
+"824 590 OFFCURVE",
+"776 705 OFFCURVE",
+"622 846 CURVE",
+"591 782 LINE",
+"715 652 OFFCURVE",
+"748 568 OFFCURVE",
+"748 470 CURVE SMOOTH",
+"748 402 OFFCURVE",
+"734 342 OFFCURVE",
+"700 270 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 924;
+}
+);
+rightMetricsKey = u1B18D;
+unicode = 1B226;
+},
+{
+glyphname = u1B227;
+lastChange = "2020-04-13 08:55:15 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"204 731 OFFCURVE",
+"227 748 OFFCURVE",
+"227 787 CURVE SMOOTH",
+"227 826 OFFCURVE",
+"204 843 OFFCURVE",
+"176 843 CURVE SMOOTH",
+"147 843 OFFCURVE",
+"124 826 OFFCURVE",
+"124 787 CURVE SMOOTH",
+"124 748 OFFCURVE",
+"147 731 OFFCURVE",
+"176 731 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"460 911 LINE",
+"331 736 OFFCURVE",
+"213 626 OFFCURVE",
+"50 489 CURVE",
+"98 429 LINE",
+"260 570 OFFCURVE",
+"382 682 OFFCURVE",
+"522 866 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"433 500 OFFCURVE",
+"456 517 OFFCURVE",
+"456 556 CURVE SMOOTH",
+"456 595 OFFCURVE",
+"433 612 OFFCURVE",
+"405 612 CURVE SMOOTH",
+"376 612 OFFCURVE",
+"353 595 OFFCURVE",
+"353 556 CURVE SMOOTH",
+"353 517 OFFCURVE",
+"376 500 OFFCURVE",
+"405 500 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"257 333 OFFCURVE",
+"280 350 OFFCURVE",
+"280 389 CURVE SMOOTH",
+"280 428 OFFCURVE",
+"257 445 OFFCURVE",
+"229 445 CURVE SMOOTH",
+"200 445 OFFCURVE",
+"177 428 OFFCURVE",
+"177 389 CURVE SMOOTH",
+"177 350 OFFCURVE",
+"200 333 OFFCURVE",
+"229 333 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"229 167 LINE",
+"368 53 OFFCURVE",
+"461 -31 OFFCURVE",
+"574 -150 CURVE",
+"629 -102 LINE",
+"577 -48 OFFCURVE",
+"537 -10 OFFCURVE",
+"458 64 CURVE",
+"441 64 LINE",
+"393 117 OFFCURVE",
+"343 167 OFFCURVE",
+"278 221 CURVE",
+"274 179 LINE",
+"343 232 OFFCURVE",
+"415 291 OFFCURVE",
+"467 348 CURVE",
+"502 370 LINE",
+"518 385 OFFCURVE",
+"534 402 OFFCURVE",
+"552 421 CURVE",
+"498 474 LINE",
+"396 370 OFFCURVE",
+"315 303 OFFCURVE",
+"229 238 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"576 278 OFFCURVE",
+"557 332 OFFCURVE",
+"497 408 CURVE",
+"437 348 LINE",
+"471 348 LINE",
+"492 303 OFFCURVE",
+"500 265 OFFCURVE",
+"500 219 CURVE SMOOTH",
+"500 172 OFFCURVE",
+"484 125 OFFCURVE",
+"445 64 CURVE",
+"435 64 LINE",
+"367 -13 OFFCURVE",
+"293 -70 OFFCURVE",
+"192 -147 CURVE",
+"237 -203 LINE",
+"336 -127 OFFCURVE",
+"409 -60 OFFCURVE",
+"462 -6 CURVE",
+"486 14 LINE",
+"552 88 OFFCURVE",
+"576 149 OFFCURVE",
+"576 218 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 699;
+}
+);
+unicode = 1B227;
+},
+{
+glyphname = u1B228;
+lastChange = "2020-04-13 08:55:07 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"505 33 LINE",
+"510 128 OFFCURVE",
+"496 226 OFFCURVE",
+"463 293 CURVE SMOOTH",
+"437 346 OFFCURVE",
+"412 390 OFFCURVE",
+"357 457 CURVE SMOOTH",
+"249 588 OFFCURVE",
+"225 649 OFFCURVE",
+"225 735 CURVE SMOOTH",
+"225 786 OFFCURVE",
+"233 828 OFFCURVE",
+"251 878 CURVE",
+"185 896 LINE",
+"161 837 OFFCURVE",
+"151 786 OFFCURVE",
+"151 725 CURVE SMOOTH",
+"151 625 OFFCURVE",
+"190 543 OFFCURVE",
+"300 406 CURVE SMOOTH",
+"426 249 OFFCURVE",
+"447 172 OFFCURVE",
+"450 -3 CURVE",
+"526 -32 LINE",
+"622 43 OFFCURVE",
+"657 118 OFFCURVE",
+"657 220 CURVE SMOOTH",
+"657 290 OFFCURVE",
+"633 355 OFFCURVE",
+"587 432 CURVE",
+"591 436 LINE",
+"663 380 OFFCURVE",
+"709 346 OFFCURVE",
+"768 299 CURVE",
+"844 341 LINE",
+"820 594 OFFCURVE",
+"767 729 OFFCURVE",
+"604 893 CURVE",
+"566 797 LINE",
+"601 797 LINE",
+"639 757 OFFCURVE",
+"663 720 OFFCURVE",
+"694 660 CURVE SMOOTH",
+"712 625 OFFCURVE",
+"726 589 OFFCURVE",
+"739 545 CURVE SMOOTH",
+"754 494 OFFCURVE",
+"767 434 OFFCURVE",
+"778 370 CURVE",
+"773 368 LINE",
+"716 419 OFFCURVE",
+"677 456 OFFCURVE",
+"575 503 CURVE",
+"521 447 LINE",
+"568 335 OFFCURVE",
+"583 274 OFFCURVE",
+"583 224 CURVE SMOOTH",
+"583 141 OFFCURVE",
+"564 87 OFFCURVE",
+"510 32 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"556 939 LINE",
+"521 701 OFFCURVE",
+"464 601 OFFCURVE",
+"328 457 CURVE",
+"298 433 LINE",
+"136 274 OFFCURVE",
+"70 118 OFFCURVE",
+"70 -30 CURVE SMOOTH",
+"70 -97 OFFCURVE",
+"77 -155 OFFCURVE",
+"94 -203 CURVE",
+"160 -188 LINE",
+"148 -138 OFFCURVE",
+"142 -94 OFFCURVE",
+"142 -31 CURVE SMOOTH",
+"142 106 OFFCURVE",
+"197 237 OFFCURVE",
+"337 386 CURVE",
+"365 415 LINE",
+"499 536 OFFCURVE",
+"574 657 OFFCURVE",
+"597 797 CURVE",
+"618 853 LINE",
+"623 877 OFFCURVE",
+"628 903 OFFCURVE",
+"632 929 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 894;
+}
+);
+leftMetricsKey = u1B1D9;
+unicode = 1B228;
+},
+{
+glyphname = u1B229;
+lastChange = "2020-04-13 08:55:05 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"602 268 OFFCURVE",
+"539 397 OFFCURVE",
+"474 502 CURVE",
+"391 505 LINE",
+"335 407 OFFCURVE",
+"265 305 OFFCURVE",
+"180 200 CURVE",
+"249 68 OFFCURVE",
+"304 -50 OFFCURVE",
+"356 -178 CURVE",
+"438 -186 LINE",
+"525 -91 OFFCURVE",
+"591 -3 OFFCURVE",
+"668 114 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"606 159 LINE",
+"578 115 OFFCURVE",
+"550 74 OFFCURVE",
+"522 36 CURVE SMOOTH",
+"482 -18 OFFCURVE",
+"442 -70 OFFCURVE",
+"408 -118 CURVE",
+"404 -118 LINE",
+"383 -48 OFFCURVE",
+"352 21 OFFCURVE",
+"325 80 CURVE SMOOTH",
+"307 119 OFFCURVE",
+"277 177 OFFCURVE",
+"246 237 CURVE",
+"251 167 LINE",
+"290 216 OFFCURVE",
+"324 262 OFFCURVE",
+"356 307 CURVE SMOOTH",
+"387 351 OFFCURVE",
+"403 376 OFFCURVE",
+"430 429 CURVE",
+"434 429 LINE",
+"467 367 OFFCURVE",
+"490 321 OFFCURVE",
+"519 261 CURVE SMOOTH",
+"545 207 OFFCURVE",
+"570 148 OFFCURVE",
+"595 86 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"508 340 LINE",
+"446 235 OFFCURVE",
+"378 146 OFFCURVE",
+"292 45 CURVE",
+"343 -4 LINE",
+"430 97 OFFCURVE",
+"491 176 OFFCURVE",
+"562 286 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"367 939 LINE",
+"300 745 OFFCURVE",
+"216 598 OFFCURVE",
+"80 428 CURVE",
+"138 378 LINE",
+"274 550 OFFCURVE",
+"361 693 OFFCURVE",
+"439 917 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"358 813 LINE",
+"479 678 OFFCURVE",
+"572 557 OFFCURVE",
+"670 397 CURVE",
+"734 438 LINE",
+"631 601 OFFCURVE",
+"541 723 OFFCURVE",
+"397 879 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 824;
+}
+);
+leftMetricsKey = u1B185;
+rightMetricsKey = u1B185;
+unicode = 1B229;
+},
+{
+glyphname = u1B22A;
+lastChange = "2020-04-13 08:55:02 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"709 296 OFFCURVE",
+"732 313 OFFCURVE",
+"732 352 CURVE SMOOTH",
+"732 391 OFFCURVE",
+"709 408 OFFCURVE",
+"681 408 CURVE SMOOTH",
+"652 408 OFFCURVE",
+"629 391 OFFCURVE",
+"629 352 CURVE SMOOTH",
+"629 313 OFFCURVE",
+"652 296 OFFCURVE",
+"681 296 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"384 92 OFFCURVE",
+"407 109 OFFCURVE",
+"407 148 CURVE SMOOTH",
+"407 187 OFFCURVE",
+"384 204 OFFCURVE",
+"356 204 CURVE SMOOTH",
+"327 204 OFFCURVE",
+"304 187 OFFCURVE",
+"304 148 CURVE SMOOTH",
+"304 109 OFFCURVE",
+"327 92 OFFCURVE",
+"356 92 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"605 939 LINE",
+"452 796 OFFCURVE",
+"306 702 OFFCURVE",
+"118 594 CURVE",
+"158 532 LINE",
+"346 639 OFFCURVE",
+"492 734 OFFCURVE",
+"659 889 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"566 754 OFFCURVE",
+"585 711 OFFCURVE",
+"585 667 CURVE SMOOTH",
+"585 581 OFFCURVE",
+"512 504 OFFCURVE",
+"194 342 CURVE",
+"230 275 LINE",
+"567 453 OFFCURVE",
+"661 546 OFFCURVE",
+"661 667 CURVE SMOOTH",
+"661 738 OFFCURVE",
+"635 795 OFFCURVE",
+"552 884 CURVE",
+"513 813 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"588 -33 LINE",
+"579 121 OFFCURVE",
+"550 283 OFFCURVE",
+"507 459 CURVE",
+"447 417 LINE",
+"481 253 OFFCURVE",
+"503 114 OFFCURVE",
+"512 -38 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"118 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -102 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 812;
+}
+);
+leftMetricsKey = u1B1B9;
+unicode = 1B22A;
+},
+{
+glyphname = u1B22B;
+lastChange = "2020-04-13 08:54:55 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"196 365 LINE",
+"177 234 OFFCURVE",
+"153 147 OFFCURVE",
+"109 38 CURVE",
+"177 12 LINE",
+"225 134 OFFCURVE",
+"245 211 OFFCURVE",
+"267 355 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"50 201 LINE",
+"96 190 OFFCURVE",
+"136 180 OFFCURVE",
+"174 168 CURVE",
+"200 164 LINE",
+"241 150 OFFCURVE",
+"280 134 OFFCURVE",
+"324 112 CURVE",
+"356 177 LINE",
+"309 200 OFFCURVE",
+"265 218 OFFCURVE",
+"220 233 CURVE",
+"194 237 LINE",
+"155 249 OFFCURVE",
+"114 260 OFFCURVE",
+"67 271 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"539 713 LINE",
+"482 606 OFFCURVE",
+"429 529 OFFCURVE",
+"349 422 CURVE",
+"391 353 LINE",
+"466 454 OFFCURVE",
+"532 548 OFFCURVE",
+"590 649 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"454 842 LINE",
+"497 765 OFFCURVE",
+"524 719 OFFCURVE",
+"566 647 CURVE SMOOTH",
+"587 611 OFFCURVE",
+"628 533 OFFCURVE",
+"674 440 CURVE",
+"679 544 LINE",
+"612 431 OFFCURVE",
+"541 320 OFFCURVE",
+"462 206 CURVE",
+"436 178 LINE",
+"362 71 OFFCURVE",
+"282 -39 OFFCURVE",
+"194 -158 CURVE",
+"253 -203 LINE",
+"333 -96 OFFCURVE",
+"408 7 OFFCURVE",
+"479 108 CURVE",
+"507 138 LINE",
+"589 257 OFFCURVE",
+"665 374 OFFCURVE",
+"736 489 CURVE",
+"654 649 OFFCURVE",
+"579 779 OFFCURVE",
+"492 910 CURVE",
+"405 908 LINE",
+"345 791 OFFCURVE",
+"281 688 OFFCURVE",
+"191 559 CURVE",
+"372 274 OFFCURVE",
+"467 102 OFFCURVE",
+"589 -161 CURVE",
+"658 -130 LINE",
+"534 138 OFFCURVE",
+"427 329 OFFCURVE",
+"251 607 CURVE",
+"257 520 LINE",
+"293 573 OFFCURVE",
+"316 606 OFFCURVE",
+"346 653 CURVE SMOOTH",
+"387 717 OFFCURVE",
+"420 774 OFFCURVE",
+"450 842 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 846;
+}
+);
+leftMetricsKey = u1B1AC;
+rightMetricsKey = u1B1DD;
+unicode = 1B22B;
+},
+{
+glyphname = u1B22C;
+lastChange = "2020-04-13 08:54:25 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"544 201 LINE",
+"489 389 OFFCURVE",
+"438 562 OFFCURVE",
+"343 774 CURVE",
+"287 714 LINE",
+"362 539 OFFCURVE",
+"424 360 OFFCURVE",
+"477 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"508 939 LINE",
+"350 801 OFFCURVE",
+"221 712 OFFCURVE",
+"60 613 CURVE",
+"97 551 LINE",
+"262 651 OFFCURVE",
+"393 744 OFFCURVE",
+"560 887 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"618 723 LINE",
+"548 667 OFFCURVE",
+"477 616 OFFCURVE",
+"403 567 CURVE",
+"377 555 LINE",
+"300 505 OFFCURVE",
+"219 457 OFFCURVE",
+"130 410 CURVE",
+"167 346 LINE",
+"252 391 OFFCURVE",
+"329 436 OFFCURVE",
+"402 483 CURVE",
+"428 494 LINE",
+"509 548 OFFCURVE",
+"585 604 OFFCURVE",
+"665 666 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"641 406 OFFCURVE",
+"664 423 OFFCURVE",
+"664 462 CURVE SMOOTH",
+"664 501 OFFCURVE",
+"641 518 OFFCURVE",
+"613 518 CURVE SMOOTH",
+"584 518 OFFCURVE",
+"561 501 OFFCURVE",
+"561 462 CURVE SMOOTH",
+"561 423 OFFCURVE",
+"584 406 OFFCURVE",
+"613 406 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"320 210 OFFCURVE",
+"343 227 OFFCURVE",
+"343 266 CURVE SMOOTH",
+"343 305 OFFCURVE",
+"320 322 OFFCURVE",
+"292 322 CURVE SMOOTH",
+"263 322 OFFCURVE",
+"240 305 OFFCURVE",
+"240 266 CURVE SMOOTH",
+"240 227 OFFCURVE",
+"263 210 OFFCURVE",
+"292 210 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"722 375 LINE",
+"573 272 OFFCURVE",
+"416 177 OFFCURVE",
+"245 89 CURVE",
+"278 23 LINE",
+"450 112 OFFCURVE",
+"610 208 OFFCURVE",
+"767 316 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"688 218 OFFCURVE",
+"706 181 OFFCURVE",
+"706 143 CURVE SMOOTH",
+"706 75 OFFCURVE",
+"641 6 OFFCURVE",
+"333 -139 CURVE",
+"366 -203 LINE",
+"686 -48 OFFCURVE",
+"782 25 OFFCURVE",
+"782 141 CURVE SMOOTH",
+"782 190 OFFCURVE",
+"763 242 OFFCURVE",
+"687 321 CURVE",
+"634 276 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 912;
+}
+);
+leftMetricsKey = u1B1A8;
+rightMetricsKey = u1B179;
+unicode = 1B22C;
+},
+{
+glyphname = u1B22D;
+lastChange = "2020-04-11 17:22:34 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"303 -163 OFFCURVE",
+"326 -146 OFFCURVE",
+"326 -107 CURVE SMOOTH",
+"326 -68 OFFCURVE",
+"303 -51 OFFCURVE",
+"275 -51 CURVE SMOOTH",
+"246 -51 OFFCURVE",
+"223 -68 OFFCURVE",
+"223 -107 CURVE SMOOTH",
+"223 -146 OFFCURVE",
+"246 -163 OFFCURVE",
+"275 -163 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"180 144 OFFCURVE",
+"203 161 OFFCURVE",
+"203 200 CURVE SMOOTH",
+"203 239 OFFCURVE",
+"180 256 OFFCURVE",
+"152 256 CURVE SMOOTH",
+"123 256 OFFCURVE",
+"100 239 OFFCURVE",
+"100 200 CURVE SMOOTH",
+"100 161 OFFCURVE",
+"123 144 OFFCURVE",
+"152 144 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"600 707 LINE",
+"513 548 OFFCURVE",
+"435 429 OFFCURVE",
+"342 305 CURVE",
+"394 254 LINE",
+"498 393 OFFCURVE",
+"567 496 OFFCURVE",
+"639 624 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"449 920 LINE",
+"381 777 OFFCURVE",
+"291 633 OFFCURVE",
+"200 507 CURVE",
+"291 328 OFFCURVE",
+"355 179 OFFCURVE",
+"415 16 CURVE",
+"507 9 LINE",
+"605 131 OFFCURVE",
+"694 263 OFFCURVE",
+"783 414 CURVE",
+"714 582 OFFCURVE",
+"645 732 OFFCURVE",
+"550 917 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"499 858 LINE",
+"531 781 OFFCURVE",
+"570 711 OFFCURVE",
+"606 635 CURVE SMOOTH",
+"648 546 OFFCURVE",
+"685 455 OFFCURVE",
+"725 351 CURVE",
+"728 472 LINE",
+"684 394 OFFCURVE",
+"641 323 OFFCURVE",
+"598 258 CURVE SMOOTH",
+"554 191 OFFCURVE",
+"512 135 OFFCURVE",
+"471 73 CURVE",
+"467 73 LINE",
+"443 152 OFFCURVE",
+"412 229 OFFCURVE",
+"376 309 CURVE SMOOTH",
+"343 383 OFFCURVE",
+"306 462 OFFCURVE",
+"261 550 CURVE",
+"266 470 LINE",
+"315 542 OFFCURVE",
+"339 576 OFFCURVE",
+"376 636 CURVE SMOOTH",
+"421 709 OFFCURVE",
+"457 770 OFFCURVE",
+"495 858 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 873;
+}
+);
+rightMetricsKey = u1B1B4;
+unicode = 1B22D;
+},
+{
+glyphname = u1B22E;
+lastChange = "2020-04-13 08:54:11 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"247 823 OFFCURVE",
+"270 840 OFFCURVE",
+"270 879 CURVE SMOOTH",
+"270 918 OFFCURVE",
+"247 935 OFFCURVE",
+"219 935 CURVE SMOOTH",
+"190 935 OFFCURVE",
+"167 918 OFFCURVE",
+"167 879 CURVE SMOOTH",
+"167 840 OFFCURVE",
+"190 823 OFFCURVE",
+"219 823 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"174 624 LINE",
+"318 542 OFFCURVE",
+"433 466 OFFCURVE",
+"559 365 CURVE",
+"604 422 LINE",
+"547 467 OFFCURVE",
+"466 528 OFFCURVE",
+"406 568 CURVE",
+"389 568 LINE",
+"333 610 OFFCURVE",
+"278 646 OFFCURVE",
+"213 685 CURVE",
+"223 645 LINE",
+"297 706 OFFCURVE",
+"356 763 OFFCURVE",
+"406 830 CURVE",
+"436 853 LINE",
+"448 867 OFFCURVE",
+"460 881 OFFCURVE",
+"473 896 CURVE",
+"417 939 LINE",
+"323 829 OFFCURVE",
+"256 760 OFFCURVE",
+"174 695 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"512 772 OFFCURVE",
+"490 818 OFFCURVE",
+"429 896 CURVE",
+"386 830 LINE",
+"410 830 LINE",
+"427 790 OFFCURVE",
+"440 748 OFFCURVE",
+"440 703 CURVE SMOOTH",
+"440 658 OFFCURVE",
+"425 615 OFFCURVE",
+"393 568 CURVE",
+"384 568 LINE",
+"346 519 OFFCURVE",
+"261 448 OFFCURVE",
+"181 385 CURVE",
+"228 330 LINE",
+"308 394 OFFCURVE",
+"363 446 OFFCURVE",
+"405 492 CURVE",
+"433 518 LINE",
+"494 590 OFFCURVE",
+"512 645 OFFCURVE",
+"512 701 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"365 347 LINE",
+"319 295 OFFCURVE",
+"277 252 OFFCURVE",
+"233 212 CURVE",
+"206 195 LINE",
+"165 158 OFFCURVE",
+"121 124 OFFCURVE",
+"70 86 CURVE",
+"115 29 LINE",
+"165 65 OFFCURVE",
+"208 100 OFFCURVE",
+"248 135 CURVE",
+"275 153 LINE",
+"324 198 OFFCURVE",
+"369 244 OFFCURVE",
+"420 299 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 195 LINE",
+"426 140 OFFCURVE",
+"379 95 OFFCURVE",
+"330 54 CURVE",
+"308 41 LINE",
+"260 2 OFFCURVE",
+"210 -34 OFFCURVE",
+"151 -72 CURVE",
+"192 -132 LINE",
+"245 -97 OFFCURVE",
+"294 -61 OFFCURVE",
+"344 -21 CURVE",
+"362 -12 LINE",
+"417 33 OFFCURVE",
+"472 84 OFFCURVE",
+"531 145 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"449 -177 LINE",
+"368 40 OFFCURVE",
+"270 200 OFFCURVE",
+"149 364 CURVE",
+"94 317 LINE",
+"221 149 OFFCURVE",
+"309 0 OFFCURVE",
+"382 -203 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 694;
+}
+);
+leftMetricsKey = u1B1ED;
+unicode = 1B22E;
+},
+{
+glyphname = u1B22F;
+lastChange = "2020-04-13 08:58:12 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"412 133 OFFCURVE",
+"435 150 OFFCURVE",
+"435 189 CURVE SMOOTH",
+"435 228 OFFCURVE",
+"412 245 OFFCURVE",
+"384 245 CURVE SMOOTH",
+"355 245 OFFCURVE",
+"332 228 OFFCURVE",
+"332 189 CURVE SMOOTH",
+"332 150 OFFCURVE",
+"355 133 OFFCURVE",
+"384 133 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"550 -28 OFFCURVE",
+"573 -11 OFFCURVE",
+"573 28 CURVE SMOOTH",
+"573 67 OFFCURVE",
+"550 84 OFFCURVE",
+"522 84 CURVE SMOOTH",
+"493 84 OFFCURVE",
+"470 67 OFFCURVE",
+"470 28 CURVE SMOOTH",
+"470 -11 OFFCURVE",
+"493 -28 OFFCURVE",
+"522 -28 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"411 -203 OFFCURVE",
+"434 -186 OFFCURVE",
+"434 -147 CURVE SMOOTH",
+"434 -108 OFFCURVE",
+"411 -91 OFFCURVE",
+"383 -91 CURVE SMOOTH",
+"354 -91 OFFCURVE",
+"331 -108 OFFCURVE",
+"331 -147 CURVE SMOOTH",
+"331 -186 OFFCURVE",
+"354 -203 OFFCURVE",
+"383 -203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"274 -31 OFFCURVE",
+"297 -14 OFFCURVE",
+"297 25 CURVE SMOOTH",
+"297 64 OFFCURVE",
+"274 81 OFFCURVE",
+"246 81 CURVE SMOOTH",
+"217 81 OFFCURVE",
+"194 64 OFFCURVE",
+"194 25 CURVE SMOOTH",
+"194 -14 OFFCURVE",
+"217 -31 OFFCURVE",
+"246 -31 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 564 LINE",
+"345 412 OFFCURVE",
+"445 318 OFFCURVE",
+"580 187 CURVE",
+"632 242 LINE",
+"555 316 OFFCURVE",
+"483 381 OFFCURVE",
+"369 483 CURVE",
+"354 483 LINE",
+"304 534 OFFCURVE",
+"246 576 OFFCURVE",
+"176 628 CURVE",
+"179 579 LINE",
+"252 663 OFFCURVE",
+"307 735 OFFCURVE",
+"347 810 CURVE",
+"374 844 LINE",
+"385 863 OFFCURVE",
+"397 883 OFFCURVE",
+"409 905 CURVE",
+"342 939 LINE",
+"268 808 OFFCURVE",
+"214 732 OFFCURVE",
+"136 640 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"479 729 OFFCURVE",
+"453 798 OFFCURVE",
+"363 880 CURVE",
+"318 810 LINE",
+"351 810 LINE",
+"385 749 OFFCURVE",
+"403 706 OFFCURVE",
+"403 650 CURVE SMOOTH",
+"403 603 OFFCURVE",
+"383 545 OFFCURVE",
+"358 483 CURVE",
+"348 483 LINE",
+"290 379 OFFCURVE",
+"202 274 OFFCURVE",
+"80 158 CURVE",
+"131 105 LINE",
+"248 218 OFFCURVE",
+"325 311 OFFCURVE",
+"380 393 CURVE",
+"406 424 LINE",
+"458 510 OFFCURVE",
+"479 582 OFFCURVE",
+"479 650 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 712;
+}
+);
+leftMetricsKey = u1B201;
+rightMetricsKey = u1B201;
+unicode = 1B22F;
+},
+{
+glyphname = u1B230;
+lastChange = "2020-04-13 08:58:33 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"271 307 OFFCURVE",
+"294 324 OFFCURVE",
+"294 363 CURVE SMOOTH",
+"294 402 OFFCURVE",
+"271 419 OFFCURVE",
+"243 419 CURVE SMOOTH",
+"214 419 OFFCURVE",
+"191 402 OFFCURVE",
+"191 363 CURVE SMOOTH",
+"191 324 OFFCURVE",
+"214 307 OFFCURVE",
+"243 307 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"576 553 OFFCURVE",
+"599 570 OFFCURVE",
+"599 609 CURVE SMOOTH",
+"599 648 OFFCURVE",
+"576 665 OFFCURVE",
+"548 665 CURVE SMOOTH",
+"519 665 OFFCURVE",
+"496 648 OFFCURVE",
+"496 609 CURVE SMOOTH",
+"496 570 OFFCURVE",
+"519 553 OFFCURVE",
+"548 553 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"534 939 LINE",
+"454 845 OFFCURVE",
+"379 765 OFFCURVE",
+"305 694 CURVE",
+"290 686 LINE",
+"213 613 OFFCURVE",
+"137 549 OFFCURVE",
+"60 489 CURVE",
+"105 430 LINE",
+"175 485 OFFCURVE",
+"244 542 OFFCURVE",
+"315 608 CURVE",
+"333 619 LINE",
+"414 695 OFFCURVE",
+"499 783 OFFCURVE",
+"590 890 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"171 856 LINE",
+"260 682 OFFCURVE",
+"331 521 OFFCURVE",
+"427 277 CURVE",
+"486 324 LINE",
+"387 572 OFFCURVE",
+"330 710 OFFCURVE",
+"235 891 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"308 154 LINE",
+"433 50 OFFCURVE",
+"543 -55 OFFCURVE",
+"643 -170 CURVE",
+"698 -120 LINE",
+"651 -68 OFFCURVE",
+"611 -29 OFFCURVE",
+"526 54 CURVE",
+"512 54 LINE",
+"472 104 OFFCURVE",
+"431 148 OFFCURVE",
+"357 210 CURVE",
+"353 166 LINE",
+"442 235 OFFCURVE",
+"501 289 OFFCURVE",
+"553 345 CURVE",
+"586 372 LINE",
+"600 387 OFFCURVE",
+"615 403 OFFCURVE",
+"631 421 CURVE",
+"577 474 LINE",
+"475 364 OFFCURVE",
+"394 290 OFFCURVE",
+"308 225 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"655 286 OFFCURVE",
+"636 335 OFFCURVE",
+"576 408 CURVE",
+"528 345 LINE",
+"557 345 LINE",
+"571 307 OFFCURVE",
+"579 266 OFFCURVE",
+"579 227 CURVE SMOOTH",
+"579 178 OFFCURVE",
+"563 120 OFFCURVE",
+"516 54 CURVE",
+"505 54 LINE",
+"433 -26 OFFCURVE",
+"366 -78 OFFCURVE",
+"272 -147 CURVE",
+"316 -203 LINE",
+"410 -135 OFFCURVE",
+"477 -72 OFFCURVE",
+"528 -19 CURVE",
+"555 2 LINE",
+"629 84 OFFCURVE",
+"655 153 OFFCURVE",
+"655 226 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 808;
+}
+);
+leftMetricsKey = u1B214;
+unicode = 1B230;
+},
+{
+glyphname = u1B231;
+lastChange = "2020-04-13 08:58:37 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"425 535 LINE",
+"530 659 OFFCURVE",
+"590 752 OFFCURVE",
+"653 915 CURVE",
+"581 939 LINE",
+"528 802 OFFCURVE",
+"480 711 OFFCURVE",
+"405 614 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"502 424 OFFCURVE",
+"445 649 OFFCURVE",
+"343 860 CURVE",
+"248 852 LINE",
+"206 702 OFFCURVE",
+"166 602 OFFCURVE",
+"114 499 CURVE",
+"182 469 LINE",
+"198 501 OFFCURVE",
+"211 530 OFFCURVE",
+"223 559 CURVE SMOOTH",
+"253 631 OFFCURVE",
+"280 699 OFFCURVE",
+"297 789 CURVE",
+"301 789 LINE",
+"335 704 OFFCURVE",
+"356 640 OFFCURVE",
+"378 556 CURVE SMOOTH",
+"410 433 OFFCURVE",
+"426 298 OFFCURVE",
+"426 138 CURVE SMOOTH",
+"426 20 OFFCURVE",
+"417 -74 OFFCURVE",
+"397 -193 CURVE",
+"472 -203 LINE",
+"492 -95 OFFCURVE",
+"502 16 OFFCURVE",
+"502 138 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"450 325 LINE",
+"579 428 OFFCURVE",
+"673 519 OFFCURVE",
+"775 689 CURVE",
+"708 724 LINE",
+"617 575 OFFCURVE",
+"544 489 OFFCURVE",
+"444 405 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"758 447 LINE",
+"663 332 OFFCURVE",
+"580 264 OFFCURVE",
+"449 184 CURVE",
+"478 127 LINE",
+"608 201 OFFCURVE",
+"711 276 OFFCURVE",
+"816 398 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"176 267 LINE",
+"204 267 LINE",
+"231 217 OFFCURVE",
+"267 138 OFFCURVE",
+"298 52 CURVE",
+"364 79 LINE",
+"328 167 OFFCURVE",
+"280 263 OFFCURVE",
+"226 343 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"166 402 LINE",
+"143 257 OFFCURVE",
+"125 175 OFFCURVE",
+"80 41 CURVE",
+"146 22 LINE",
+"176 112 OFFCURVE",
+"186 179 OFFCURVE",
+"200 267 CURVE",
+"222 317 LINE",
+"226 341 OFFCURVE",
+"232 365 OFFCURVE",
+"235 392 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 886;
+}
+);
+leftMetricsKey = u1B21E;
+unicode = 1B231;
+},
+{
+glyphname = u1B232;
+lastChange = "2020-04-13 08:58:41 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"462 -193 LINE",
+"437 57 OFFCURVE",
+"376 207 OFFCURVE",
+"255 446 CURVE",
+"258 374 LINE",
+"285 399 OFFCURVE",
+"312 426 OFFCURVE",
+"339 453 CURVE SMOOTH",
+"365 479 OFFCURVE",
+"392 508 OFFCURVE",
+"426 553 CURVE",
+"431 552 LINE",
+"454 499 OFFCURVE",
+"478 455 OFFCURVE",
+"498 412 CURVE SMOOTH",
+"527 350 OFFCURVE",
+"555 288 OFFCURVE",
+"576 231 CURVE",
+"567 294 LINE",
+"508 226 OFFCURVE",
+"443 163 OFFCURVE",
+"372 101 CURVE",
+"409 36 LINE",
+"489 106 OFFCURVE",
+"562 175 OFFCURVE",
+"642 263 CURVE",
+"595 381 OFFCURVE",
+"533 513 OFFCURVE",
+"472 619 CURVE",
+"400 627 LINE",
+"334 546 OFFCURVE",
+"268 477 OFFCURVE",
+"192 408 CURVE",
+"311 187 OFFCURVE",
+"369 57 OFFCURVE",
+"388 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"480 451 LINE",
+"426 389 OFFCURVE",
+"374 338 OFFCURVE",
+"308 278 CURVE",
+"348 223 LINE",
+"413 282 OFFCURVE",
+"468 334 OFFCURVE",
+"528 401 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"382 941 LINE",
+"298 764 OFFCURVE",
+"212 649 OFFCURVE",
+"80 529 CURVE",
+"129 473 LINE",
+"261 595 OFFCURVE",
+"361 719 OFFCURVE",
+"450 913 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"373 819 LINE",
+"484 721 OFFCURVE",
+"583 611 OFFCURVE",
+"669 489 CURVE",
+"729 533 LINE",
+"638 658 OFFCURVE",
+"546 762 OFFCURVE",
+"412 881 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 819;
+}
+);
+leftMetricsKey = u1B185;
+rightMetricsKey = u1B185;
+unicode = 1B232;
+},
+{
+glyphname = u1B233;
+lastChange = "2020-04-11 17:18:05 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"763 686 LINE",
+"647 499 OFFCURVE",
+"533 398 OFFCURVE",
+"411 322 CURVE",
+"396 236 LINE",
+"556 317 OFFCURVE",
+"707 446 OFFCURVE",
+"827 650 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"268 395 OFFCURVE",
+"195 474 OFFCURVE",
+"106 591 CURVE",
+"50 544 LINE",
+"138 425 OFFCURVE",
+"236 318 OFFCURVE",
+"361 236 CURVE",
+"367 322 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"268 611 OFFCURVE",
+"291 628 OFFCURVE",
+"291 667 CURVE SMOOTH",
+"291 706 OFFCURVE",
+"268 723 OFFCURVE",
+"240 723 CURVE SMOOTH",
+"211 723 OFFCURVE",
+"188 706 OFFCURVE",
+"188 667 CURVE SMOOTH",
+"188 628 OFFCURVE",
+"211 611 OFFCURVE",
+"240 611 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"638 663 OFFCURVE",
+"661 680 OFFCURVE",
+"661 719 CURVE SMOOTH",
+"661 758 OFFCURVE",
+"638 775 OFFCURVE",
+"610 775 CURVE SMOOTH",
+"581 775 OFFCURVE",
+"558 758 OFFCURVE",
+"558 719 CURVE SMOOTH",
+"558 680 OFFCURVE",
+"581 663 OFFCURVE",
+"610 663 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"620 96 OFFCURVE",
+"643 113 OFFCURVE",
+"643 152 CURVE SMOOTH",
+"643 191 OFFCURVE",
+"620 208 OFFCURVE",
+"592 208 CURVE SMOOTH",
+"563 208 OFFCURVE",
+"540 191 OFFCURVE",
+"540 152 CURVE SMOOTH",
+"540 113 OFFCURVE",
+"563 96 OFFCURVE",
+"592 96 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"177 134 OFFCURVE",
+"200 151 OFFCURVE",
+"200 190 CURVE SMOOTH",
+"200 229 OFFCURVE",
+"177 246 OFFCURVE",
+"149 246 CURVE SMOOTH",
+"120 246 OFFCURVE",
+"97 229 OFFCURVE",
+"97 190 CURVE SMOOTH",
+"97 151 OFFCURVE",
+"120 134 OFFCURVE",
+"149 134 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"402 938 LINE",
+"401 477 OFFCURVE",
+"328 96 OFFCURVE",
+"191 -166 CURVE",
+"258 -203 LINE",
+"397 61 OFFCURVE",
+"475 443 OFFCURVE",
+"478 938 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 867;
+}
+);
+unicode = 1B233;
+},
+{
+glyphname = u1B234;
+lastChange = "2020-04-13 08:59:34 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"558 707 LINE",
+"499 625 OFFCURVE",
+"434 546 OFFCURVE",
+"364 471 CURVE",
+"335 449 LINE",
+"282 394 OFFCURVE",
+"226 341 OFFCURVE",
+"168 292 CURVE",
+"218 235 LINE",
+"269 279 OFFCURVE",
+"317 324 OFFCURVE",
+"364 370 CURVE",
+"389 388 LINE",
+"471 472 OFFCURVE",
+"547 562 OFFCURVE",
+"620 663 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"485 23 LINE",
+"476 110 OFFCURVE",
+"463 193 OFFCURVE",
+"445 266 CURVE SMOOTH",
+"413 397 OFFCURVE",
+"366 536 OFFCURVE",
+"299 694 CURVE",
+"242 625 LINE",
+"338 415 OFFCURVE",
+"394 201 OFFCURVE",
+"426 -26 CURVE",
+"513 -47 LINE",
+"633 85 OFFCURVE",
+"713 193 OFFCURVE",
+"786 320 CURVE",
+"721 355 LINE",
+"692 304 OFFCURVE",
+"661 258 OFFCURVE",
+"629 213 CURVE SMOOTH",
+"580 144 OFFCURVE",
+"538 89 OFFCURVE",
+"490 22 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"511 348 LINE",
+"549 282 OFFCURVE",
+"581 218 OFFCURVE",
+"608 154 CURVE",
+"619 119 LINE",
+"640 66 OFFCURVE",
+"659 12 OFFCURVE",
+"675 -44 CURVE",
+"746 -20 LINE",
+"723 50 OFFCURVE",
+"699 113 OFFCURVE",
+"671 178 CURVE",
+"659 212 LINE",
+"633 268 OFFCURVE",
+"605 325 OFFCURVE",
+"571 386 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"429 939 LINE",
+"328 769 OFFCURVE",
+"202 624 OFFCURVE",
+"80 510 CURVE",
+"132 454 LINE",
+"265 579 OFFCURVE",
+"395 733 OFFCURVE",
+"497 904 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 -95 OFFCURVE",
+"109 -143 OFFCURVE",
+"177 -183 CURVE",
+"248 -174 LINE",
+"316 -95 OFFCURVE",
+"334 -30 OFFCURVE",
+"334 31 CURVE SMOOTH",
+"334 91 OFFCURVE",
+"300 132 OFFCURVE",
+"232 170 CURVE",
+"158 160 LINE",
+"100 78 OFFCURVE",
+"80 11 OFFCURVE",
+"80 -38 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 116 LINE",
+"244 84 OFFCURVE",
+"259 49 OFFCURVE",
+"259 20 CURVE SMOOTH",
+"259 -23 OFFCURVE",
+"249 -68 OFFCURVE",
+"209 -132 CURVE",
+"204 -133 LINE",
+"169 -98 OFFCURVE",
+"154 -67 OFFCURVE",
+"154 -34 CURVE SMOOTH",
+"154 8 OFFCURVE",
+"167 52 OFFCURVE",
+"199 115 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 886;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B200;
+unicode = 1B234;
+},
+{
+glyphname = u1B235;
+lastChange = "2020-04-13 08:59:37 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"445 285 LINE",
+"421 114 OFFCURVE",
+"383 -15 OFFCURVE",
+"330 -134 CURVE",
+"397 -160 LINE",
+"436 -67 OFFCURVE",
+"462 11 OFFCURVE",
+"479 135 CURVE",
+"502 190 LINE",
+"507 217 OFFCURVE",
+"512 246 OFFCURVE",
+"516 277 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"446 127 LINE",
+"484 136 LINE",
+"531 68 OFFCURVE",
+"557 22 OFFCURVE",
+"610 -77 CURVE",
+"679 -41 LINE",
+"620 59 OFFCURVE",
+"563 132 OFFCURVE",
+"482 222 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"360 939 LINE",
+"360 475 OFFCURVE",
+"337 354 OFFCURVE",
+"269 168 CURVE",
+"340 146 LINE",
+"386 273 OFFCURVE",
+"404 382 OFFCURVE",
+"412 542 CURVE",
+"430 603 LINE",
+"434 691 OFFCURVE",
+"436 815 OFFCURVE",
+"436 936 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"396 538 LINE",
+"417 543 LINE",
+"481 462 OFFCURVE",
+"501 423 OFFCURVE",
+"566 324 CURVE",
+"626 363 LINE",
+"573 452 OFFCURVE",
+"512 527 OFFCURVE",
+"425 619 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"440 690 OFFCURVE",
+"283 571 OFFCURVE",
+"120 471 CURVE",
+"149 276 OFFCURVE",
+"159 189 OFFCURVE",
+"159 0 CURVE SMOOTH",
+"159 -76 OFFCURVE",
+"154 -136 OFFCURVE",
+"145 -194 CURVE",
+"219 -203 LINE",
+"227 -142 OFFCURVE",
+"233 -70 OFFCURVE",
+"233 2 CURVE SMOOTH",
+"233 191 OFFCURVE",
+"223 289 OFFCURVE",
+"189 485 CURVE",
+"182 419 LINE",
+"269 474 OFFCURVE",
+"353 534 OFFCURVE",
+"438 600 CURVE SMOOTH",
+"507 654 OFFCURVE",
+"558 700 OFFCURVE",
+"623 767 CURVE",
+"628 766 LINE",
+"647 679 OFFCURVE",
+"660 606 OFFCURVE",
+"668 520 CURVE SMOOTH",
+"673 469 OFFCURVE",
+"675 416 OFFCURVE",
+"675 354 CURVE SMOOTH",
+"675 274 OFFCURVE",
+"674 204 OFFCURVE",
+"666 132 CURVE",
+"739 126 LINE",
+"745 193 OFFCURVE",
+"749 258 OFFCURVE",
+"749 354 CURVE SMOOTH",
+"749 519 OFFCURVE",
+"731 658 OFFCURVE",
+"689 822 CURVE",
+"607 844 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 889;
+}
+);
+leftMetricsKey = u1B1AB;
+rightMetricsKey = u1B1AB;
+unicode = 1B235;
+},
+{
+glyphname = u1B236;
+lastChange = "2020-04-13 08:59:48 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"292 248 LINE",
+"269 185 OFFCURVE",
+"245 127 OFFCURVE",
+"217 70 CURVE",
+"197 39 LINE",
+"164 -26 OFFCURVE",
+"125 -90 OFFCURVE",
+"79 -161 CURVE",
+"141 -203 LINE",
+"179 -147 OFFCURVE",
+"216 -86 OFFCURVE",
+"250 -21 CURVE",
+"269 6 LINE",
+"304 76 OFFCURVE",
+"335 149 OFFCURVE",
+"361 222 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"60 167 LINE",
+"172 52 OFFCURVE",
+"243 -47 OFFCURVE",
+"321 -180 CURVE",
+"390 -147 LINE",
+"311 -13 OFFCURVE",
+"217 110 OFFCURVE",
+"116 217 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"644 707 LINE",
+"557 548 OFFCURVE",
+"479 429 OFFCURVE",
+"386 305 CURVE",
+"438 254 LINE",
+"542 393 OFFCURVE",
+"611 496 OFFCURVE",
+"683 624 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"493 920 LINE",
+"425 777 OFFCURVE",
+"335 633 OFFCURVE",
+"244 507 CURVE",
+"335 328 OFFCURVE",
+"399 179 OFFCURVE",
+"459 16 CURVE",
+"551 9 LINE",
+"649 131 OFFCURVE",
+"738 263 OFFCURVE",
+"827 414 CURVE",
+"758 582 OFFCURVE",
+"689 732 OFFCURVE",
+"594 917 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"543 858 LINE",
+"575 781 OFFCURVE",
+"614 711 OFFCURVE",
+"650 635 CURVE SMOOTH",
+"692 546 OFFCURVE",
+"729 455 OFFCURVE",
+"769 351 CURVE",
+"772 472 LINE",
+"728 394 OFFCURVE",
+"685 323 OFFCURVE",
+"642 258 CURVE SMOOTH",
+"598 191 OFFCURVE",
+"556 135 OFFCURVE",
+"515 73 CURVE",
+"511 73 LINE",
+"487 152 OFFCURVE",
+"456 229 OFFCURVE",
+"420 309 CURVE SMOOTH",
+"387 383 OFFCURVE",
+"350 462 OFFCURVE",
+"305 550 CURVE",
+"310 470 LINE",
+"359 542 OFFCURVE",
+"383 576 OFFCURVE",
+"420 636 CURVE SMOOTH",
+"465 709 OFFCURVE",
+"501 770 OFFCURVE",
+"539 858 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 917;
+}
+);
+leftMetricsKey = u1B1C9;
+rightMetricsKey = u1B1B4;
+unicode = 1B236;
+},
+{
+glyphname = u1B237;
+lastChange = "2020-04-13 09:00:11 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"100 133 LINE",
+"202 40 OFFCURVE",
+"278 -43 OFFCURVE",
+"380 -164 CURVE",
+"439 -118 LINE",
+"395 -69 OFFCURVE",
+"364 -31 OFFCURVE",
+"292 45 CURVE",
+"278 45 LINE",
+"246 94 OFFCURVE",
+"199 137 OFFCURVE",
+"142 191 CURVE",
+"149 161 LINE",
+"196 205 OFFCURVE",
+"253 262 OFFCURVE",
+"284 315 CURVE",
+"311 343 LINE",
+"324 359 OFFCURVE",
+"337 377 OFFCURVE",
+"352 396 CURVE",
+"292 439 LINE",
+"221 337 OFFCURVE",
+"160 269 OFFCURVE",
+"100 215 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"258 315 LINE",
+"288 315 LINE",
+"304 274 OFFCURVE",
+"312 237 OFFCURVE",
+"312 201 CURVE SMOOTH",
+"312 153 OFFCURVE",
+"301 95 OFFCURVE",
+"282 45 CURVE",
+"272 45 LINE",
+"236 -31 OFFCURVE",
+"191 -95 OFFCURVE",
+"138 -162 CURVE",
+"195 -203 LINE",
+"241 -143 OFFCURVE",
+"272 -93 OFFCURVE",
+"298 -48 CURVE",
+"322 -15 LINE",
+"369 71 OFFCURVE",
+"382 134 OFFCURVE",
+"382 201 CURVE SMOOTH",
+"382 254 OFFCURVE",
+"366 315 OFFCURVE",
+"314 382 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"761 660 LINE",
+"713 598 OFFCURVE",
+"663 540 OFFCURVE",
+"612 486 CURVE",
+"590 469 LINE",
+"532 409 OFFCURVE",
+"471 352 OFFCURVE",
+"408 299 CURVE",
+"454 243 LINE",
+"511 291 OFFCURVE",
+"561 337 OFFCURVE",
+"610 385 CURVE",
+"634 404 LINE",
+"695 467 OFFCURVE",
+"753 535 OFFCURVE",
+"818 614 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"688 939 LINE",
+"575 771 OFFCURVE",
+"460 645 OFFCURVE",
+"306 502 CURVE",
+"358 445 LINE",
+"504 584 OFFCURVE",
+"634 722 OFFCURVE",
+"753 898 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"809 377 LINE",
+"702 249 OFFCURVE",
+"603 153 OFFCURVE",
+"481 60 CURVE",
+"526 0 LINE",
+"665 110 OFFCURVE",
+"758 205 OFFCURVE",
+"867 332 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"521 634 LINE",
+"572 472 OFFCURVE",
+"603 318 OFFCURVE",
+"621 157 CURVE",
+"690 187 LINE",
+"671 357 OFFCURVE",
+"637 513 OFFCURVE",
+"580 709 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 947;
+}
+);
+leftMetricsKey = u1B20A;
+rightMetricsKey = u1B197;
+unicode = 1B237;
+},
+{
+glyphname = u1B238;
+lastChange = "2020-04-13 09:00:23 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"314 432 LINE",
+"248 278 OFFCURVE",
+"170 134 OFFCURVE",
+"76 -7 CURVE",
+"132 -46 LINE",
+"155 -11 OFFCURVE",
+"178 25 OFFCURVE",
+"201 63 CURVE",
+"217 106 LINE",
+"240 146 OFFCURVE",
+"263 186 OFFCURVE",
+"292 241 CURVE",
+"311 261 LINE",
+"334 308 OFFCURVE",
+"356 357 OFFCURVE",
+"377 406 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"169 411 LINE",
+"202 361 OFFCURVE",
+"231 312 OFFCURVE",
+"259 265 CURVE",
+"280 247 LINE",
+"312 188 OFFCURVE",
+"335 144 OFFCURVE",
+"357 100 CURVE",
+"366 63 LINE",
+"386 19 OFFCURVE",
+"406 -24 OFFCURVE",
+"425 -69 CURVE",
+"487 -44 LINE",
+"409 145 OFFCURVE",
+"325 294 OFFCURVE",
+"225 448 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"423 300 LINE",
+"405 260 OFFCURVE",
+"387 220 OFFCURVE",
+"368 181 CURVE",
+"357 141 LINE",
+"332 92 OFFCURVE",
+"305 43 OFFCURVE",
+"277 -4 CURVE",
+"257 -19 LINE",
+"228 -66 OFFCURVE",
+"197 -111 OFFCURVE",
+"163 -155 CURVE",
+"217 -196 LINE",
+"321 -61 OFFCURVE",
+"407 92 OFFCURVE",
+"485 273 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"70 241 LINE",
+"175 80 OFFCURVE",
+"239 -48 OFFCURVE",
+"305 -203 CURVE",
+"369 -176 LINE",
+"345 -122 OFFCURVE",
+"323 -73 OFFCURVE",
+"300 -27 CURVE",
+"283 -6 LINE",
+"258 44 OFFCURVE",
+"233 91 OFFCURVE",
+"206 138 CURVE",
+"194 171 LINE",
+"173 207 OFFCURVE",
+"152 242 OFFCURVE",
+"128 280 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"415 697 LINE",
+"543 492 OFFCURVE",
+"595 353 OFFCURVE",
+"644 152 CURVE",
+"716 173 LINE",
+"663 394 OFFCURVE",
+"593 557 OFFCURVE",
+"470 747 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"569 939 LINE",
+"484 789 OFFCURVE",
+"371 657 OFFCURVE",
+"272 558 CURVE",
+"322 504 LINE",
+"439 619 OFFCURVE",
+"540 742 OFFCURVE",
+"635 904 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"707 736 LINE",
+"661 665 OFFCURVE",
+"614 600 OFFCURVE",
+"563 538 CURVE",
+"534 513 LINE",
+"489 461 OFFCURVE",
+"441 411 OFFCURVE",
+"390 361 CURVE",
+"442 307 LINE",
+"491 356 OFFCURVE",
+"535 401 OFFCURVE",
+"577 449 CURVE",
+"600 467 LINE",
+"656 533 OFFCURVE",
+"710 605 OFFCURVE",
+"770 695 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 860;
+}
+);
+rightMetricsKey = u1B187;
+unicode = 1B238;
+},
+{
+glyphname = u1B239;
+lastChange = "2020-04-13 09:00:26 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"599 325 OFFCURVE",
+"534 280 OFFCURVE",
+"437 223 CURVE",
+"464 161 LINE",
+"497 178 OFFCURVE",
+"527 196 OFFCURVE",
+"556 214 CURVE SMOOTH",
+"609 247 OFFCURVE",
+"649 285 OFFCURVE",
+"696 336 CURVE",
+"701 335 LINE",
+"696 218 OFFCURVE",
+"698 115 OFFCURVE",
+"692 40 CURVE",
+"766 36 LINE",
+"772 137 OFFCURVE",
+"771 233 OFFCURVE",
+"764 384 CURVE",
+"683 409 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"693 665 LINE",
+"593 543 OFFCURVE",
+"525 484 OFFCURVE",
+"400 398 CURVE",
+"438 340 LINE",
+"567 423 OFFCURVE",
+"656 500 OFFCURVE",
+"751 619 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"643 939 LINE",
+"552 789 OFFCURVE",
+"453 669 OFFCURVE",
+"326 550 CURVE",
+"396 392 OFFCURVE",
+"417 299 OFFCURVE",
+"417 167 CURVE SMOOTH",
+"417 37 OFFCURVE",
+"390 -60 OFFCURVE",
+"341 -177 CURVE",
+"410 -203 LINE",
+"463 -84 OFFCURVE",
+"491 32 OFFCURVE",
+"491 167 CURVE SMOOTH",
+"491 299 OFFCURVE",
+"465 414 OFFCURVE",
+"399 568 CURVE",
+"385 511 LINE",
+"505 623 OFFCURVE",
+"614 743 OFFCURVE",
+"710 902 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 55 OFFCURVE",
+"109 7 OFFCURVE",
+"177 -33 CURVE",
+"248 -24 LINE",
+"316 55 OFFCURVE",
+"334 120 OFFCURVE",
+"334 181 CURVE SMOOTH",
+"334 241 OFFCURVE",
+"300 282 OFFCURVE",
+"232 320 CURVE",
+"158 310 LINE",
+"100 228 OFFCURVE",
+"80 161 OFFCURVE",
+"80 112 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 266 LINE",
+"244 234 OFFCURVE",
+"259 199 OFFCURVE",
+"259 170 CURVE SMOOTH",
+"259 127 OFFCURVE",
+"249 82 OFFCURVE",
+"209 18 CURVE",
+"204 17 LINE",
+"169 52 OFFCURVE",
+"154 83 OFFCURVE",
+"154 116 CURVE SMOOTH",
+"154 158 OFFCURVE",
+"167 202 OFFCURVE",
+"199 265 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 890;
+}
+);
+leftMetricsKey = u1B1DC;
+unicode = 1B239;
+},
+{
+glyphname = u1B23A;
+lastChange = "2020-04-13 09:01:20 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"306 507 OFFCURVE",
+"348 562 OFFCURVE",
+"387 619 CURVE",
+"407 643 LINE",
+"460 726 OFFCURVE",
+"505 812 OFFCURVE",
+"549 913 CURVE",
+"480 939 LINE",
+"444 852 OFFCURVE",
+"405 778 OFFCURVE",
+"363 709 CURVE",
+"342 680 LINE",
+"336 672 OFFCURVE",
+"331 664 OFFCURVE",
+"325 655 CURVE SMOOTH",
+"292 604 OFFCURVE",
+"261 556 OFFCURVE",
+"230 506 CURVE",
+"226 506 LINE",
+"215 572 OFFCURVE",
+"193 625 OFFCURVE",
+"159 702 CURVE",
+"96 669 LINE",
+"136 595 OFFCURVE",
+"158 542 OFFCURVE",
+"184 459 CURVE",
+"256 451 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"624 -31 LINE",
+"566 391 OFFCURVE",
+"465 596 OFFCURVE",
+"274 895 CURVE",
+"212 854 LINE",
+"405 570 OFFCURVE",
+"499 357 OFFCURVE",
+"548 -40 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"311 267 LINE",
+"368 324 OFFCURVE",
+"420 381 OFFCURVE",
+"468 441 CURVE",
+"488 461 LINE",
+"549 541 OFFCURVE",
+"604 627 OFFCURVE",
+"655 732 CURVE",
+"589 761 LINE",
+"549 679 OFFCURVE",
+"504 605 OFFCURVE",
+"455 537 CURVE",
+"434 514 LINE",
+"382 446 OFFCURVE",
+"324 382 OFFCURVE",
+"259 317 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"672 553 LINE",
+"629 484 OFFCURVE",
+"581 418 OFFCURVE",
+"527 353 CURVE",
+"504 333 LINE",
+"450 270 OFFCURVE",
+"389 208 OFFCURVE",
+"321 144 CURVE",
+"368 94 LINE",
+"424 144 OFFCURVE",
+"477 198 OFFCURVE",
+"527 254 CURVE",
+"551 275 LINE",
+"619 353 OFFCURVE",
+"681 434 OFFCURVE",
+"734 514 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"118 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -103 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 804;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B231;
+unicode = 1B23A;
+},
+{
+glyphname = u1B23B;
+lastChange = "2020-04-13 09:01:32 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"566 939 LINE",
+"428 790 OFFCURVE",
+"295 685 OFFCURVE",
+"134 581 CURVE",
+"174 517 LINE",
+"342 626 OFFCURVE",
+"474 728 OFFCURVE",
+"623 890 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"672 691 LINE",
+"611 635 OFFCURVE",
+"546 579 OFFCURVE",
+"478 527 CURVE",
+"449 512 LINE",
+"371 455 OFFCURVE",
+"290 401 OFFCURVE",
+"207 353 CURVE",
+"244 287 LINE",
+"328 335 OFFCURVE",
+"403 384 OFFCURVE",
+"475 436 CURVE",
+"496 445 LINE",
+"573 503 OFFCURVE",
+"648 565 OFFCURVE",
+"725 636 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"719 306 OFFCURVE",
+"742 323 OFFCURVE",
+"742 362 CURVE SMOOTH",
+"742 401 OFFCURVE",
+"719 418 OFFCURVE",
+"691 418 CURVE SMOOTH",
+"662 418 OFFCURVE",
+"639 401 OFFCURVE",
+"639 362 CURVE SMOOTH",
+"639 323 OFFCURVE",
+"662 306 OFFCURVE",
+"691 306 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"394 112 OFFCURVE",
+"417 129 OFFCURVE",
+"417 168 CURVE SMOOTH",
+"417 207 OFFCURVE",
+"394 224 OFFCURVE",
+"366 224 CURVE SMOOTH",
+"337 224 OFFCURVE",
+"314 207 OFFCURVE",
+"314 168 CURVE SMOOTH",
+"314 129 OFFCURVE",
+"337 112 OFFCURVE",
+"366 112 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"586 -36 LINE",
+"570 242 OFFCURVE",
+"539 415 OFFCURVE",
+"435 738 CURVE",
+"374 693 LINE",
+"469 382 OFFCURVE",
+"496 235 OFFCURVE",
+"512 -41 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"118 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -103 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 822;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B22A;
+unicode = 1B23B;
+},
+{
+glyphname = u1B23C;
+lastChange = "2020-04-13 09:01:48 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"562 827 OFFCURVE",
+"585 844 OFFCURVE",
+"585 883 CURVE SMOOTH",
+"585 922 OFFCURVE",
+"562 939 OFFCURVE",
+"534 939 CURVE SMOOTH",
+"505 939 OFFCURVE",
+"482 922 OFFCURVE",
+"482 883 CURVE SMOOTH",
+"482 844 OFFCURVE",
+"505 827 OFFCURVE",
+"534 827 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"142 663 OFFCURVE",
+"165 680 OFFCURVE",
+"165 719 CURVE SMOOTH",
+"165 758 OFFCURVE",
+"142 775 OFFCURVE",
+"114 775 CURVE SMOOTH",
+"85 775 OFFCURVE",
+"62 758 OFFCURVE",
+"62 719 CURVE SMOOTH",
+"62 680 OFFCURVE",
+"85 663 OFFCURVE",
+"114 663 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"250 908 LINE",
+"366 597 OFFCURVE",
+"400 361 OFFCURVE",
+"400 76 CURVE SMOOTH",
+"400 -26 OFFCURVE",
+"396 -107 OFFCURVE",
+"387 -194 CURVE",
+"461 -203 LINE",
+"470 -110 OFFCURVE",
+"476 -22 OFFCURVE",
+"476 83 CURVE SMOOTH",
+"476 355 OFFCURVE",
+"443 616 OFFCURVE",
+"319 933 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"687 72 OFFCURVE",
+"710 89 OFFCURVE",
+"710 128 CURVE SMOOTH",
+"710 167 OFFCURVE",
+"687 184 OFFCURVE",
+"659 184 CURVE SMOOTH",
+"630 184 OFFCURVE",
+"607 167 OFFCURVE",
+"607 128 CURVE SMOOTH",
+"607 89 OFFCURVE",
+"630 72 OFFCURVE",
+"659 72 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"253 -61 OFFCURVE",
+"276 -44 OFFCURVE",
+"276 -5 CURVE SMOOTH",
+"276 34 OFFCURVE",
+"253 51 OFFCURVE",
+"225 51 CURVE SMOOTH",
+"196 51 OFFCURVE",
+"173 34 OFFCURVE",
+"173 -5 CURVE SMOOTH",
+"173 -44 OFFCURVE",
+"196 -61 OFFCURVE",
+"225 -61 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"696 792 LINE",
+"595 732 OFFCURVE",
+"498 680 OFFCURVE",
+"399 633 CURVE",
+"369 624 LINE",
+"269 577 OFFCURVE",
+"167 536 OFFCURVE",
+"60 497 CURVE",
+"89 426 LINE",
+"189 463 OFFCURVE",
+"286 502 OFFCURVE",
+"381 546 CURVE",
+"410 554 LINE",
+"518 604 OFFCURVE",
+"625 660 OFFCURVE",
+"735 726 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"643 619 OFFCURVE",
+"659 575 OFFCURVE",
+"659 523 CURVE SMOOTH",
+"659 452 OFFCURVE",
+"616 414 OFFCURVE",
+"444 343 CURVE",
+"412 335 LINE",
+"340 306 OFFCURVE",
+"249 271 OFFCURVE",
+"132 227 CURVE",
+"159 156 LINE",
+"263 195 OFFCURVE",
+"349 227 OFFCURVE",
+"420 256 CURVE",
+"444 261 LINE",
+"669 355 OFFCURVE",
+"735 413 OFFCURVE",
+"735 523 CURVE SMOOTH",
+"735 602 OFFCURVE",
+"705 653 OFFCURVE",
+"645 747 CURVE",
+"598 687 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 855;
+}
+);
+leftMetricsKey = u1B1B3;
+rightMetricsKey = u1B1B3;
+unicode = 1B23C;
+},
+{
+glyphname = u1B23D;
+lastChange = "2020-04-13 09:02:23 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"589 569 LINE",
+"510 495 OFFCURVE",
+"430 430 OFFCURVE",
+"347 371 CURVE",
+"322 360 LINE",
+"270 324 OFFCURVE",
+"216 290 OFFCURVE",
+"161 259 CURVE",
+"197 200 LINE",
+"248 229 OFFCURVE",
+"296 258 OFFCURVE",
+"344 290 CURVE",
+"366 299 LINE",
+"456 361 OFFCURVE",
+"544 431 OFFCURVE",
+"640 520 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"432 -10 LINE",
+"429 78 OFFCURVE",
+"416 160 OFFCURVE",
+"403 233 CURVE SMOOTH",
+"376 390 OFFCURVE",
+"337 548 OFFCURVE",
+"287 707 CURVE",
+"223 661 LINE",
+"297 429 OFFCURVE",
+"340 195 OFFCURVE",
+"368 -48 CURVE",
+"456 -80 LINE",
+"581 27 OFFCURVE",
+"656 118 OFFCURVE",
+"751 263 CURVE",
+"689 303 LINE",
+"653 246 OFFCURVE",
+"620 198 OFFCURVE",
+"586 154 CURVE SMOOTH",
+"536 90 OFFCURVE",
+"491 46 OFFCURVE",
+"437 -11 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"489 274 LINE",
+"521 212 OFFCURVE",
+"547 150 OFFCURVE",
+"568 91 CURVE",
+"570 68 LINE",
+"592 3 OFFCURVE",
+"608 -60 OFFCURVE",
+"621 -120 CURVE",
+"693 -103 LINE",
+"675 -26 OFFCURVE",
+"651 48 OFFCURVE",
+"624 122 CURVE",
+"619 149 LINE",
+"598 201 OFFCURVE",
+"576 253 OFFCURVE",
+"551 305 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"450 939 LINE",
+"330 807 OFFCURVE",
+"216 709 OFFCURVE",
+"80 610 CURVE",
+"120 550 LINE",
+"262 651 OFFCURVE",
+"384 760 OFFCURVE",
+"507 895 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"511 746 LINE",
+"443 673 OFFCURVE",
+"374 610 OFFCURVE",
+"302 553 CURVE",
+"281 543 LINE",
+"229 504 OFFCURVE",
+"174 467 OFFCURVE",
+"116 432 CURVE",
+"151 373 LINE",
+"205 406 OFFCURVE",
+"256 440 OFFCURVE",
+"304 475 CURVE",
+"323 483 LINE",
+"406 546 OFFCURVE",
+"483 615 OFFCURVE",
+"566 700 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"158 134 LINE",
+"187 10 OFFCURVE",
+"196 -66 OFFCURVE",
+"202 -203 CURVE",
+"274 -198 LINE",
+"268 -68 OFFCURVE",
+"254 36 OFFCURVE",
+"226 152 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 831;
+}
+);
+leftMetricsKey = u1B1B1;
+rightMetricsKey = u1B19E;
+unicode = 1B23D;
+},
+{
+glyphname = u1B23E;
+lastChange = "2020-04-13 09:02:28 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"160 267 OFFCURVE",
+"183 284 OFFCURVE",
+"183 323 CURVE SMOOTH",
+"183 362 OFFCURVE",
+"160 379 OFFCURVE",
+"132 379 CURVE SMOOTH",
+"103 379 OFFCURVE",
+"80 362 OFFCURVE",
+"80 323 CURVE SMOOTH",
+"80 284 OFFCURVE",
+"103 267 OFFCURVE",
+"132 267 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"431 707 OFFCURVE",
+"454 724 OFFCURVE",
+"454 763 CURVE SMOOTH",
+"454 802 OFFCURVE",
+"431 819 OFFCURVE",
+"403 819 CURVE SMOOTH",
+"374 819 OFFCURVE",
+"351 802 OFFCURVE",
+"351 763 CURVE SMOOTH",
+"351 724 OFFCURVE",
+"374 707 OFFCURVE",
+"403 707 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"697 500 LINE",
+"598 343 OFFCURVE",
+"537 261 OFFCURVE",
+"435 134 CURVE",
+"480 73 LINE",
+"579 196 OFFCURVE",
+"640 276 OFFCURVE",
+"728 410 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"684 914 LINE",
+"532 654 OFFCURVE",
+"419 491 OFFCURVE",
+"332 380 CURVE",
+"357 286 LINE",
+"463 429 OFFCURVE",
+"577 583 OFFCURVE",
+"750 879 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"593 701 LINE",
+"675 501 OFFCURVE",
+"736 356 OFFCURVE",
+"811 141 CURVE",
+"816 258 LINE",
+"769 185 OFFCURVE",
+"728 126 OFFCURVE",
+"687 72 CURVE SMOOTH",
+"641 12 OFFCURVE",
+"598 -40 OFFCURVE",
+"555 -98 CURVE",
+"551 -98 LINE",
+"529 -19 OFFCURVE",
+"500 57 OFFCURVE",
+"469 136 CURVE SMOOTH",
+"384 355 OFFCURVE",
+"292 571 OFFCURVE",
+"200 748 CURVE",
+"135 714 LINE",
+"251 489 OFFCURVE",
+"379 176 OFFCURVE",
+"499 -153 CURVE",
+"587 -163 LINE",
+"699 -35 OFFCURVE",
+"763 44 OFFCURVE",
+"870 201 CURVE",
+"804 387 OFFCURVE",
+"742 540 OFFCURVE",
+"650 744 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 960;
+}
+);
+leftMetricsKey = u1B176;
+rightMetricsKey = u1B1B4;
+unicode = 1B23E;
+},
+{
+glyphname = u1B23F;
+lastChange = "2020-04-13 09:03:07 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"706 96 OFFCURVE",
+"729 113 OFFCURVE",
+"729 152 CURVE SMOOTH",
+"729 191 OFFCURVE",
+"706 208 OFFCURVE",
+"678 208 CURVE SMOOTH",
+"649 208 OFFCURVE",
+"626 191 OFFCURVE",
+"626 152 CURVE SMOOTH",
+"626 113 OFFCURVE",
+"649 96 OFFCURVE",
+"678 96 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"712 -123 OFFCURVE",
+"735 -106 OFFCURVE",
+"735 -67 CURVE SMOOTH",
+"735 -28 OFFCURVE",
+"712 -11 OFFCURVE",
+"684 -11 CURVE SMOOTH",
+"655 -11 OFFCURVE",
+"632 -28 OFFCURVE",
+"632 -67 CURVE SMOOTH",
+"632 -106 OFFCURVE",
+"655 -123 OFFCURVE",
+"684 -123 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"275 520 OFFCURVE",
+"323 571 OFFCURVE",
+"370 625 CURVE",
+"396 649 LINE",
+"458 725 OFFCURVE",
+"516 807 OFFCURVE",
+"575 903 CURVE",
+"510 939 LINE",
+"460 855 OFFCURVE",
+"409 782 OFFCURVE",
+"356 715 CURVE",
+"333 693 LINE",
+"327 684 OFFCURVE",
+"320 676 OFFCURVE",
+"313 668 CURVE SMOOTH",
+"271 618 OFFCURVE",
+"230 566 OFFCURVE",
+"197 527 CURVE",
+"193 527 LINE",
+"180 597 OFFCURVE",
+"154 663 OFFCURVE",
+"125 720 CURVE",
+"60 689 LINE",
+"103 603 OFFCURVE",
+"123 559 OFFCURVE",
+"147 481 CURVE",
+"222 468 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"207 856 LINE",
+"382 619 OFFCURVE",
+"453 379 OFFCURVE",
+"453 57 CURVE SMOOTH",
+"453 -33 OFFCURVE",
+"449 -111 OFFCURVE",
+"439 -192 CURVE",
+"512 -203 LINE",
+"523 -116 OFFCURVE",
+"529 -36 OFFCURVE",
+"529 58 CURVE SMOOTH",
+"529 408 OFFCURVE",
+"440 664 OFFCURVE",
+"267 900 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"245 252 LINE",
+"314 312 OFFCURVE",
+"376 370 OFFCURVE",
+"436 431 CURVE",
+"464 455 LINE",
+"534 529 OFFCURVE",
+"602 608 OFFCURVE",
+"674 702 CURVE",
+"616 744 LINE",
+"562 671 OFFCURVE",
+"503 602 OFFCURVE",
+"440 534 CURVE",
+"412 511 LINE",
+"345 441 OFFCURVE",
+"273 372 OFFCURVE",
+"197 304 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"687 522 LINE",
+"625 443 OFFCURVE",
+"560 368 OFFCURVE",
+"490 298 CURVE",
+"462 276 LINE",
+"400 215 OFFCURVE",
+"334 158 OFFCURVE",
+"265 104 CURVE",
+"311 51 LINE",
+"373 100 OFFCURVE",
+"427 146 OFFCURVE",
+"476 192 CURVE",
+"512 220 LINE",
+"591 296 OFFCURVE",
+"663 376 OFFCURVE",
+"743 477 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 863;
+}
+);
+leftMetricsKey = u1B1CF;
+rightMetricsKey = u1B1CF;
+unicode = 1B23F;
+},
+{
+glyphname = u1B240;
+lastChange = "2020-04-13 09:03:10 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"470 518 LINE",
+"439 356 OFFCURVE",
+"374 214 OFFCURVE",
+"304 132 CURVE",
+"356 85 LINE",
+"428 172 OFFCURVE",
+"508 333 OFFCURVE",
+"541 505 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"334 318 OFFCURVE",
+"357 335 OFFCURVE",
+"357 374 CURVE SMOOTH",
+"357 413 OFFCURVE",
+"334 430 OFFCURVE",
+"306 430 CURVE SMOOTH",
+"277 430 OFFCURVE",
+"254 413 OFFCURVE",
+"254 374 CURVE SMOOTH",
+"254 335 OFFCURVE",
+"277 318 OFFCURVE",
+"306 318 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"599 119 OFFCURVE",
+"622 136 OFFCURVE",
+"622 175 CURVE SMOOTH",
+"622 214 OFFCURVE",
+"599 231 OFFCURVE",
+"571 231 CURVE SMOOTH",
+"542 231 OFFCURVE",
+"519 214 OFFCURVE",
+"519 175 CURVE SMOOTH",
+"519 136 OFFCURVE",
+"542 119 OFFCURVE",
+"571 119 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"381 939 LINE",
+"308 726 OFFCURVE",
+"228 591 OFFCURVE",
+"94 427 CURVE",
+"154 380 LINE",
+"288 546 OFFCURVE",
+"372 680 OFFCURVE",
+"454 917 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"373 812 LINE",
+"494 677 OFFCURVE",
+"587 556 OFFCURVE",
+"685 396 CURVE",
+"748 438 LINE",
+"645 601 OFFCURVE",
+"555 723 OFFCURVE",
+"411 879 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"118 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -103 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 838;
+}
+);
+leftMetricsKey = u1B23A;
+rightMetricsKey = u1B185;
+unicode = 1B240;
+},
+{
+glyphname = u1B241;
+lastChange = "2020-04-13 09:06:13 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"199 -153 OFFCURVE",
+"222 -136 OFFCURVE",
+"222 -97 CURVE SMOOTH",
+"222 -58 OFFCURVE",
+"199 -41 OFFCURVE",
+"171 -41 CURVE SMOOTH",
+"142 -41 OFFCURVE",
+"119 -58 OFFCURVE",
+"119 -97 CURVE SMOOTH",
+"119 -136 OFFCURVE",
+"142 -153 OFFCURVE",
+"171 -153 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"615 -129 OFFCURVE",
+"638 -112 OFFCURVE",
+"638 -73 CURVE SMOOTH",
+"638 -34 OFFCURVE",
+"615 -17 OFFCURVE",
+"587 -17 CURVE SMOOTH",
+"558 -17 OFFCURVE",
+"535 -34 OFFCURVE",
+"535 -73 CURVE SMOOTH",
+"535 -112 OFFCURVE",
+"558 -129 OFFCURVE",
+"587 -129 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"490 707 LINE",
+"403 548 OFFCURVE",
+"325 429 OFFCURVE",
+"232 305 CURVE",
+"284 254 LINE",
+"388 393 OFFCURVE",
+"457 496 OFFCURVE",
+"529 624 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"339 920 LINE",
+"271 777 OFFCURVE",
+"181 633 OFFCURVE",
+"90 507 CURVE",
+"181 328 OFFCURVE",
+"245 179 OFFCURVE",
+"305 16 CURVE",
+"397 9 LINE",
+"495 131 OFFCURVE",
+"584 263 OFFCURVE",
+"673 414 CURVE",
+"604 582 OFFCURVE",
+"535 732 OFFCURVE",
+"440 917 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"389 858 LINE",
+"421 781 OFFCURVE",
+"460 711 OFFCURVE",
+"496 635 CURVE SMOOTH",
+"538 546 OFFCURVE",
+"575 455 OFFCURVE",
+"615 351 CURVE",
+"618 472 LINE",
+"574 394 OFFCURVE",
+"531 323 OFFCURVE",
+"488 258 CURVE SMOOTH",
+"444 191 OFFCURVE",
+"402 135 OFFCURVE",
+"361 73 CURVE",
+"357 73 LINE",
+"333 152 OFFCURVE",
+"302 229 OFFCURVE",
+"266 309 CURVE SMOOTH",
+"233 383 OFFCURVE",
+"196 462 OFFCURVE",
+"151 550 CURVE",
+"156 470 LINE",
+"205 542 OFFCURVE",
+"229 576 OFFCURVE",
+"266 636 CURVE SMOOTH",
+"311 709 OFFCURVE",
+"347 770 OFFCURVE",
+"385 858 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 763;
+}
+);
+leftMetricsKey = u1B1B4;
+rightMetricsKey = u1B1B4;
+unicode = 1B241;
+},
+{
+glyphname = u1B242;
+lastChange = "2020-04-13 09:06:11 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"525 508 LINE",
+"433 410 OFFCURVE",
+"357 347 OFFCURVE",
+"256 273 CURVE",
+"289 169 OFFCURVE",
+"300 94 OFFCURVE",
+"300 17 CURVE SMOOTH",
+"300 -56 OFFCURVE",
+"296 -110 OFFCURVE",
+"281 -188 CURVE",
+"351 -203 LINE",
+"367 -129 OFFCURVE",
+"374 -69 OFFCURVE",
+"374 17 CURVE SMOOTH",
+"374 107 OFFCURVE",
+"363 175 OFFCURVE",
+"328 281 CURVE",
+"328 236 LINE",
+"411 297 OFFCURVE",
+"499 369 OFFCURVE",
+"578 459 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"546 70 LINE",
+"532 123 OFFCURVE",
+"521 159 OFFCURVE",
+"498 206 CURVE",
+"437 175 LINE",
+"467 121 OFFCURVE",
+"479 91 OFFCURVE",
+"499 28 CURVE",
+"590 19 LINE",
+"639 99 OFFCURVE",
+"656 152 OFFCURVE",
+"656 219 CURVE SMOOTH",
+"656 292 OFFCURVE",
+"625 354 OFFCURVE",
+"512 464 CURVE",
+"479 404 LINE",
+"557 324 OFFCURVE",
+"580 272 OFFCURVE",
+"580 212 CURVE SMOOTH",
+"580 168 OFFCURVE",
+"570 121 OFFCURVE",
+"550 70 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"476 939 LINE",
+"396 854 OFFCURVE",
+"327 788 OFFCURVE",
+"256 726 CURVE",
+"233 711 LINE",
+"179 667 OFFCURVE",
+"124 624 OFFCURVE",
+"60 578 CURVE",
+"101 517 LINE",
+"160 560 OFFCURVE",
+"214 601 OFFCURVE",
+"267 644 CURVE",
+"288 657 LINE",
+"365 722 OFFCURVE",
+"441 795 OFFCURVE",
+"532 891 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"490 677 LINE",
+"381 573 OFFCURVE",
+"278 490 OFFCURVE",
+"153 397 CURVE",
+"194 336 LINE",
+"330 438 OFFCURVE",
+"421 510 OFFCURVE",
+"541 624 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"135 856 LINE",
+"224 682 OFFCURVE",
+"275 560 OFFCURVE",
+"311 445 CURVE",
+"372 491 LINE",
+"333 610 OFFCURVE",
+"296 709 OFFCURVE",
+"201 890 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 756;
+}
+);
+leftMetricsKey = u1B214;
+rightMetricsKey = u1B18D;
+unicode = 1B242;
+},
+{
+glyphname = u1B243;
+lastChange = "2020-04-13 09:06:01 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"250 -122 LINE",
+"249 30 OFFCURVE",
+"225 178 OFFCURVE",
+"187 297 CURVE",
+"120 272 LINE",
+"158 160 OFFCURVE",
+"176 22 OFFCURVE",
+"179 -122 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"877 -55 LINE",
+"894 36 OFFCURVE",
+"900 114 OFFCURVE",
+"900 202 CURVE SMOOTH",
+"900 302 OFFCURVE",
+"895 383 OFFCURVE",
+"873 491 CURVE",
+"803 475 LINE",
+"821 376 OFFCURVE",
+"828 301 OFFCURVE",
+"828 199 CURVE SMOOTH",
+"828 108 OFFCURVE",
+"822 31 OFFCURVE",
+"808 -44 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"385 76 OFFCURVE",
+"408 93 OFFCURVE",
+"408 132 CURVE SMOOTH",
+"408 171 OFFCURVE",
+"385 188 OFFCURVE",
+"357 188 CURVE SMOOTH",
+"328 188 OFFCURVE",
+"305 171 OFFCURVE",
+"305 132 CURVE SMOOTH",
+"305 93 OFFCURVE",
+"328 76 OFFCURVE",
+"357 76 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"722 198 OFFCURVE",
+"745 215 OFFCURVE",
+"745 254 CURVE SMOOTH",
+"745 293 OFFCURVE",
+"722 310 OFFCURVE",
+"694 310 CURVE SMOOTH",
+"665 310 OFFCURVE",
+"642 293 OFFCURVE",
+"642 254 CURVE SMOOTH",
+"642 215 OFFCURVE",
+"665 198 OFFCURVE",
+"694 198 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"572 -200 LINE",
+"580 172 OFFCURVE",
+"538 504 OFFCURVE",
+"451 754 CURVE",
+"398 686 LINE",
+"466 453 OFFCURVE",
+"505 163 OFFCURVE",
+"497 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"626 939 LINE",
+"473 806 OFFCURVE",
+"335 706 OFFCURVE",
+"147 593 CURVE",
+"184 531 LINE",
+"361 638 OFFCURVE",
+"521 748 OFFCURVE",
+"676 884 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"715 643 LINE",
+"638 591 OFFCURVE",
+"567 545 OFFCURVE",
+"492 502 CURVE",
+"466 494 LINE",
+"389 450 OFFCURVE",
+"307 409 OFFCURVE",
+"211 366 CURVE",
+"242 299 LINE",
+"329 338 OFFCURVE",
+"406 376 OFFCURVE",
+"480 416 CURVE",
+"506 423 LINE",
+"591 470 OFFCURVE",
+"672 520 OFFCURVE",
+"761 583 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 1040;
+}
+);
+leftMetricsKey = u1B1F5;
+rightMetricsKey = u1B1AB;
+unicode = 1B243;
+},
+{
+glyphname = u1B244;
+lastChange = "2020-04-13 09:05:50 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"691 93 LINE",
+"542 -2 OFFCURVE",
+"416 -67 OFFCURVE",
+"240 -138 CURVE",
+"267 -203 LINE",
+"447 -128 OFFCURVE",
+"577 -64 OFFCURVE",
+"730 35 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"645 301 LINE",
+"584 258 OFFCURVE",
+"525 219 OFFCURVE",
+"465 183 CURVE",
+"424 163 LINE",
+"354 124 OFFCURVE",
+"283 88 OFFCURVE",
+"205 53 CURVE",
+"235 -11 LINE",
+"305 21 OFFCURVE",
+"367 52 OFFCURVE",
+"426 85 CURVE",
+"467 105 LINE",
+"539 147 OFFCURVE",
+"609 191 OFFCURVE",
+"685 242 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"559 718 LINE",
+"508 675 OFFCURVE",
+"455 634 OFFCURVE",
+"399 594 CURVE",
+"361 570 LINE",
+"302 530 OFFCURVE",
+"239 490 OFFCURVE",
+"172 450 CURVE",
+"192 378 LINE",
+"258 418 OFFCURVE",
+"320 458 OFFCURVE",
+"379 498 CURVE",
+"423 525 LINE",
+"488 570 OFFCURVE",
+"550 616 OFFCURVE",
+"614 667 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"491 -83 LINE",
+"487 90 OFFCURVE",
+"479 214 OFFCURVE",
+"462 339 CURVE",
+"452 383 LINE",
+"433 504 OFFCURVE",
+"410 630 OFFCURVE",
+"375 767 CURVE",
+"320 713 LINE",
+"352 573 OFFCURVE",
+"373 455 OFFCURVE",
+"389 346 CURVE",
+"395 297 LINE",
+"409 186 OFFCURVE",
+"416 76 OFFCURVE",
+"419 -90 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"501 929 LINE",
+"367 817 OFFCURVE",
+"239 725 OFFCURVE",
+"100 637 CURVE",
+"132 490 OFFCURVE",
+"162 339 OFFCURVE",
+"176 208 CURVE",
+"255 184 LINE",
+"306 215 OFFCURVE",
+"358 243 OFFCURVE",
+"412 277 CURVE",
+"456 303 LINE",
+"524 348 OFFCURVE",
+"593 397 OFFCURVE",
+"667 454 CURVE",
+"645 608 OFFCURVE",
+"615 761 OFFCURVE",
+"580 906 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"517 853 LINE",
+"533 782 OFFCURVE",
+"545 723 OFFCURVE",
+"559 653 CURVE SMOOTH",
+"572 589 OFFCURVE",
+"581 527 OFFCURVE",
+"588 467 CURVE",
+"625 519 LINE",
+"564 469 OFFCURVE",
+"503 424 OFFCURVE",
+"443 383 CURVE",
+"396 355 LINE",
+"340 319 OFFCURVE",
+"292 290 OFFCURVE",
+"245 258 CURVE",
+"240 259 LINE",
+"237 332 OFFCURVE",
+"222 409 OFFCURVE",
+"210 471 CURVE SMOOTH",
+"201 518 OFFCURVE",
+"188 585 OFFCURVE",
+"173 646 CURVE",
+"153 585 LINE",
+"217 624 OFFCURVE",
+"286 670 OFFCURVE",
+"355 721 CURVE SMOOTH",
+"415 765 OFFCURVE",
+"462 805 OFFCURVE",
+"512 854 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 830;
+}
+);
+leftMetricsKey = u1B205;
+rightMetricsKey = u1B216;
+unicode = 1B244;
+},
+{
+glyphname = u1B245;
+lastChange = "2020-04-13 09:05:48 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"435 173 LINE",
+"545 93 OFFCURVE",
+"636 21 OFFCURVE",
+"720 -60 CURVE",
+"766 -9 LINE",
+"735 20 OFFCURVE",
+"689 66 OFFCURVE",
+"638 107 CURVE",
+"623 106 LINE",
+"583 148 OFFCURVE",
+"545 177 OFFCURVE",
+"471 230 CURVE",
+"471 187 LINE",
+"531 242 OFFCURVE",
+"586 302 OFFCURVE",
+"632 365 CURVE",
+"661 393 LINE",
+"675 411 OFFCURVE",
+"688 430 OFFCURVE",
+"702 450 CURVE",
+"644 488 LINE",
+"572 386 OFFCURVE",
+"507 310 OFFCURVE",
+"435 244 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"598 365 LINE",
+"636 365 LINE",
+"650 323 OFFCURVE",
+"656 286 OFFCURVE",
+"656 250 CURVE SMOOTH",
+"656 204 OFFCURVE",
+"644 154 OFFCURVE",
+"627 106 CURVE",
+"616 106 LINE",
+"574 26 OFFCURVE",
+"520 -37 OFFCURVE",
+"415 -134 CURVE",
+"465 -183 LINE",
+"556 -99 OFFCURVE",
+"612 -30 OFFCURVE",
+"651 30 CURVE",
+"672 59 LINE",
+"708 124 OFFCURVE",
+"720 181 OFFCURVE",
+"720 243 CURVE SMOOTH",
+"720 313 OFFCURVE",
+"704 358 OFFCURVE",
+"670 416 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"338 780 OFFCURVE",
+"361 797 OFFCURVE",
+"361 836 CURVE SMOOTH",
+"361 875 OFFCURVE",
+"338 892 OFFCURVE",
+"310 892 CURVE SMOOTH",
+"281 892 OFFCURVE",
+"258 875 OFFCURVE",
+"258 836 CURVE SMOOTH",
+"258 797 OFFCURVE",
+"281 780 OFFCURVE",
+"310 780 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"486 939 LINE",
+"431 760 OFFCURVE",
+"372 657 OFFCURVE",
+"259 531 CURVE",
+"295 476 LINE",
+"422 608 OFFCURVE",
+"504 739 OFFCURVE",
+"560 919 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"605 742 LINE",
+"523 577 OFFCURVE",
+"434 469 OFFCURVE",
+"314 376 CURVE",
+"344 313 LINE",
+"484 424 OFFCURVE",
+"590 538 OFFCURVE",
+"673 709 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"160 191 OFFCURVE",
+"183 208 OFFCURVE",
+"183 247 CURVE SMOOTH",
+"183 286 OFFCURVE",
+"160 303 OFFCURVE",
+"132 303 CURVE SMOOTH",
+"103 303 OFFCURVE",
+"80 286 OFFCURVE",
+"80 247 CURVE SMOOTH",
+"80 208 OFFCURVE",
+"103 191 OFFCURVE",
+"132 191 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"345 -203 LINE",
+"365 -102 OFFCURVE",
+"375 0 OFFCURVE",
+"375 126 CURVE SMOOTH",
+"375 379 OFFCURVE",
+"321 584 OFFCURVE",
+"149 836 CURVE",
+"90 794 LINE",
+"254 562 OFFCURVE",
+"299 371 OFFCURVE",
+"299 126 CURVE SMOOTH",
+"299 11 OFFCURVE",
+"288 -83 OFFCURVE",
+"270 -191 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 876;
+}
+);
+leftMetricsKey = u1B176;
+rightMetricsKey = u1B17C;
+unicode = 1B245;
+},
+{
+glyphname = u1B246;
+lastChange = "2020-04-13 09:05:41 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"675 281 LINE",
+"647 336 OFFCURVE",
+"616 392 OFFCURVE",
+"574 452 CURVE SMOOTH",
+"523 524 OFFCURVE",
+"469 593 OFFCURVE",
+"419 646 CURVE",
+"404 575 LINE",
+"494 704 OFFCURVE",
+"539 771 OFFCURVE",
+"613 905 CURVE",
+"548 939 LINE",
+"479 816 OFFCURVE",
+"428 735 OFFCURVE",
+"345 621 CURVE",
+"447 507 OFFCURVE",
+"562 351 OFFCURVE",
+"629 220 CURVE",
+"714 216 LINE",
+"786 315 OFFCURVE",
+"849 407 OFFCURVE",
+"911 514 CURVE",
+"845 549 LINE",
+"825 515 OFFCURVE",
+"806 482 OFFCURVE",
+"786 451 CURVE SMOOTH",
+"745 388 OFFCURVE",
+"710 331 OFFCURVE",
+"679 281 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"545 404 LINE",
+"645 524 OFFCURVE",
+"696 601 OFFCURVE",
+"764 720 CURVE",
+"699 754 LINE",
+"634 634 OFFCURVE",
+"588 567 OFFCURVE",
+"521 480 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 400 LINE",
+"346 337 OFFCURVE",
+"380 290 OFFCURVE",
+"419 230 CURVE SMOOTH",
+"460 166 OFFCURVE",
+"497 103 OFFCURVE",
+"528 39 CURVE",
+"550 122 LINE",
+"467 -7 OFFCURVE",
+"424 -73 OFFCURVE",
+"367 -166 CURVE",
+"432 -203 LINE",
+"484 -117 OFFCURVE",
+"529 -47 OFFCURVE",
+"600 62 CURVE",
+"523 213 OFFCURVE",
+"442 337 OFFCURVE",
+"345 463 CURVE",
+"261 463 LINE",
+"197 375 OFFCURVE",
+"151 313 OFFCURVE",
+"80 214 CURVE",
+"142 173 LINE",
+"160 198 OFFCURVE",
+"177 222 OFFCURVE",
+"194 246 CURVE SMOOTH",
+"232 299 OFFCURVE",
+"261 340 OFFCURVE",
+"301 400 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"415 313 LINE",
+"329 198 OFFCURVE",
+"275 124 OFFCURVE",
+"210 32 CURVE",
+"272 -11 LINE",
+"321 62 OFFCURVE",
+"364 124 OFFCURVE",
+"438 228 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 1001;
+}
+);
+leftMetricsKey = u1B21A;
+rightMetricsKey = u1B21A;
+unicode = 1B246;
+},
+{
+glyphname = u1B247;
+lastChange = "2020-04-12 10:06:19 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"665 939 LINE",
+"625 844 OFFCURVE",
+"581 756 OFFCURVE",
+"534 675 CURVE SMOOTH",
+"491 601 OFFCURVE",
+"453 541 OFFCURVE",
+"410 475 CURVE",
+"405 476 LINE",
+"389 543 OFFCURVE",
+"363 617 OFFCURVE",
+"338 673 CURVE SMOOTH",
+"321 711 OFFCURVE",
+"302 750 OFFCURVE",
+"280 792 CURVE",
+"215 756 LINE",
+"281 634 OFFCURVE",
+"317 536 OFFCURVE",
+"355 434 CURVE",
+"445 415 LINE",
+"561 567 OFFCURVE",
+"657 720 OFFCURVE",
+"735 912 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"600 85 OFFCURVE",
+"555 186 OFFCURVE",
+"472 322 CURVE",
+"386 314 LINE",
+"308 94 OFFCURVE",
+"245 -32 OFFCURVE",
+"167 -168 CURVE",
+"235 -203 LINE",
+"280 -123 OFFCURVE",
+"318 -44 OFFCURVE",
+"358 47 CURVE SMOOTH",
+"386 111 OFFCURVE",
+"411 174 OFFCURVE",
+"431 252 CURVE",
+"436 253 LINE",
+"472 189 OFFCURVE",
+"497 139 OFFCURVE",
+"524 71 CURVE SMOOTH",
+"544 20 OFFCURVE",
+"563 -32 OFFCURVE",
+"581 -90 CURVE",
+"652 -67 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"60 241 OFFCURVE",
+"89 193 OFFCURVE",
+"157 153 CURVE",
+"228 162 LINE",
+"296 241 OFFCURVE",
+"314 306 OFFCURVE",
+"314 367 CURVE SMOOTH",
+"314 427 OFFCURVE",
+"280 468 OFFCURVE",
+"212 506 CURVE",
+"138 496 LINE",
+"80 414 OFFCURVE",
+"60 347 OFFCURVE",
+"60 298 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"184 452 LINE",
+"224 420 OFFCURVE",
+"239 385 OFFCURVE",
+"239 356 CURVE SMOOTH",
+"239 313 OFFCURVE",
+"229 268 OFFCURVE",
+"189 204 CURVE",
+"184 203 LINE",
+"149 238 OFFCURVE",
+"134 269 OFFCURVE",
+"134 302 CURVE SMOOTH",
+"134 344 OFFCURVE",
+"147 388 OFFCURVE",
+"179 451 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"560 316 OFFCURVE",
+"589 268 OFFCURVE",
+"657 228 CURVE",
+"728 237 LINE",
+"796 316 OFFCURVE",
+"814 381 OFFCURVE",
+"814 442 CURVE SMOOTH",
+"814 502 OFFCURVE",
+"780 543 OFFCURVE",
+"712 581 CURVE",
+"638 571 LINE",
+"580 489 OFFCURVE",
+"560 422 OFFCURVE",
+"560 373 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"684 527 LINE",
+"724 495 OFFCURVE",
+"739 460 OFFCURVE",
+"739 431 CURVE SMOOTH",
+"739 388 OFFCURVE",
+"729 343 OFFCURVE",
+"689 279 CURVE",
+"684 278 LINE",
+"649 313 OFFCURVE",
+"634 344 OFFCURVE",
+"634 377 CURVE SMOOTH",
+"634 419 OFFCURVE",
+"647 463 OFFCURVE",
+"679 526 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 874;
+}
+);
+leftMetricsKey = u1B1F1;
+rightMetricsKey = u1B1F1;
+unicode = 1B247;
+},
+{
+glyphname = u1B248;
+lastChange = "2020-04-13 09:05:35 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"447 414 LINE",
+"525 251 OFFCURVE",
+"581 105 OFFCURVE",
+"631 -87 CURVE",
+"702 -68 LINE",
+"643 146 OFFCURVE",
+"580 308 OFFCURVE",
+"491 469 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"541 637 LINE",
+"456 488 OFFCURVE",
+"361 369 OFFCURVE",
+"277 282 CURVE",
+"327 234 LINE",
+"422 331 OFFCURVE",
+"513 439 OFFCURVE",
+"607 603 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"534 299 LINE",
+"482 212 OFFCURVE",
+"418 133 OFFCURVE",
+"355 67 CURVE",
+"410 20 LINE",
+"473 88 OFFCURVE",
+"526 164 OFFCURVE",
+"573 242 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"298 391 OFFCURVE",
+"321 408 OFFCURVE",
+"321 447 CURVE SMOOTH",
+"321 486 OFFCURVE",
+"298 503 OFFCURVE",
+"270 503 CURVE SMOOTH",
+"241 503 OFFCURVE",
+"218 486 OFFCURVE",
+"218 447 CURVE SMOOTH",
+"218 408 OFFCURVE",
+"241 391 OFFCURVE",
+"270 391 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"434 577 OFFCURVE",
+"457 594 OFFCURVE",
+"457 633 CURVE SMOOTH",
+"457 672 OFFCURVE",
+"434 689 OFFCURVE",
+"406 689 CURVE SMOOTH",
+"377 689 OFFCURVE",
+"354 672 OFFCURVE",
+"354 633 CURVE SMOOTH",
+"354 594 OFFCURVE",
+"377 577 OFFCURVE",
+"406 577 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"360 939 LINE",
+"278 777 OFFCURVE",
+"200 656 OFFCURVE",
+"79 507 CURVE",
+"132 460 LINE",
+"259 611 OFFCURVE",
+"340 734 OFFCURVE",
+"428 910 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"118 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -103 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 812;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B1EF;
+unicode = 1B248;
+},
+{
+glyphname = u1B249;
+lastChange = "2020-04-13 09:05:31 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"549 102 LINE",
+"486 263 OFFCURVE",
+"436 368 OFFCURVE",
+"342 532 CURVE",
+"306 455 LINE",
+"373 332 OFFCURVE",
+"438 199 OFFCURVE",
+"489 62 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"398 623 LINE",
+"328 521 OFFCURVE",
+"267 446 OFFCURVE",
+"189 366 CURVE",
+"237 313 LINE",
+"320 398 OFFCURVE",
+"385 478 OFFCURVE",
+"459 585 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"516 463 LINE",
+"484 416 OFFCURVE",
+"457 377 OFFCURVE",
+"428 342 CURVE",
+"399 313 LINE",
+"369 277 OFFCURVE",
+"335 241 OFFCURVE",
+"294 198 CURVE",
+"342 147 LINE",
+"379 185 OFFCURVE",
+"411 218 OFFCURVE",
+"440 252 CURVE",
+"465 276 LINE",
+"500 319 OFFCURVE",
+"535 364 OFFCURVE",
+"575 425 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"644 307 LINE",
+"560 190 OFFCURVE",
+"466 76 OFFCURVE",
+"372 -12 CURVE",
+"418 -61 LINE",
+"514 31 OFFCURVE",
+"616 143 OFFCURVE",
+"703 266 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"367 939 LINE",
+"278 762 OFFCURVE",
+"185 635 OFFCURVE",
+"60 503 CURVE",
+"116 452 LINE",
+"250 591 OFFCURVE",
+"340 720 OFFCURVE",
+"438 910 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"357 809 LINE",
+"467 707 OFFCURVE",
+"551 614 OFFCURVE",
+"633 501 CURVE",
+"693 545 LINE",
+"598 677 OFFCURVE",
+"512 768 OFFCURVE",
+"390 871 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"276 157 LINE",
+"249 104 OFFCURVE",
+"224 59 OFFCURVE",
+"199 19 CURVE",
+"176 -10 LINE",
+"142 -59 OFFCURVE",
+"106 -104 OFFCURVE",
+"60 -154 CURVE",
+"112 -203 LINE",
+"157 -150 OFFCURVE",
+"192 -107 OFFCURVE",
+"222 -64 CURVE",
+"248 -31 LINE",
+"278 15 OFFCURVE",
+"305 63 OFFCURVE",
+"340 126 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"66 88 LINE",
+"158 -5 OFFCURVE",
+"219 -83 OFFCURVE",
+"282 -182 CURVE",
+"341 -143 LINE",
+"268 -34 OFFCURVE",
+"200 49 OFFCURVE",
+"116 138 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 783;
+}
+);
+leftMetricsKey = u1B1C9;
+rightMetricsKey = u1B1E7;
+unicode = 1B249;
+},
+{
+glyphname = u1B24A;
+lastChange = "2020-04-11 18:58:35 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"384 -108 OFFCURVE",
+"407 -91 OFFCURVE",
+"407 -52 CURVE SMOOTH",
+"407 -13 OFFCURVE",
+"384 4 OFFCURVE",
+"356 4 CURVE SMOOTH",
+"327 4 OFFCURVE",
+"304 -13 OFFCURVE",
+"304 -52 CURVE SMOOTH",
+"304 -91 OFFCURVE",
+"327 -108 OFFCURVE",
+"356 -108 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"730 58 OFFCURVE",
+"753 75 OFFCURVE",
+"753 114 CURVE SMOOTH",
+"753 153 OFFCURVE",
+"730 170 OFFCURVE",
+"702 170 CURVE SMOOTH",
+"673 170 OFFCURVE",
+"650 153 OFFCURVE",
+"650 114 CURVE SMOOTH",
+"650 75 OFFCURVE",
+"673 58 OFFCURVE",
+"702 58 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"228 27 LINE",
+"220 184 OFFCURVE",
+"203 309 OFFCURVE",
+"168 437 CURVE",
+"100 417 LINE",
+"131 301 OFFCURVE",
+"149 172 OFFCURVE",
+"157 24 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"293 288 LINE",
+"446 395 OFFCURVE",
+"534 467 OFFCURVE",
+"683 623 CURVE",
+"627 669 LINE",
+"500 533 OFFCURVE",
+"394 445 OFFCURVE",
+"251 346 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"581 -199 LINE",
+"581 -46 OFFCURVE",
+"574 79 OFFCURVE",
+"543 273 CURVE",
+"482 208 LINE",
+"498 60 OFFCURVE",
+"505 -65 OFFCURVE",
+"505 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"625 365 OFFCURVE",
+"547 305 OFFCURVE",
+"294 152 CURVE",
+"332 91 LINE",
+"608 259 OFFCURVE",
+"701 338 OFFCURVE",
+"701 433 CURVE SMOOTH",
+"701 497 OFFCURVE",
+"669 549 OFFCURVE",
+"614 611 CURVE",
+"567 563 LINE",
+"610 508 OFFCURVE",
+"625 477 OFFCURVE",
+"625 433 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"624 939 LINE",
+"552 840 OFFCURVE",
+"485 759 OFFCURVE",
+"419 690 CURVE SMOOTH",
+"361 629 OFFCURVE",
+"306 572 OFFCURVE",
+"261 529 CURVE",
+"256 530 LINE",
+"245 602 OFFCURVE",
+"226 660 OFFCURVE",
+"214 695 CURVE SMOOTH",
+"206 719 OFFCURVE",
+"197 744 OFFCURVE",
+"188 770 CURVE",
+"120 744 LINE",
+"155 654 OFFCURVE",
+"180 581 OFFCURVE",
+"201 489 CURVE",
+"286 468 LINE",
+"439 591 OFFCURVE",
+"546 701 OFFCURVE",
+"687 897 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 873;
+}
+);
+leftMetricsKey = u1B224;
+rightMetricsKey = u1B1B3;
+unicode = 1B24A;
+},
+{
+glyphname = u1B24B;
+lastChange = "2020-04-13 09:04:57 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"578 729 LINE",
+"520 690 OFFCURVE",
+"465 656 OFFCURVE",
+"411 625 CURVE",
+"381 611 LINE",
+"323 579 OFFCURVE",
+"263 547 OFFCURVE",
+"194 514 CURVE",
+"209 445 LINE",
+"275 477 OFFCURVE",
+"341 511 OFFCURVE",
+"405 546 CURVE",
+"436 561 LINE",
+"501 597 OFFCURVE",
+"565 637 OFFCURVE",
+"628 679 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"566 -33 LINE",
+"545 136 OFFCURVE",
+"524 274 OFFCURVE",
+"497 397 CURVE",
+"484 440 LINE",
+"457 557 OFFCURVE",
+"424 663 OFFCURVE",
+"384 772 CURVE",
+"371 813 LINE",
+"355 854 OFFCURVE",
+"338 896 OFFCURVE",
+"320 939 CURVE",
+"256 913 LINE",
+"275 866 OFFCURVE",
+"293 817 OFFCURVE",
+"309 774 CURVE",
+"325 734 LINE",
+"366 620 OFFCURVE",
+"398 515 OFFCURVE",
+"423 403 CURVE",
+"431 363 LINE",
+"456 243 OFFCURVE",
+"475 115 OFFCURVE",
+"491 -40 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"499 914 LINE",
+"449 880 OFFCURVE",
+"401 849 OFFCURVE",
+"352 820 CURVE",
+"314 800 LINE",
+"252 764 OFFCURVE",
+"188 731 OFFCURVE",
+"118 696 CURVE",
+"164 551 OFFCURVE",
+"196 434 OFFCURVE",
+"226 301 CURVE",
+"304 278 LINE",
+"348 296 OFFCURVE",
+"399 321 OFFCURVE",
+"450 348 CURVE",
+"490 366 LINE",
+"559 402 OFFCURVE",
+"628 442 OFFCURVE",
+"694 482 CURVE",
+"659 635 OFFCURVE",
+"622 759 OFFCURVE",
+"573 899 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"518 840 LINE",
+"536 780 OFFCURVE",
+"551 730 OFFCURVE",
+"569 670 CURVE SMOOTH",
+"587 609 OFFCURVE",
+"602 549 OFFCURVE",
+"615 492 CURVE",
+"652 544 LINE",
+"586 503 OFFCURVE",
+"522 466 OFFCURVE",
+"460 433 CURVE",
+"433 421 LINE",
+"377 392 OFFCURVE",
+"336 372 OFFCURVE",
+"291 347 CURVE",
+"286 348 LINE",
+"273 415 OFFCURVE",
+"263 463 OFFCURVE",
+"251 508 CURVE SMOOTH",
+"234 570 OFFCURVE",
+"214 635 OFFCURVE",
+"191 705 CURVE",
+"165 639 LINE",
+"228 668 OFFCURVE",
+"288 699 OFFCURVE",
+"347 733 CURVE",
+"374 746 LINE",
+"418 775 OFFCURVE",
+"465 804 OFFCURVE",
+"513 841 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"118 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -103 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 784;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B205;
+unicode = 1B24B;
+},
+{
+glyphname = u1B24C;
+lastChange = "2020-04-13 09:04:54 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"906 625 LINE",
+"876 574 OFFCURVE",
+"846 530 OFFCURVE",
+"815 490 CURVE",
+"790 466 LINE",
+"753 420 OFFCURVE",
+"711 378 OFFCURVE",
+"662 332 CURVE",
+"710 279 LINE",
+"757 323 OFFCURVE",
+"797 366 OFFCURVE",
+"835 411 CURVE",
+"859 434 LINE",
+"897 481 OFFCURVE",
+"932 531 OFFCURVE",
+"968 589 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"674 577 LINE",
+"776 462 OFFCURVE",
+"822 394 OFFCURVE",
+"895 264 CURVE",
+"957 302 LINE",
+"881 438 OFFCURVE",
+"829 507 OFFCURVE",
+"726 627 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"257 318 LINE",
+"238 264 OFFCURVE",
+"219 217 OFFCURVE",
+"198 173 CURVE",
+"182 148 LINE",
+"156 95 OFFCURVE",
+"126 46 OFFCURVE",
+"90 -9 CURVE",
+"152 -50 LINE",
+"185 0 OFFCURVE",
+"213 47 OFFCURVE",
+"239 98 CURVE",
+"256 123 LINE",
+"281 174 OFFCURVE",
+"304 229 OFFCURVE",
+"326 293 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"50 214 LINE",
+"177 131 OFFCURVE",
+"234 83 OFFCURVE",
+"326 -16 CURVE",
+"378 36 LINE",
+"274 136 OFFCURVE",
+"199 198 OFFCURVE",
+"88 277 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"400 609 LINE",
+"468 389 OFFCURVE",
+"508 185 OFFCURVE",
+"535 -61 CURVE",
+"604 -34 LINE",
+"577 218 OFFCURVE",
+"530 433 OFFCURVE",
+"457 674 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"740 160 LINE",
+"618 34 OFFCURVE",
+"513 -48 OFFCURVE",
+"376 -142 CURVE",
+"416 -203 LINE",
+"547 -115 OFFCURVE",
+"670 -18 OFFCURVE",
+"795 110 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"573 939 LINE",
+"457 748 OFFCURVE",
+"343 602 OFFCURVE",
+"211 468 CURVE",
+"264 415 LINE",
+"404 562 OFFCURVE",
+"518 704 OFFCURVE",
+"642 906 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"630 493 LINE",
+"592 446 OFFCURVE",
+"553 401 OFFCURVE",
+"511 359 CURVE",
+"488 344 LINE",
+"439 297 OFFCURVE",
+"388 252 OFFCURVE",
+"334 209 CURVE",
+"379 150 LINE",
+"425 187 OFFCURVE",
+"468 224 OFFCURVE",
+"509 263 CURVE",
+"535 280 LINE",
+"590 332 OFFCURVE",
+"640 386 OFFCURVE",
+"689 446 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 1013;
+}
+);
+leftMetricsKey = u1B1AC;
+unicode = 1B24C;
+},
+{
+glyphname = u1B24D;
+lastChange = "2020-04-13 09:03:58 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"188 714 OFFCURVE",
+"211 731 OFFCURVE",
+"211 770 CURVE SMOOTH",
+"211 809 OFFCURVE",
+"188 826 OFFCURVE",
+"160 826 CURVE SMOOTH",
+"131 826 OFFCURVE",
+"108 809 OFFCURVE",
+"108 770 CURVE SMOOTH",
+"108 731 OFFCURVE",
+"131 714 OFFCURVE",
+"160 714 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"669 754 OFFCURVE",
+"692 771 OFFCURVE",
+"692 810 CURVE SMOOTH",
+"692 849 OFFCURVE",
+"669 866 OFFCURVE",
+"641 866 CURVE SMOOTH",
+"612 866 OFFCURVE",
+"589 849 OFFCURVE",
+"589 810 CURVE SMOOTH",
+"589 771 OFFCURVE",
+"612 754 OFFCURVE",
+"641 754 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"406 939 LINE",
+"329 747 OFFCURVE",
+"240 642 OFFCURVE",
+"80 520 CURVE",
+"123 463 LINE",
+"291 589 OFFCURVE",
+"389 704 OFFCURVE",
+"473 913 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"377 754 LINE",
+"500 666 OFFCURVE",
+"608 578 OFFCURVE",
+"717 471 CURVE",
+"767 522 LINE",
+"635 652 OFFCURVE",
+"538 724 OFFCURVE",
+"409 814 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"512 585 LINE",
+"387 512 OFFCURVE",
+"274 455 OFFCURVE",
+"139 400 CURVE",
+"169 334 LINE",
+"308 392 OFFCURVE",
+"424 449 OFFCURVE",
+"551 525 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"479 435 OFFCURVE",
+"487 415 OFFCURVE",
+"487 390 CURVE SMOOTH",
+"487 342 OFFCURVE",
+"426 297 OFFCURVE",
+"179 208 CURVE",
+"204 140 LINE",
+"478 245 OFFCURVE",
+"561 296 OFFCURVE",
+"561 388 CURVE SMOOTH",
+"561 427 OFFCURVE",
+"545 461 OFFCURVE",
+"504 510 CURVE",
+"444 484 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"604 254 LINE",
+"468 174 OFFCURVE",
+"343 122 OFFCURVE",
+"191 66 CURVE",
+"217 -1 LINE",
+"369 55 OFFCURVE",
+"499 109 OFFCURVE",
+"643 194 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"576 110 OFFCURVE",
+"581 89 OFFCURVE",
+"581 59 CURVE SMOOTH",
+"581 0 OFFCURVE",
+"536 -37 OFFCURVE",
+"238 -137 CURVE",
+"261 -203 LINE",
+"581 -100 OFFCURVE",
+"655 -43 OFFCURVE",
+"655 57 CURVE SMOOTH",
+"655 98 OFFCURVE",
+"643 134 OFFCURVE",
+"584 201 CURVE",
+"539 156 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 857;
+}
+);
+leftMetricsKey = u1B185;
+rightMetricsKey = u1B185;
+unicode = 1B24D;
+},
+{
+glyphname = u1B24E;
+lastChange = "2020-04-13 09:03:56 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"394 285 OFFCURVE",
+"416 301 OFFCURVE",
+"416 338 CURVE SMOOTH",
+"416 375 OFFCURVE",
+"394 391 OFFCURVE",
+"367 391 CURVE SMOOTH",
+"340 391 OFFCURVE",
+"318 375 OFFCURVE",
+"318 338 CURVE SMOOTH",
+"318 301 OFFCURVE",
+"340 285 OFFCURVE",
+"367 285 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 400 OFFCURVE",
+"633 416 OFFCURVE",
+"633 453 CURVE SMOOTH",
+"633 490 OFFCURVE",
+"611 506 OFFCURVE",
+"585 506 CURVE SMOOTH",
+"557 506 OFFCURVE",
+"535 490 OFFCURVE",
+"535 453 CURVE SMOOTH",
+"535 416 OFFCURVE",
+"557 400 OFFCURVE",
+"585 400 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"710 401 LINE",
+"550 296 OFFCURVE",
+"446 242 OFFCURVE",
+"318 185 CURVE",
+"351 121 LINE",
+"487 183 OFFCURVE",
+"583 232 OFFCURVE",
+"751 342 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"667 250 OFFCURVE",
+"677 221 OFFCURVE",
+"677 181 CURVE SMOOTH",
+"677 115 OFFCURVE",
+"603 59 OFFCURVE",
+"361 -43 CURVE",
+"390 -109 LINE",
+"668 10 OFFCURVE",
+"753 77 OFFCURVE",
+"753 181 CURVE SMOOTH",
+"753 233 OFFCURVE",
+"739 275 OFFCURVE",
+"674 355 CURVE",
+"624 305 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"561 939 LINE",
+"417 832 OFFCURVE",
+"277 751 OFFCURVE",
+"164 700 CURVE",
+"196 635 LINE",
+"306 685 OFFCURVE",
+"460 773 OFFCURVE",
+"605 881 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 788 OFFCURVE",
+"547 756 OFFCURVE",
+"547 714 CURVE SMOOTH",
+"547 639 OFFCURVE",
+"478 594 OFFCURVE",
+"221 478 CURVE",
+"250 412 LINE",
+"557 546 OFFCURVE",
+"623 613 OFFCURVE",
+"623 714 CURVE SMOOTH",
+"623 764 OFFCURVE",
+"600 815 OFFCURVE",
+"541 879 CURVE",
+"488 833 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"130 -18 OFFCURVE",
+"153 -1 OFFCURVE",
+"153 38 CURVE SMOOTH",
+"153 77 OFFCURVE",
+"130 94 OFFCURVE",
+"102 94 CURVE SMOOTH",
+"73 94 OFFCURVE",
+"50 77 OFFCURVE",
+"50 38 CURVE SMOOTH",
+"50 -1 OFFCURVE",
+"73 -18 OFFCURVE",
+"102 -18 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"155 230 LINE",
+"218 170 OFFCURVE",
+"242 113 OFFCURVE",
+"242 34 CURVE SMOOTH",
+"242 -46 OFFCURVE",
+"221 -101 OFFCURVE",
+"167 -160 CURVE",
+"222 -203 LINE",
+"285 -130 OFFCURVE",
+"316 -62 OFFCURVE",
+"316 32 CURVE SMOOTH",
+"316 131 OFFCURVE",
+"282 203 OFFCURVE",
+"206 278 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 883;
+}
+);
+leftMetricsKey = u1B1D7;
+rightMetricsKey = u1B179;
+unicode = 1B24E;
+},
+{
+glyphname = u1B24F;
+lastChange = "2020-04-13 09:03:54 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"500 174 LINE",
+"449 356 OFFCURVE",
+"399 501 OFFCURVE",
+"349 627 CURVE",
+"289 577 LINE",
+"342 452 OFFCURVE",
+"386 313 OFFCURVE",
+"428 173 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"548 939 LINE",
+"421 764 OFFCURVE",
+"295 626 OFFCURVE",
+"136 476 CURVE",
+"186 420 LINE",
+"330 555 OFFCURVE",
+"475 704 OFFCURVE",
+"612 900 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"700 482 LINE",
+"579 332 OFFCURVE",
+"478 225 OFFCURVE",
+"344 119 CURVE",
+"389 64 LINE",
+"537 183 OFFCURVE",
+"638 285 OFFCURVE",
+"758 438 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"608 320 LINE",
+"564 477 OFFCURVE",
+"528 586 OFFCURVE",
+"462 748 CURVE",
+"402 698 LINE",
+"458 570 OFFCURVE",
+"501 440 OFFCURVE",
+"544 278 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"290 237 OFFCURVE",
+"313 254 OFFCURVE",
+"313 293 CURVE SMOOTH",
+"313 332 OFFCURVE",
+"290 349 OFFCURVE",
+"262 349 CURVE SMOOTH",
+"233 349 OFFCURVE",
+"210 332 OFFCURVE",
+"210 293 CURVE SMOOTH",
+"210 254 OFFCURVE",
+"233 237 OFFCURVE",
+"262 237 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"665 584 OFFCURVE",
+"688 601 OFFCURVE",
+"688 640 CURVE SMOOTH",
+"688 679 OFFCURVE",
+"665 696 OFFCURVE",
+"637 696 CURVE SMOOTH",
+"608 696 OFFCURVE",
+"585 679 OFFCURVE",
+"585 640 CURVE SMOOTH",
+"585 601 OFFCURVE",
+"608 584 OFFCURVE",
+"637 584 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 -95 OFFCURVE",
+"109 -143 OFFCURVE",
+"177 -183 CURVE",
+"248 -174 LINE",
+"316 -95 OFFCURVE",
+"334 -30 OFFCURVE",
+"334 31 CURVE SMOOTH",
+"334 91 OFFCURVE",
+"300 132 OFFCURVE",
+"232 170 CURVE",
+"158 160 LINE",
+"100 78 OFFCURVE",
+"80 11 OFFCURVE",
+"80 -38 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 116 LINE",
+"244 84 OFFCURVE",
+"259 49 OFFCURVE",
+"259 20 CURVE SMOOTH",
+"259 -23 OFFCURVE",
+"249 -68 OFFCURVE",
+"209 -132 CURVE",
+"204 -133 LINE",
+"169 -98 OFFCURVE",
+"154 -67 OFFCURVE",
+"154 -34 CURVE SMOOTH",
+"154 8 OFFCURVE",
+"167 52 OFFCURVE",
+"199 115 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 828;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B183;
+unicode = 1B24F;
+},
+{
+glyphname = u1B250;
+lastChange = "2020-04-13 09:03:51 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"80 -128 OFFCURVE",
+"105 -168 OFFCURVE",
+"173 -203 CURVE",
+"244 -194 LINE",
+"306 -119 OFFCURVE",
+"325 -65 OFFCURVE",
+"325 -10 CURVE SMOOTH",
+"325 45 OFFCURVE",
+"296 81 OFFCURVE",
+"228 110 CURVE",
+"154 100 LINE",
+"95 18 OFFCURVE",
+"80 -40 OFFCURVE",
+"80 -78 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"202 55 LINE",
+"238 40 OFFCURVE",
+"255 16 OFFCURVE",
+"255 -13 CURVE SMOOTH",
+"255 -52 OFFCURVE",
+"241 -100 OFFCURVE",
+"206 -154 CURVE",
+"201 -155 LINE",
+"164 -127 OFFCURVE",
+"150 -99 OFFCURVE",
+"150 -69 CURVE SMOOTH",
+"150 -34 OFFCURVE",
+"163 3 OFFCURVE",
+"197 54 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"217 552 LINE",
+"369 453 OFFCURVE",
+"528 331 OFFCURVE",
+"671 205 CURVE",
+"719 262 LINE",
+"654 319 OFFCURVE",
+"596 365 OFFCURVE",
+"492 445 CURVE",
+"473 445 LINE",
+"423 493 OFFCURVE",
+"364 544 OFFCURVE",
+"270 610 CURVE",
+"262 560 LINE",
+"366 670 OFFCURVE",
+"417 738 OFFCURVE",
+"465 817 CURVE",
+"490 842 LINE",
+"503 861 OFFCURVE",
+"516 881 OFFCURVE",
+"530 903 CURVE",
+"466 939 LINE",
+"379 805 OFFCURVE",
+"306 711 OFFCURVE",
+"217 623 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"493 742 OFFCURVE",
+"507 680 OFFCURVE",
+"507 614 CURVE SMOOTH",
+"507 566 OFFCURVE",
+"495 501 OFFCURVE",
+"477 445 CURVE",
+"467 445 LINE",
+"415 352 OFFCURVE",
+"373 279 OFFCURVE",
+"295 175 CURVE",
+"352 134 LINE",
+"420 229 OFFCURVE",
+"465 304 OFFCURVE",
+"500 367 CURVE",
+"522 399 LINE",
+"566 485 OFFCURVE",
+"581 549 OFFCURVE",
+"581 614 CURVE SMOOTH",
+"581 724 OFFCURVE",
+"559 784 OFFCURVE",
+"487 896 CURVE",
+"438 817 LINE",
+"469 817 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"241 187 OFFCURVE",
+"386 65 OFFCURVE",
+"498 -64 CURVE",
+"553 -13 LINE",
+"441 117 OFFCURVE",
+"279 245 OFFCURVE",
+"123 329 CURVE",
+"88 263 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"293 335 OFFCURVE",
+"315 351 OFFCURVE",
+"315 388 CURVE SMOOTH",
+"315 425 OFFCURVE",
+"293 441 OFFCURVE",
+"266 441 CURVE SMOOTH",
+"238 441 OFFCURVE",
+"216 425 OFFCURVE",
+"216 388 CURVE SMOOTH",
+"216 351 OFFCURVE",
+"238 335 OFFCURVE",
+"266 335 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"578 110 OFFCURVE",
+"600 126 OFFCURVE",
+"600 163 CURVE SMOOTH",
+"600 200 OFFCURVE",
+"578 216 OFFCURVE",
+"551 216 CURVE SMOOTH",
+"523 216 OFFCURVE",
+"502 200 OFFCURVE",
+"502 163 CURVE SMOOTH",
+"502 126 OFFCURVE",
+"523 110 OFFCURVE",
+"551 110 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 819;
+}
+);
+leftMetricsKey = u1B1D4;
+rightMetricsKey = u1B1F4;
+unicode = 1B250;
+},
+{
+glyphname = u1B251;
+lastChange = "2020-04-13 09:03:40 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"543 137 OFFCURVE",
+"499 220 OFFCURVE",
+"436 316 CURVE",
+"362 321 LINE",
+"296 227 OFFCURVE",
+"241 160 OFFCURVE",
+"163 83 CURVE",
+"226 -23 OFFCURVE",
+"270 -102 OFFCURVE",
+"308 -191 CURVE",
+"382 -203 LINE",
+"450 -140 OFFCURVE",
+"518 -61 OFFCURVE",
+"588 31 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"532 73 LINE",
+"506 35 OFFCURVE",
+"481 1 OFFCURVE",
+"456 -29 CURVE SMOOTH",
+"417 -75 OFFCURVE",
+"390 -106 OFFCURVE",
+"360 -139 CURVE",
+"356 -139 LINE",
+"337 -88 OFFCURVE",
+"307 -27 OFFCURVE",
+"287 9 CURVE SMOOTH",
+"270 40 OFFCURVE",
+"251 72 OFFCURVE",
+"230 107 CURVE",
+"224 52 LINE",
+"252 80 OFFCURVE",
+"279 108 OFFCURVE",
+"305 138 CURVE SMOOTH",
+"332 169 OFFCURVE",
+"362 210 OFFCURVE",
+"392 256 CURVE",
+"396 256 LINE",
+"425 204 OFFCURVE",
+"449 161 OFFCURVE",
+"471 117 CURVE SMOOTH",
+"490 79 OFFCURVE",
+"508 42 OFFCURVE",
+"524 2 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"451 196 LINE",
+"401 121 OFFCURVE",
+"338 52 OFFCURVE",
+"273 -12 CURVE",
+"298 -74 LINE",
+"380 7 OFFCURVE",
+"442 79 OFFCURVE",
+"500 155 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"144 594 LINE",
+"307 489 OFFCURVE",
+"441 388 OFFCURVE",
+"592 257 CURVE",
+"639 314 LINE",
+"563 380 OFFCURVE",
+"486 443 OFFCURVE",
+"368 534 CURVE",
+"351 534 LINE",
+"309 569 OFFCURVE",
+"273 592 OFFCURVE",
+"183 655 CURVE",
+"186 610 LINE",
+"265 696 OFFCURVE",
+"309 756 OFFCURVE",
+"350 826 CURVE",
+"373 844 LINE",
+"385 862 OFFCURVE",
+"398 882 OFFCURVE",
+"412 903 CURVE",
+"350 939 LINE",
+"278 830 OFFCURVE",
+"218 753 OFFCURVE",
+"144 670 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"479 749 OFFCURVE",
+"459 802 OFFCURVE",
+"371 890 CURVE",
+"321 826 LINE",
+"354 826 LINE",
+"388 770 OFFCURVE",
+"403 724 OFFCURVE",
+"403 679 CURVE SMOOTH",
+"403 630 OFFCURVE",
+"395 594 OFFCURVE",
+"355 534 CURVE",
+"346 534 LINE",
+"281 431 OFFCURVE",
+"199 338 OFFCURVE",
+"80 225 CURVE",
+"132 172 LINE",
+"247 284 OFFCURVE",
+"324 374 OFFCURVE",
+"379 450 CURVE",
+"406 480 LINE",
+"457 556 OFFCURVE",
+"479 619 OFFCURVE",
+"479 679 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 719;
+}
+);
+leftMetricsKey = u1B22F;
+rightMetricsKey = u1B22F;
+unicode = 1B251;
+},
+{
+glyphname = u1B252;
+lastChange = "2020-04-13 09:03:33 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"509 91 OFFCURVE",
+"532 108 OFFCURVE",
+"532 147 CURVE SMOOTH",
+"532 186 OFFCURVE",
+"509 203 OFFCURVE",
+"481 203 CURVE SMOOTH",
+"452 203 OFFCURVE",
+"429 186 OFFCURVE",
+"429 147 CURVE SMOOTH",
+"429 108 OFFCURVE",
+"452 91 OFFCURVE",
+"481 91 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"609 -71 OFFCURVE",
+"632 -54 OFFCURVE",
+"632 -15 CURVE SMOOTH",
+"632 24 OFFCURVE",
+"609 41 OFFCURVE",
+"581 41 CURVE SMOOTH",
+"552 41 OFFCURVE",
+"529 24 OFFCURVE",
+"529 -15 CURVE SMOOTH",
+"529 -54 OFFCURVE",
+"552 -71 OFFCURVE",
+"581 -71 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"466 -203 OFFCURVE",
+"489 -186 OFFCURVE",
+"489 -147 CURVE SMOOTH",
+"489 -108 OFFCURVE",
+"466 -91 OFFCURVE",
+"438 -91 CURVE SMOOTH",
+"409 -91 OFFCURVE",
+"386 -108 OFFCURVE",
+"386 -147 CURVE SMOOTH",
+"386 -186 OFFCURVE",
+"409 -203 OFFCURVE",
+"438 -203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"372 -39 OFFCURVE",
+"395 -22 OFFCURVE",
+"395 17 CURVE SMOOTH",
+"395 56 OFFCURVE",
+"372 73 OFFCURVE",
+"344 73 CURVE SMOOTH",
+"315 73 OFFCURVE",
+"292 56 OFFCURVE",
+"292 17 CURVE SMOOTH",
+"292 -22 OFFCURVE",
+"315 -39 OFFCURVE",
+"344 -39 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"402 939 LINE",
+"298 802 OFFCURVE",
+"191 683 OFFCURVE",
+"70 568 CURVE",
+"122 512 LINE",
+"251 634 OFFCURVE",
+"352 749 OFFCURVE",
+"464 894 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"302 733 LINE",
+"458 507 OFFCURVE",
+"580 299 OFFCURVE",
+"690 81 CURVE",
+"757 113 LINE",
+"648 326 OFFCURVE",
+"523 528 OFFCURVE",
+"358 782 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"508 769 LINE",
+"480 732 OFFCURVE",
+"450 696 OFFCURVE",
+"419 659 CURVE",
+"391 637 LINE",
+"306 537 OFFCURVE",
+"216 441 OFFCURVE",
+"132 360 CURVE",
+"184 310 LINE",
+"273 398 OFFCURVE",
+"356 485 OFFCURVE",
+"435 576 CURVE",
+"462 597 LINE",
+"498 639 OFFCURVE",
+"533 683 OFFCURVE",
+"567 727 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"601 600 LINE",
+"572 566 OFFCURVE",
+"545 532 OFFCURVE",
+"518 500 CURVE",
+"490 479 LINE",
+"392 365 OFFCURVE",
+"298 263 OFFCURVE",
+"192 156 CURVE",
+"244 103 LINE",
+"354 215 OFFCURVE",
+"441 309 OFFCURVE",
+"530 412 CURVE",
+"557 432 LINE",
+"590 471 OFFCURVE",
+"624 512 OFFCURVE",
+"660 555 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 837;
+}
+);
+leftMetricsKey = u1B1F8;
+rightMetricsKey = u1B1F8;
+unicode = 1B252;
+},
+{
+glyphname = u1B253;
+lastChange = "2020-04-13 09:06:30 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"467 667 OFFCURVE",
+"381 452 OFFCURVE",
+"265 221 CURVE",
+"331 186 LINE",
+"454 434 OFFCURVE",
+"529 619 OFFCURVE",
+"602 923 CURVE",
+"530 939 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"250 599 OFFCURVE",
+"335 555 OFFCURVE",
+"417 508 CURVE",
+"447 495 LINE",
+"529 447 OFFCURVE",
+"608 396 OFFCURVE",
+"691 339 CURVE",
+"733 398 LINE",
+"655 453 OFFCURVE",
+"567 510 OFFCURVE",
+"474 564 CURVE",
+"440 578 LINE",
+"358 625 OFFCURVE",
+"273 669 OFFCURVE",
+"186 710 CURVE",
+"156 642 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"372 755 OFFCURVE",
+"395 772 OFFCURVE",
+"395 811 CURVE SMOOTH",
+"395 850 OFFCURVE",
+"372 867 OFFCURVE",
+"344 867 CURVE SMOOTH",
+"315 867 OFFCURVE",
+"292 850 OFFCURVE",
+"292 811 CURVE SMOOTH",
+"292 772 OFFCURVE",
+"315 755 OFFCURVE",
+"344 755 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"717 586 OFFCURVE",
+"740 603 OFFCURVE",
+"740 642 CURVE SMOOTH",
+"740 681 OFFCURVE",
+"717 698 OFFCURVE",
+"689 698 CURVE SMOOTH",
+"660 698 OFFCURVE",
+"637 681 OFFCURVE",
+"637 642 CURVE SMOOTH",
+"637 603 OFFCURVE",
+"660 586 OFFCURVE",
+"689 586 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"223 381 OFFCURVE",
+"246 398 OFFCURVE",
+"246 437 CURVE SMOOTH",
+"246 476 OFFCURVE",
+"223 493 OFFCURVE",
+"195 493 CURVE SMOOTH",
+"166 493 OFFCURVE",
+"143 476 OFFCURVE",
+"143 437 CURVE SMOOTH",
+"143 398 OFFCURVE",
+"166 381 OFFCURVE",
+"195 381 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"554 189 OFFCURVE",
+"577 206 OFFCURVE",
+"577 245 CURVE SMOOTH",
+"577 284 OFFCURVE",
+"554 301 OFFCURVE",
+"526 301 CURVE SMOOTH",
+"497 301 OFFCURVE",
+"474 284 OFFCURVE",
+"474 245 CURVE SMOOTH",
+"474 206 OFFCURVE",
+"497 189 OFFCURVE",
+"526 189 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 -95 OFFCURVE",
+"109 -143 OFFCURVE",
+"177 -183 CURVE",
+"248 -174 LINE",
+"316 -95 OFFCURVE",
+"334 -30 OFFCURVE",
+"334 31 CURVE SMOOTH",
+"334 91 OFFCURVE",
+"300 132 OFFCURVE",
+"232 170 CURVE",
+"158 160 LINE",
+"100 78 OFFCURVE",
+"80 11 OFFCURVE",
+"80 -38 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 116 LINE",
+"244 84 OFFCURVE",
+"259 49 OFFCURVE",
+"259 20 CURVE SMOOTH",
+"259 -23 OFFCURVE",
+"249 -68 OFFCURVE",
+"209 -132 CURVE",
+"204 -133 LINE",
+"169 -98 OFFCURVE",
+"154 -67 OFFCURVE",
+"154 -34 CURVE SMOOTH",
+"154 8 OFFCURVE",
+"167 52 OFFCURVE",
+"199 115 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 830;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B1B0;
+unicode = 1B253;
+},
+{
+glyphname = u1B254;
+lastChange = "2020-04-13 09:07:29 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"178 247 LINE",
+"173 112 OFFCURVE",
+"161 19 OFFCURVE",
+"120 -86 CURVE",
+"184 -114 LINE",
+"226 -8 OFFCURVE",
+"242 100 OFFCURVE",
+"249 242 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"50 77 LINE",
+"98 67 OFFCURVE",
+"141 56 OFFCURVE",
+"182 43 CURVE",
+"203 41 LINE",
+"242 29 OFFCURVE",
+"279 15 OFFCURVE",
+"315 -2 CURVE",
+"347 60 LINE",
+"305 80 OFFCURVE",
+"261 97 OFFCURVE",
+"216 112 CURVE",
+"192 114 LINE",
+"152 126 OFFCURVE",
+"111 136 OFFCURVE",
+"68 145 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"319 167 LINE",
+"458 53 OFFCURVE",
+"551 -31 OFFCURVE",
+"664 -150 CURVE",
+"719 -102 LINE",
+"667 -48 OFFCURVE",
+"627 -10 OFFCURVE",
+"548 64 CURVE",
+"531 64 LINE",
+"483 117 OFFCURVE",
+"433 167 OFFCURVE",
+"368 221 CURVE",
+"364 179 LINE",
+"433 232 OFFCURVE",
+"505 291 OFFCURVE",
+"557 348 CURVE",
+"592 370 LINE",
+"608 385 OFFCURVE",
+"624 402 OFFCURVE",
+"642 421 CURVE",
+"588 474 LINE",
+"486 370 OFFCURVE",
+"405 303 OFFCURVE",
+"319 238 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"666 278 OFFCURVE",
+"647 332 OFFCURVE",
+"587 408 CURVE",
+"527 348 LINE",
+"561 348 LINE",
+"582 303 OFFCURVE",
+"590 265 OFFCURVE",
+"590 219 CURVE SMOOTH",
+"590 172 OFFCURVE",
+"574 125 OFFCURVE",
+"535 64 CURVE",
+"525 64 LINE",
+"457 -13 OFFCURVE",
+"383 -70 OFFCURVE",
+"282 -147 CURVE",
+"327 -203 LINE",
+"428 -126 OFFCURVE",
+"497 -64 OFFCURVE",
+"549 -10 CURVE",
+"573 11 LINE",
+"642 87 OFFCURVE",
+"666 147 OFFCURVE",
+"666 218 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"554 939 LINE",
+"470 850 OFFCURVE",
+"393 775 OFFCURVE",
+"313 706 CURVE",
+"297 697 LINE",
+"241 649 OFFCURVE",
+"183 604 OFFCURVE",
+"120 558 CURVE",
+"162 497 LINE",
+"221 540 OFFCURVE",
+"276 583 OFFCURVE",
+"331 629 CURVE",
+"348 639 LINE",
+"433 711 OFFCURVE",
+"517 792 OFFCURVE",
+"611 891 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"555 648 LINE",
+"446 544 OFFCURVE",
+"343 461 OFFCURVE",
+"218 368 CURVE",
+"261 308 LINE",
+"397 410 OFFCURVE",
+"488 482 OFFCURVE",
+"608 596 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"191 856 LINE",
+"280 682 OFFCURVE",
+"331 560 OFFCURVE",
+"367 445 CURVE",
+"429 490 LINE",
+"390 609 OFFCURVE",
+"353 708 OFFCURVE",
+"258 889 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 829;
+}
+);
+leftMetricsKey = u1B1AC;
+rightMetricsKey = u1B214;
+unicode = 1B254;
+},
+{
+glyphname = u1B255;
+lastChange = "2020-04-13 09:07:53 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"559 743 LINE",
+"598 743 LINE",
+"635 654 OFFCURVE",
+"651 581 OFFCURVE",
+"651 502 CURVE SMOOTH",
+"651 421 OFFCURVE",
+"632 329 OFFCURVE",
+"588 215 CURVE",
+"575 215 LINE",
+"515 86 OFFCURVE",
+"454 -18 OFFCURVE",
+"359 -166 CURVE",
+"421 -203 LINE",
+"491 -90 OFFCURVE",
+"540 1 OFFCURVE",
+"582 78 CURVE",
+"610 119 LINE",
+"702 291 OFFCURVE",
+"725 387 OFFCURVE",
+"725 503 CURVE SMOOTH",
+"725 623 OFFCURVE",
+"696 697 OFFCURVE",
+"616 834 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"714 -141 LINE",
+"680 -30 OFFCURVE",
+"652 59 OFFCURVE",
+"595 215 CURVE",
+"584 215 LINE",
+"557 315 OFFCURVE",
+"520 408 OFFCURVE",
+"473 516 CURVE SMOOTH",
+"437 598 OFFCURVE",
+"390 690 OFFCURVE",
+"344 774 CURVE",
+"280 741 LINE",
+"450 432 OFFCURVE",
+"546 161 OFFCURVE",
+"645 -161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"599 939 LINE",
+"551 796 OFFCURVE",
+"498 677 OFFCURVE",
+"433 558 CURVE",
+"410 527 LINE",
+"382 478 OFFCURVE",
+"351 428 OFFCURVE",
+"317 377 CURVE",
+"376 338 LINE",
+"403 376 OFFCURVE",
+"427 414 OFFCURVE",
+"450 451 CURVE",
+"474 482 LINE",
+"484 498 OFFCURVE",
+"493 513 OFFCURVE",
+"502 529 CURVE SMOOTH",
+"533 583 OFFCURVE",
+"570 670 OFFCURVE",
+"594 743 CURVE",
+"623 788 LINE",
+"638 827 OFFCURVE",
+"654 871 OFFCURVE",
+"670 916 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"271 266 OFFCURVE",
+"269 246 OFFCURVE",
+"267 227 CURVE SMOOTH",
+"262 178 OFFCURVE",
+"259 124 OFFCURVE",
+"249 59 CURVE",
+"241 17 LINE",
+"233 -34 OFFCURVE",
+"223 -86 OFFCURVE",
+"211 -132 CURVE",
+"272 -143 LINE",
+"283 -98 OFFCURVE",
+"295 -45 OFFCURVE",
+"305 10 CURVE",
+"313 52 LINE",
+"323 120 OFFCURVE",
+"329 172 OFFCURVE",
+"335 226 CURVE SMOOTH",
+"337 244 OFFCURVE",
+"339 262 OFFCURVE",
+"340 279 CURVE",
+"272 285 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"164 114 OFFCURVE",
+"209 33 OFFCURVE",
+"239 -53 CURVE",
+"278 -57 LINE",
+"352 -1 OFFCURVE",
+"417 72 OFFCURVE",
+"489 173 CURVE",
+"433 209 LINE",
+"427 200 OFFCURVE",
+"421 190 OFFCURVE",
+"415 181 CURVE SMOOTH",
+"385 137 OFFCURVE",
+"350 95 OFFCURVE",
+"317 51 CURVE",
+"245 62 LINE",
+"231 112 OFFCURVE",
+"199 185 OFFCURVE",
+"182 218 CURVE SMOOTH",
+"178 226 OFFCURVE",
+"174 235 OFFCURVE",
+"169 243 CURVE",
+"109 211 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 396 OFFCURVE",
+"105 357 OFFCURVE",
+"173 317 CURVE",
+"244 326 LINE",
+"301 404 OFFCURVE",
+"325 470 OFFCURVE",
+"325 541 CURVE SMOOTH",
+"325 591 OFFCURVE",
+"296 632 OFFCURVE",
+"228 670 CURVE",
+"154 660 LINE",
+"103 578 OFFCURVE",
+"80 514 OFFCURVE",
+"80 462 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 611 LINE",
+"239 585 OFFCURVE",
+"255 556 OFFCURVE",
+"255 527 CURVE SMOOTH",
+"255 484 OFFCURVE",
+"241 435 OFFCURVE",
+"204 369 CURVE",
+"200 369 LINE",
+"168 398 OFFCURVE",
+"150 427 OFFCURVE",
+"150 466 CURVE SMOOTH",
+"150 510 OFFCURVE",
+"164 550 OFFCURVE",
+"197 611 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 795;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B182;
+unicode = 1B255;
+},
+{
+glyphname = u1B256;
+lastChange = "2020-04-13 09:07:56 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"808 409 LINE",
+"747 291 OFFCURVE",
+"689 191 OFFCURVE",
+"629 102 CURVE SMOOTH",
+"566 8 OFFCURVE",
+"513 -58 OFFCURVE",
+"455 -137 CURVE",
+"450 -136 LINE",
+"427 -40 OFFCURVE",
+"397 43 OFFCURVE",
+"358 116 CURVE SMOOTH",
+"351 129 OFFCURVE",
+"344 143 OFFCURVE",
+"337 157 CURVE",
+"270 121 LINE",
+"330 9 OFFCURVE",
+"359 -57 OFFCURVE",
+"395 -178 CURVE",
+"487 -198 LINE",
+"641 -24 OFFCURVE",
+"752 134 OFFCURVE",
+"877 375 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"529 131 OFFCURVE",
+"552 148 OFFCURVE",
+"552 187 CURVE SMOOTH",
+"552 226 OFFCURVE",
+"529 243 OFFCURVE",
+"501 243 CURVE SMOOTH",
+"472 243 OFFCURVE",
+"449 226 OFFCURVE",
+"449 187 CURVE SMOOTH",
+"449 148 OFFCURVE",
+"472 131 OFFCURVE",
+"501 131 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 -120 OFFCURVE",
+"249 -103 OFFCURVE",
+"249 -64 CURVE SMOOTH",
+"249 -25 OFFCURVE",
+"226 -8 OFFCURVE",
+"198 -8 CURVE SMOOTH",
+"169 -8 OFFCURVE",
+"146 -25 OFFCURVE",
+"146 -64 CURVE SMOOTH",
+"146 -103 OFFCURVE",
+"169 -120 OFFCURVE",
+"198 -120 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"742 915 LINE",
+"671 767 OFFCURVE",
+"605 654 OFFCURVE",
+"534 554 CURVE SMOOTH",
+"479 477 OFFCURVE",
+"433 415 OFFCURVE",
+"381 348 CURVE",
+"376 349 LINE",
+"353 428 OFFCURVE",
+"333 489 OFFCURVE",
+"294 567 CURVE SMOOTH",
+"280 595 OFFCURVE",
+"266 623 OFFCURVE",
+"251 651 CURVE",
+"184 615 LINE",
+"244 503 OFFCURVE",
+"281 416 OFFCURVE",
+"324 304 CURVE",
+"408 283 LINE",
+"572 466 OFFCURVE",
+"685 622 OFFCURVE",
+"812 884 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"452 638 OFFCURVE",
+"475 655 OFFCURVE",
+"475 694 CURVE SMOOTH",
+"475 733 OFFCURVE",
+"452 750 OFFCURVE",
+"424 750 CURVE SMOOTH",
+"395 750 OFFCURVE",
+"372 733 OFFCURVE",
+"372 694 CURVE SMOOTH",
+"372 655 OFFCURVE",
+"395 638 OFFCURVE",
+"424 638 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 346 OFFCURVE",
+"163 363 OFFCURVE",
+"163 402 CURVE SMOOTH",
+"163 441 OFFCURVE",
+"140 458 OFFCURVE",
+"112 458 CURVE SMOOTH",
+"83 458 OFFCURVE",
+"60 441 OFFCURVE",
+"60 402 CURVE SMOOTH",
+"60 363 OFFCURVE",
+"83 346 OFFCURVE",
+"112 346 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 957;
+}
+);
+leftMetricsKey = u1B193;
+rightMetricsKey = u1B193;
+unicode = 1B256;
+},
+{
+glyphname = u1B257;
+lastChange = "2020-04-13 09:08:03 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"165 587 LINE",
+"244 543 OFFCURVE",
+"303 510 OFFCURVE",
+"372 467 CURVE",
+"460 400 OFFCURVE",
+"531 349 OFFCURVE",
+"638 254 CURVE",
+"685 309 LINE",
+"599 379 OFFCURVE",
+"519 440 OFFCURVE",
+"393 528 CURVE",
+"379 528 LINE",
+"337 565 OFFCURVE",
+"301 590 OFFCURVE",
+"218 642 CURVE",
+"211 606 LINE",
+"281 692 OFFCURVE",
+"327 755 OFFCURVE",
+"360 815 CURVE",
+"382 847 LINE",
+"393 866 OFFCURVE",
+"405 886 OFFCURVE",
+"416 907 CURVE",
+"347 939 LINE",
+"286 823 OFFCURVE",
+"229 744 OFFCURVE",
+"165 668 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"324 815 LINE",
+"364 815 LINE",
+"400 756 OFFCURVE",
+"410 717 OFFCURVE",
+"410 659 CURVE SMOOTH",
+"410 614 OFFCURVE",
+"399 572 OFFCURVE",
+"383 528 CURVE",
+"373 528 LINE",
+"336 436 OFFCURVE",
+"239 334 OFFCURVE",
+"80 189 CURVE",
+"133 137 LINE",
+"289 281 OFFCURVE",
+"363 367 OFFCURVE",
+"428 483 CURVE",
+"461 528 OFFCURVE",
+"482 597 OFFCURVE",
+"482 659 CURVE SMOOTH",
+"482 734 OFFCURVE",
+"456 806 OFFCURVE",
+"377 882 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"628 633 LINE",
+"544 589 OFFCURVE",
+"466 555 OFFCURVE",
+"388 519 CURVE",
+"289 492 OFFCURVE",
+"190 468 OFFCURVE",
+"91 447 CURVE",
+"110 375 LINE",
+"212 400 OFFCURVE",
+"309 429 OFFCURVE",
+"394 463 CURVE",
+"498 500 OFFCURVE",
+"572 528 OFFCURVE",
+"662 567 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"344 161 LINE",
+"387 27 OFFCURVE",
+"397 -70 OFFCURVE",
+"397 -202 CURVE",
+"471 -203 LINE",
+"470 -58 OFFCURVE",
+"454 55 OFFCURVE",
+"407 193 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"523 300 LINE",
+"396 198 OFFCURVE",
+"305 147 OFFCURVE",
+"154 70 CURVE",
+"184 5 LINE",
+"344 86 OFFCURVE",
+"437 134 OFFCURVE",
+"571 246 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"275 -142 OFFCURVE",
+"298 -125 OFFCURVE",
+"298 -86 CURVE SMOOTH",
+"298 -47 OFFCURVE",
+"275 -30 OFFCURVE",
+"247 -30 CURVE SMOOTH",
+"218 -30 OFFCURVE",
+"195 -47 OFFCURVE",
+"195 -86 CURVE SMOOTH",
+"195 -125 OFFCURVE",
+"218 -142 OFFCURVE",
+"247 -142 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"630 19 OFFCURVE",
+"653 36 OFFCURVE",
+"653 75 CURVE SMOOTH",
+"653 114 OFFCURVE",
+"630 131 OFFCURVE",
+"602 131 CURVE SMOOTH",
+"571 131 OFFCURVE",
+"550 114 OFFCURVE",
+"550 75 CURVE SMOOTH",
+"550 36 OFFCURVE",
+"573 19 OFFCURVE",
+"602 19 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 765;
+}
+);
+leftMetricsKey = u1B213;
+rightMetricsKey = u1B213;
+unicode = 1B257;
+},
+{
+glyphname = u1B258;
+lastChange = "2020-04-13 09:08:14 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"323 138 OFFCURVE",
+"320 111 OFFCURVE",
+"320 88 CURVE SMOOTH",
+"320 -62 OFFCURVE",
+"408 -159 OFFCURVE",
+"568 -159 CURVE SMOOTH",
+"600 -159 OFFCURVE",
+"635 -154 OFFCURVE",
+"668 -147 CURVE",
+"655 -74 LINE",
+"626 -80 OFFCURVE",
+"600 -83 OFFCURVE",
+"572 -83 CURVE SMOOTH",
+"460 -83 OFFCURVE",
+"394 -18 OFFCURVE",
+"394 96 CURVE SMOOTH",
+"394 134 OFFCURVE",
+"398 170 OFFCURVE",
+"414 206 CURVE",
+"372 229 LINE",
+"358 228 OFFCURVE",
+"345 228 OFFCURVE",
+"333 228 CURVE SMOOTH",
+"212 228 OFFCURVE",
+"146 301 OFFCURVE",
+"146 418 CURVE SMOOTH",
+"146 449 OFFCURVE",
+"151 481 OFFCURVE",
+"163 516 CURVE",
+"95 538 LINE",
+"79 503 OFFCURVE",
+"70 460 OFFCURVE",
+"70 419 CURVE SMOOTH",
+"70 323 OFFCURVE",
+"105 239 OFFCURVE",
+"184 192 CURVE SMOOTH",
+"218 172 OFFCURVE",
+"272 162 OFFCURVE",
+"331 165 CURVE",
+"333 162 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"585 663 OFFCURVE",
+"468 392 OFFCURVE",
+"327 182 CURVE",
+"379 120 LINE",
+"541 381 OFFCURVE",
+"648 619 OFFCURVE",
+"721 923 CURVE",
+"647 939 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"368 600 OFFCURVE",
+"451 557 OFFCURVE",
+"530 512 CURVE",
+"554 503 LINE",
+"640 453 OFFCURVE",
+"724 399 OFFCURVE",
+"811 339 CURVE",
+"855 400 LINE",
+"773 458 OFFCURVE",
+"680 516 OFFCURVE",
+"581 572 CURVE",
+"558 580 LINE",
+"476 626 OFFCURVE",
+"391 670 OFFCURVE",
+"305 710 CURVE",
+"276 642 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"488 755 OFFCURVE",
+"511 772 OFFCURVE",
+"511 811 CURVE SMOOTH",
+"511 850 OFFCURVE",
+"488 867 OFFCURVE",
+"460 867 CURVE SMOOTH",
+"431 867 OFFCURVE",
+"408 850 OFFCURVE",
+"408 811 CURVE SMOOTH",
+"408 772 OFFCURVE",
+"431 755 OFFCURVE",
+"460 755 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"833 586 OFFCURVE",
+"856 603 OFFCURVE",
+"856 642 CURVE SMOOTH",
+"856 681 OFFCURVE",
+"833 698 OFFCURVE",
+"805 698 CURVE SMOOTH",
+"776 698 OFFCURVE",
+"753 681 OFFCURVE",
+"753 642 CURVE SMOOTH",
+"753 603 OFFCURVE",
+"776 586 OFFCURVE",
+"805 586 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"329 381 OFFCURVE",
+"352 398 OFFCURVE",
+"352 437 CURVE SMOOTH",
+"352 476 OFFCURVE",
+"329 493 OFFCURVE",
+"301 493 CURVE SMOOTH",
+"272 493 OFFCURVE",
+"249 476 OFFCURVE",
+"249 437 CURVE SMOOTH",
+"249 398 OFFCURVE",
+"272 381 OFFCURVE",
+"301 381 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"670 189 OFFCURVE",
+"693 206 OFFCURVE",
+"693 245 CURVE SMOOTH",
+"693 284 OFFCURVE",
+"670 301 OFFCURVE",
+"642 301 CURVE SMOOTH",
+"613 301 OFFCURVE",
+"590 284 OFFCURVE",
+"590 245 CURVE SMOOTH",
+"590 206 OFFCURVE",
+"613 189 OFFCURVE",
+"642 189 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 946;
+}
+);
+leftMetricsKey = u1B1D0;
+rightMetricsKey = u1B253;
+unicode = 1B258;
+},
+{
+glyphname = u1B259;
+lastChange = "2020-04-13 09:08:33 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"416 701 OFFCURVE",
+"440 663 OFFCURVE",
+"505 630 CURVE",
+"580 641 LINE",
+"634 721 OFFCURVE",
+"648 771 OFFCURVE",
+"648 821 CURVE SMOOTH",
+"648 867 OFFCURVE",
+"624 908 OFFCURVE",
+"557 939 CURVE",
+"483 929 LINE",
+"430 854 OFFCURVE",
+"416 804 OFFCURVE",
+"416 762 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 377 OFFCURVE",
+"104 337 OFFCURVE",
+"169 302 CURVE",
+"244 313 LINE",
+"298 393 OFFCURVE",
+"312 442 OFFCURVE",
+"312 490 CURVE SMOOTH",
+"312 539 OFFCURVE",
+"288 580 OFFCURVE",
+"221 611 CURVE",
+"147 601 LINE",
+"94 521 OFFCURVE",
+"80 477 OFFCURVE",
+"80 429 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"196 553 LINE",
+"225 533 OFFCURVE",
+"236 512 OFFCURVE",
+"236 488 CURVE SMOOTH",
+"236 455 OFFCURVE",
+"226 412 OFFCURVE",
+"202 360 CURVE",
+"197 359 LINE",
+"169 384 OFFCURVE",
+"158 410 OFFCURVE",
+"158 437 CURVE SMOOTH",
+"158 465 OFFCURVE",
+"165 495 OFFCURVE",
+"191 552 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"802 939 LINE",
+"707 733 OFFCURVE",
+"598 571 OFFCURVE",
+"473 433 CURVE",
+"451 416 LINE",
+"385 344 OFFCURVE",
+"314 279 OFFCURVE",
+"238 217 CURVE",
+"283 164 LINE",
+"356 224 OFFCURVE",
+"424 285 OFFCURVE",
+"488 352 CURVE",
+"513 372 LINE",
+"650 519 OFFCURVE",
+"768 690 OFFCURVE",
+"871 909 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"724 438 LINE",
+"670 366 OFFCURVE",
+"618 305 OFFCURVE",
+"564 248 CURVE",
+"541 230 LINE",
+"483 171 OFFCURVE",
+"420 116 OFFCURVE",
+"346 56 CURVE",
+"387 2 LINE",
+"454 55 OFFCURVE",
+"513 107 OFFCURVE",
+"569 162 CURVE",
+"593 180 LINE",
+"657 245 OFFCURVE",
+"717 316 OFFCURVE",
+"781 400 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"816 229 LINE",
+"696 83 OFFCURVE",
+"576 -37 OFFCURVE",
+"429 -150 CURVE",
+"471 -203 LINE",
+"631 -75 OFFCURVE",
+"743 30 OFFCURVE",
+"871 185 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"685 0 LINE",
+"565 305 OFFCURVE",
+"470 525 OFFCURVE",
+"275 858 CURVE",
+"211 820 LINE",
+"412 483 OFFCURVE",
+"505 260 OFFCURVE",
+"617 -23 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 880 LINE",
+"559 860 OFFCURVE",
+"570 839 OFFCURVE",
+"570 815 CURVE SMOOTH",
+"570 782 OFFCURVE",
+"560 739 OFFCURVE",
+"536 687 CURVE",
+"531 686 LINE",
+"503 711 OFFCURVE",
+"492 737 OFFCURVE",
+"492 764 CURVE SMOOTH",
+"492 792 OFFCURVE",
+"499 822 OFFCURVE",
+"525 879 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 951;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B197;
+unicode = 1B259;
+},
+{
+glyphname = u1B25A;
+lastChange = "2020-04-13 09:08:44 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"222 198 LINE",
+"270 236 OFFCURVE",
+"296 293 OFFCURVE",
+"296 356 CURVE SMOOTH",
+"296 465 OFFCURVE",
+"233 553 OFFCURVE",
+"94 574 CURVE",
+"84 507 LINE",
+"184 495 OFFCURVE",
+"226 440 OFFCURVE",
+"226 356 CURVE SMOOTH",
+"226 281 OFFCURVE",
+"199 243 OFFCURVE",
+"147 214 CURVE",
+"160 141 LINE",
+"269 136 OFFCURVE",
+"311 86 OFFCURVE",
+"311 3 CURVE SMOOTH",
+"311 -77 OFFCURVE",
+"274 -116 OFFCURVE",
+"208 -142 CURVE",
+"233 -203 LINE",
+"336 -163 OFFCURVE",
+"381 -94 OFFCURVE",
+"381 -2 CURVE SMOOTH",
+"381 88 OFFCURVE",
+"331 172 OFFCURVE",
+"223 193 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"124 308 OFFCURVE",
+"145 323 OFFCURVE",
+"145 358 CURVE SMOOTH",
+"145 393 OFFCURVE",
+"124 408 OFFCURVE",
+"98 408 CURVE SMOOTH",
+"71 408 OFFCURVE",
+"50 393 OFFCURVE",
+"50 358 CURVE SMOOTH",
+"50 323 OFFCURVE",
+"71 308 OFFCURVE",
+"98 308 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"208 -51 OFFCURVE",
+"229 -36 OFFCURVE",
+"229 -1 CURVE SMOOTH",
+"229 34 OFFCURVE",
+"208 49 OFFCURVE",
+"182 49 CURVE SMOOTH",
+"155 49 OFFCURVE",
+"134 34 OFFCURVE",
+"134 -1 CURVE SMOOTH",
+"134 -36 OFFCURVE",
+"155 -51 OFFCURVE",
+"182 -51 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"714 661 LINE",
+"666 598 OFFCURVE",
+"616 540 OFFCURVE",
+"564 485 CURVE",
+"545 474 LINE",
+"485 412 OFFCURVE",
+"423 354 OFFCURVE",
+"358 299 CURVE",
+"404 243 LINE",
+"461 291 OFFCURVE",
+"512 337 OFFCURVE",
+"560 386 CURVE",
+"583 402 LINE",
+"646 466 OFFCURVE",
+"705 534 OFFCURVE",
+"771 615 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"638 939 LINE",
+"525 771 OFFCURVE",
+"410 645 OFFCURVE",
+"279 525 CURVE",
+"331 468 LINE",
+"454 584 OFFCURVE",
+"584 722 OFFCURVE",
+"703 898 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"759 377 LINE",
+"652 249 OFFCURVE",
+"553 153 OFFCURVE",
+"431 60 CURVE",
+"476 0 LINE",
+"615 110 OFFCURVE",
+"708 205 OFFCURVE",
+"817 332 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"471 634 LINE",
+"522 472 OFFCURVE",
+"553 318 OFFCURVE",
+"571 157 CURVE",
+"640 187 LINE",
+"621 357 OFFCURVE",
+"585 515 OFFCURVE",
+"530 709 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 897;
+}
+);
+leftMetricsKey = u1B1D7;
+rightMetricsKey = u1B1A7;
+unicode = 1B25A;
+},
+{
+glyphname = u1B25B;
+lastChange = "2020-04-13 09:09:04 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"664 700 LINE",
+"583 575 OFFCURVE",
+"521 494 OFFCURVE",
+"422 384 CURVE",
+"472 329 LINE",
+"561 428 OFFCURVE",
+"635 520 OFFCURVE",
+"708 626 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"533 905 LINE",
+"469 802 OFFCURVE",
+"389 690 OFFCURVE",
+"306 595 CURVE",
+"389 422 OFFCURVE",
+"449 287 OFFCURVE",
+"504 145 CURVE",
+"596 135 LINE",
+"667 209 OFFCURVE",
+"745 299 OFFCURVE",
+"836 421 CURVE",
+"775 587 OFFCURVE",
+"707 747 OFFCURVE",
+"629 899 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"576 838 LINE",
+"610 769 OFFCURVE",
+"632 726 OFFCURVE",
+"664 652 CURVE SMOOTH",
+"703 562 OFFCURVE",
+"741 466 OFFCURVE",
+"775 366 CURVE",
+"784 476 LINE",
+"751 430 OFFCURVE",
+"720 390 OFFCURVE",
+"690 353 CURVE SMOOTH",
+"642 294 OFFCURVE",
+"602 250 OFFCURVE",
+"560 198 CURVE",
+"556 198 LINE",
+"532 272 OFFCURVE",
+"506 337 OFFCURVE",
+"474 409 CURVE SMOOTH",
+"441 483 OFFCURVE",
+"405 558 OFFCURVE",
+"368 633 CURVE",
+"374 556 LINE",
+"414 608 OFFCURVE",
+"450 654 OFFCURVE",
+"482 698 CURVE SMOOTH",
+"521 751 OFFCURVE",
+"540 779 OFFCURVE",
+"572 838 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"100 133 LINE",
+"202 40 OFFCURVE",
+"278 -43 OFFCURVE",
+"380 -164 CURVE",
+"439 -118 LINE",
+"395 -69 OFFCURVE",
+"364 -31 OFFCURVE",
+"292 45 CURVE",
+"278 45 LINE",
+"246 94 OFFCURVE",
+"199 137 OFFCURVE",
+"142 191 CURVE",
+"149 161 LINE",
+"196 205 OFFCURVE",
+"253 262 OFFCURVE",
+"284 315 CURVE",
+"311 343 LINE",
+"324 359 OFFCURVE",
+"337 377 OFFCURVE",
+"352 396 CURVE",
+"292 439 LINE",
+"221 337 OFFCURVE",
+"160 269 OFFCURVE",
+"100 215 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"258 315 LINE",
+"288 315 LINE",
+"304 274 OFFCURVE",
+"312 237 OFFCURVE",
+"312 201 CURVE SMOOTH",
+"312 153 OFFCURVE",
+"301 95 OFFCURVE",
+"282 45 CURVE",
+"272 45 LINE",
+"236 -31 OFFCURVE",
+"191 -95 OFFCURVE",
+"138 -162 CURVE",
+"195 -203 LINE",
+"241 -143 OFFCURVE",
+"272 -93 OFFCURVE",
+"298 -48 CURVE",
+"322 -15 LINE",
+"369 71 OFFCURVE",
+"382 134 OFFCURVE",
+"382 201 CURVE SMOOTH",
+"382 254 OFFCURVE",
+"366 315 OFFCURVE",
+"314 382 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 926;
+}
+);
+leftMetricsKey = u1B20A;
+rightMetricsKey = u1B1C8;
+unicode = 1B25B;
+},
+{
+glyphname = u1B25C;
+lastChange = "2020-04-13 09:09:25 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"517 939 LINE",
+"457 696 OFFCURVE",
+"391 536 OFFCURVE",
+"290 374 CURVE",
+"300 294 LINE",
+"345 252 OFFCURVE",
+"385 212 OFFCURVE",
+"423 172 CURVE",
+"447 153 LINE",
+"513 82 OFFCURVE",
+"570 10 OFFCURVE",
+"628 -70 CURVE",
+"689 -23 LINE",
+"619 68 OFFCURVE",
+"553 143 OFFCURVE",
+"481 220 CURVE",
+"461 234 LINE",
+"421 276 OFFCURVE",
+"378 319 OFFCURVE",
+"332 366 CURVE",
+"343 321 LINE",
+"450 495 OFFCURVE",
+"528 673 OFFCURVE",
+"592 924 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"200 785 LINE",
+"270 696 OFFCURVE",
+"333 624 OFFCURVE",
+"400 556 CURVE",
+"420 531 LINE",
+"461 490 OFFCURVE",
+"504 450 OFFCURVE",
+"550 408 CURVE",
+"548 441 LINE",
+"430 214 OFFCURVE",
+"344 51 OFFCURVE",
+"251 -176 CURVE",
+"323 -203 LINE",
+"406 9 OFFCURVE",
+"498 192 OFFCURVE",
+"600 383 CURVE",
+"590 469 LINE",
+"546 509 OFFCURVE",
+"501 552 OFFCURVE",
+"456 599 CURVE",
+"432 630 LINE",
+"375 691 OFFCURVE",
+"318 758 OFFCURVE",
+"259 833 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"70 483 LINE",
+"133 389 OFFCURVE",
+"175 316 OFFCURVE",
+"200 250 CURVE",
+"194 300 LINE",
+"160 228 OFFCURVE",
+"132 141 OFFCURVE",
+"108 45 CURVE",
+"181 31 LINE",
+"201 118 OFFCURVE",
+"228 198 OFFCURVE",
+"264 285 CURVE",
+"235 360 OFFCURVE",
+"193 432 OFFCURVE",
+"132 523 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"673 636 OFFCURVE",
+"646 561 OFFCURVE",
+"624 488 CURVE",
+"674 409 OFFCURVE",
+"714 329 OFFCURVE",
+"746 239 CURVE",
+"816 265 LINE",
+"777 364 OFFCURVE",
+"738 440 OFFCURVE",
+"689 521 CURVE",
+"691 466 LINE",
+"711 538 OFFCURVE",
+"740 602 OFFCURVE",
+"787 710 CURVE",
+"716 739 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 886;
+}
+);
+unicode = 1B25C;
+},
+{
+glyphname = u1B25D;
+lastChange = "2020-04-13 09:09:27 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"378 573 LINE",
+"363 198 OFFCURVE",
+"315 29 OFFCURVE",
+"198 -168 CURVE",
+"262 -203 LINE",
+"389 14 OFFCURVE",
+"435 181 OFFCURVE",
+"452 570 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"236 260 OFFCURVE",
+"259 277 OFFCURVE",
+"259 316 CURVE SMOOTH",
+"259 355 OFFCURVE",
+"236 372 OFFCURVE",
+"208 372 CURVE SMOOTH",
+"179 372 OFFCURVE",
+"156 355 OFFCURVE",
+"156 316 CURVE SMOOTH",
+"156 277 OFFCURVE",
+"179 260 OFFCURVE",
+"208 260 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"175 22 OFFCURVE",
+"198 39 OFFCURVE",
+"198 78 CURVE SMOOTH",
+"198 117 OFFCURVE",
+"175 134 OFFCURVE",
+"147 134 CURVE SMOOTH",
+"118 134 OFFCURVE",
+"95 117 OFFCURVE",
+"95 78 CURVE SMOOTH",
+"95 39 OFFCURVE",
+"118 22 OFFCURVE",
+"147 22 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"615 279 OFFCURVE",
+"638 296 OFFCURVE",
+"638 335 CURVE SMOOTH",
+"638 374 OFFCURVE",
+"615 391 OFFCURVE",
+"587 391 CURVE SMOOTH",
+"558 391 OFFCURVE",
+"535 374 OFFCURVE",
+"535 335 CURVE SMOOTH",
+"535 296 OFFCURVE",
+"558 279 OFFCURVE",
+"587 279 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"599 53 OFFCURVE",
+"622 70 OFFCURVE",
+"622 109 CURVE SMOOTH",
+"622 148 OFFCURVE",
+"599 165 OFFCURVE",
+"571 165 CURVE SMOOTH",
+"542 165 OFFCURVE",
+"519 148 OFFCURVE",
+"519 109 CURVE SMOOTH",
+"519 70 OFFCURVE",
+"542 53 OFFCURVE",
+"571 53 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"514 -162 OFFCURVE",
+"537 -145 OFFCURVE",
+"537 -106 CURVE SMOOTH",
+"537 -67 OFFCURVE",
+"514 -50 OFFCURVE",
+"486 -50 CURVE SMOOTH",
+"457 -50 OFFCURVE",
+"434 -67 OFFCURVE",
+"434 -106 CURVE SMOOTH",
+"434 -145 OFFCURVE",
+"457 -162 OFFCURVE",
+"486 -162 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"382 941 LINE",
+"298 745 OFFCURVE",
+"212 633 OFFCURVE",
+"80 509 CURVE",
+"132 456 LINE",
+"264 582 OFFCURVE",
+"364 705 OFFCURVE",
+"453 918 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"374 819 LINE",
+"485 721 OFFCURVE",
+"584 611 OFFCURVE",
+"670 489 CURVE",
+"729 533 LINE",
+"638 658 OFFCURVE",
+"546 762 OFFCURVE",
+"412 881 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 819;
+}
+);
+rightMetricsKey = u1B185;
+unicode = 1B25D;
+},
+{
+glyphname = u1B25E;
+lastChange = "2020-04-13 09:09:29 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"559 157 OFFCURVE",
+"594 105 OFFCURVE",
+"661 71 CURVE",
+"726 79 LINE",
+"776 146 OFFCURVE",
+"801 207 OFFCURVE",
+"801 259 CURVE SMOOTH",
+"801 318 OFFCURVE",
+"774 363 OFFCURVE",
+"704 410 CURVE",
+"632 401 LINE",
+"573 327 OFFCURVE",
+"559 274 OFFCURVE",
+"559 217 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"358 907 LINE",
+"272 772 OFFCURVE",
+"189 662 OFFCURVE",
+"90 544 CURVE",
+"168 394 OFFCURVE",
+"213 300 OFFCURVE",
+"268 167 CURVE",
+"356 157 LINE",
+"458 270 OFFCURVE",
+"536 369 OFFCURVE",
+"628 509 CURVE",
+"573 649 OFFCURVE",
+"524 756 OFFCURVE",
+"450 899 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"321 -117 OFFCURVE",
+"356 -169 OFFCURVE",
+"423 -203 CURVE",
+"488 -195 LINE",
+"538 -128 OFFCURVE",
+"563 -67 OFFCURVE",
+"563 -15 CURVE SMOOTH",
+"563 44 OFFCURVE",
+"536 89 OFFCURVE",
+"466 136 CURVE",
+"394 127 LINE",
+"335 53 OFFCURVE",
+"321 -9 OFFCURVE",
+"321 -57 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"439 74 LINE",
+"475 40 OFFCURVE",
+"489 14 OFFCURVE",
+"489 -16 CURVE SMOOTH",
+"489 -58 OFFCURVE",
+"477 -101 OFFCURVE",
+"450 -148 CURVE",
+"446 -148 LINE",
+"411 -119 OFFCURVE",
+"395 -88 OFFCURVE",
+"395 -55 CURVE SMOOTH",
+"395 -17 OFFCURVE",
+"404 17 OFFCURVE",
+"435 74 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"401 839 LINE",
+"432 772 OFFCURVE",
+"453 726 OFFCURVE",
+"487 650 CURVE SMOOTH",
+"514 589 OFFCURVE",
+"540 524 OFFCURVE",
+"569 446 CURVE",
+"574 567 LINE",
+"538 510 OFFCURVE",
+"502 458 OFFCURVE",
+"466 410 CURVE SMOOTH",
+"415 342 OFFCURVE",
+"363 273 OFFCURVE",
+"323 219 CURVE",
+"319 219 LINE",
+"297 286 OFFCURVE",
+"265 363 OFFCURVE",
+"237 422 CURVE SMOOTH",
+"213 472 OFFCURVE",
+"185 525 OFFCURVE",
+"151 587 CURVE",
+"152 499 LINE",
+"203 562 OFFCURVE",
+"246 614 OFFCURVE",
+"285 666 CURVE SMOOTH",
+"323 716 OFFCURVE",
+"360 773 OFFCURVE",
+"397 839 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"677 348 LINE",
+"713 314 OFFCURVE",
+"727 288 OFFCURVE",
+"727 258 CURVE SMOOTH",
+"727 216 OFFCURVE",
+"715 173 OFFCURVE",
+"688 126 CURVE",
+"684 126 LINE",
+"649 155 OFFCURVE",
+"633 186 OFFCURVE",
+"633 219 CURVE SMOOTH",
+"633 257 OFFCURVE",
+"642 291 OFFCURVE",
+"673 348 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 861;
+}
+);
+leftMetricsKey = u1B1C8;
+rightMetricsKey = u1B1F1;
+unicode = 1B25E;
+},
+{
+glyphname = u1B25F;
+lastChange = "2020-04-13 09:09:39 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"492 260 LINE",
+"468 376 OFFCURVE",
+"450 451 OFFCURVE",
+"404 577 CURVE",
+"344 522 LINE",
+"382 418 OFFCURVE",
+"407 334 OFFCURVE",
+"424 225 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"488 939 LINE",
+"332 807 OFFCURVE",
+"205 724 OFFCURVE",
+"60 645 CURVE",
+"97 580 LINE",
+"239 658 OFFCURVE",
+"376 746 OFFCURVE",
+"538 886 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"594 435 OFFCURVE",
+"616 451 OFFCURVE",
+"616 488 CURVE SMOOTH",
+"616 526 OFFCURVE",
+"594 542 OFFCURVE",
+"567 542 CURVE SMOOTH",
+"540 542 OFFCURVE",
+"518 526 OFFCURVE",
+"518 488 CURVE SMOOTH",
+"518 451 OFFCURVE",
+"540 435 OFFCURVE",
+"567 435 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"311 253 OFFCURVE",
+"333 269 OFFCURVE",
+"333 307 CURVE SMOOTH",
+"333 344 OFFCURVE",
+"311 360 OFFCURVE",
+"285 360 CURVE SMOOTH",
+"257 360 OFFCURVE",
+"235 344 OFFCURVE",
+"235 307 CURVE SMOOTH",
+"235 269 OFFCURVE",
+"257 253 OFFCURVE",
+"285 253 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"475 774 OFFCURVE",
+"485 744 OFFCURVE",
+"485 711 CURVE SMOOTH",
+"485 655 OFFCURVE",
+"434 595 OFFCURVE",
+"129 434 CURVE",
+"165 369 LINE",
+"494 540 OFFCURVE",
+"561 623 OFFCURVE",
+"561 710 CURVE SMOOTH",
+"561 762 OFFCURVE",
+"547 796 OFFCURVE",
+"488 862 CURVE",
+"437 818 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"266 103 LINE",
+"414 23 OFFCURVE",
+"532 -48 OFFCURVE",
+"668 -141 CURVE",
+"708 -81 LINE",
+"656 -44 OFFCURVE",
+"610 -17 OFFCURVE",
+"518 39 CURVE",
+"504 39 LINE",
+"453 77 OFFCURVE",
+"405 110 OFFCURVE",
+"327 153 CURVE",
+"316 117 LINE",
+"433 193 OFFCURVE",
+"493 240 OFFCURVE",
+"543 288 CURVE",
+"582 312 LINE",
+"599 325 OFFCURVE",
+"616 339 OFFCURVE",
+"633 354 CURVE",
+"586 410 LINE",
+"474 309 OFFCURVE",
+"380 242 OFFCURVE",
+"266 174 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"523 288 LINE",
+"547 288 LINE",
+"556 253 OFFCURVE",
+"561 220 OFFCURVE",
+"561 193 CURVE SMOOTH",
+"561 146 OFFCURVE",
+"541 93 OFFCURVE",
+"508 39 CURVE",
+"499 39 LINE",
+"437 -32 OFFCURVE",
+"361 -81 OFFCURVE",
+"272 -142 CURVE",
+"311 -203 LINE",
+"409 -137 OFFCURVE",
+"473 -81 OFFCURVE",
+"522 -30 CURVE",
+"552 -5 LINE",
+"616 69 OFFCURVE",
+"635 132 OFFCURVE",
+"635 193 CURVE SMOOTH",
+"635 240 OFFCURVE",
+"623 288 OFFCURVE",
+"580 352 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 818;
+}
+);
+leftMetricsKey = u1B179;
+rightMetricsKey = u1B214;
+unicode = 1B25F;
+},
+{
+glyphname = u1B260;
+lastChange = "2020-04-13 09:10:10 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"618 363 LINE",
+"484 252 OFFCURVE",
+"377 185 OFFCURVE",
+"226 105 CURVE",
+"262 42 LINE",
+"419 123 OFFCURVE",
+"528 191 OFFCURVE",
+"667 309 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"590 185 OFFCURVE",
+"604 151 OFFCURVE",
+"604 104 CURVE SMOOTH",
+"604 29 OFFCURVE",
+"553 -19 OFFCURVE",
+"296 -137 CURVE",
+"329 -203 LINE",
+"611 -69 OFFCURVE",
+"678 -10 OFFCURVE",
+"678 102 CURVE SMOOTH",
+"678 156 OFFCURVE",
+"663 209 OFFCURVE",
+"605 278 CURVE",
+"553 232 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"821 77 OFFCURVE",
+"844 94 OFFCURVE",
+"844 133 CURVE SMOOTH",
+"844 172 OFFCURVE",
+"821 189 OFFCURVE",
+"793 189 CURVE SMOOTH",
+"764 189 OFFCURVE",
+"741 172 OFFCURVE",
+"741 133 CURVE SMOOTH",
+"741 94 OFFCURVE",
+"764 77 OFFCURVE",
+"793 77 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"802 297 OFFCURVE",
+"825 314 OFFCURVE",
+"825 353 CURVE SMOOTH",
+"825 392 OFFCURVE",
+"802 409 OFFCURVE",
+"774 409 CURVE SMOOTH",
+"745 409 OFFCURVE",
+"722 392 OFFCURVE",
+"722 353 CURVE SMOOTH",
+"722 314 OFFCURVE",
+"745 297 OFFCURVE",
+"774 297 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"316 326 LINE",
+"295 388 OFFCURVE",
+"269 443 OFFCURVE",
+"232 509 CURVE SMOOTH",
+"205 557 OFFCURVE",
+"176 606 OFFCURVE",
+"142 657 CURVE",
+"80 615 LINE",
+"159 496 OFFCURVE",
+"212 397 OFFCURVE",
+"265 275 CURVE",
+"346 260 LINE",
+"523 392 OFFCURVE",
+"617 496 OFFCURVE",
+"751 689 CURVE",
+"689 729 LINE",
+"607 613 OFFCURVE",
+"547 536 OFFCURVE",
+"479 465 CURVE SMOOTH",
+"429 413 OFFCURVE",
+"384 372 OFFCURVE",
+"321 325 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"548 939 LINE",
+"445 762 OFFCURVE",
+"346 646 OFFCURVE",
+"208 508 CURVE",
+"253 453 LINE",
+"399 596 OFFCURVE",
+"505 713 OFFCURVE",
+"613 904 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 828 LINE",
+"248 762 OFFCURVE",
+"291 693 OFFCURVE",
+"331 622 CURVE",
+"352 594 LINE",
+"388 529 OFFCURVE",
+"422 460 OFFCURVE",
+"455 390 CURVE",
+"497 454 LINE",
+"470 516 OFFCURVE",
+"441 576 OFFCURVE",
+"409 638 CURVE",
+"381 678 LINE",
+"347 740 OFFCURVE",
+"308 802 OFFCURVE",
+"261 868 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 964;
+}
+);
+leftMetricsKey = u1B1A2;
+rightMetricsKey = u1B21C;
+unicode = 1B260;
+},
+{
+glyphname = u1B261;
+lastChange = "2020-04-13 09:10:29 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"182 159 LINE",
+"210 159 LINE",
+"234 105 OFFCURVE",
+"256 56 OFFCURVE",
+"287 -30 CURVE",
+"353 -4 LINE",
+"317 84 OFFCURVE",
+"280 153 OFFCURVE",
+"226 233 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"166 292 LINE",
+"143 147 OFFCURVE",
+"125 65 OFFCURVE",
+"80 -69 CURVE",
+"147 -90 LINE",
+"177 0 OFFCURVE",
+"192 71 OFFCURVE",
+"206 159 CURVE",
+"223 205 LINE",
+"227 229 OFFCURVE",
+"231 255 OFFCURVE",
+"234 282 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"329 167 LINE",
+"468 53 OFFCURVE",
+"561 -31 OFFCURVE",
+"674 -150 CURVE",
+"729 -102 LINE",
+"677 -48 OFFCURVE",
+"637 -10 OFFCURVE",
+"558 64 CURVE",
+"541 64 LINE",
+"493 117 OFFCURVE",
+"443 167 OFFCURVE",
+"378 221 CURVE",
+"374 179 LINE",
+"443 232 OFFCURVE",
+"515 291 OFFCURVE",
+"567 348 CURVE",
+"602 370 LINE",
+"618 385 OFFCURVE",
+"634 402 OFFCURVE",
+"652 421 CURVE",
+"598 474 LINE",
+"496 370 OFFCURVE",
+"415 303 OFFCURVE",
+"329 238 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"676 278 OFFCURVE",
+"657 332 OFFCURVE",
+"597 408 CURVE",
+"537 348 LINE",
+"571 348 LINE",
+"592 303 OFFCURVE",
+"600 265 OFFCURVE",
+"600 219 CURVE SMOOTH",
+"600 172 OFFCURVE",
+"584 125 OFFCURVE",
+"545 64 CURVE",
+"535 64 LINE",
+"467 -13 OFFCURVE",
+"393 -70 OFFCURVE",
+"292 -147 CURVE",
+"337 -203 LINE",
+"438 -126 OFFCURVE",
+"507 -64 OFFCURVE",
+"559 -10 CURVE",
+"583 11 LINE",
+"652 87 OFFCURVE",
+"676 147 OFFCURVE",
+"676 218 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"564 939 LINE",
+"480 850 OFFCURVE",
+"403 775 OFFCURVE",
+"323 706 CURVE",
+"307 697 LINE",
+"251 649 OFFCURVE",
+"193 604 OFFCURVE",
+"130 558 CURVE",
+"172 497 LINE",
+"231 540 OFFCURVE",
+"286 583 OFFCURVE",
+"341 629 CURVE",
+"358 639 LINE",
+"443 711 OFFCURVE",
+"527 792 OFFCURVE",
+"621 891 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"565 648 LINE",
+"456 544 OFFCURVE",
+"353 461 OFFCURVE",
+"228 368 CURVE",
+"271 308 LINE",
+"407 410 OFFCURVE",
+"498 482 OFFCURVE",
+"618 596 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 856 LINE",
+"290 682 OFFCURVE",
+"341 560 OFFCURVE",
+"377 445 CURVE",
+"439 490 LINE",
+"400 609 OFFCURVE",
+"363 708 OFFCURVE",
+"268 889 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 839;
+}
+);
+leftMetricsKey = u1B231;
+rightMetricsKey = u1B214;
+unicode = 1B261;
+},
+{
+glyphname = u1B262;
+lastChange = "2020-04-13 09:10:33 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"585 -104 OFFCURVE",
+"608 -87 OFFCURVE",
+"608 -48 CURVE SMOOTH",
+"608 -9 OFFCURVE",
+"585 8 OFFCURVE",
+"557 8 CURVE SMOOTH",
+"528 8 OFFCURVE",
+"505 -9 OFFCURVE",
+"505 -48 CURVE SMOOTH",
+"505 -87 OFFCURVE",
+"528 -104 OFFCURVE",
+"557 -104 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"731 32 OFFCURVE",
+"754 49 OFFCURVE",
+"754 88 CURVE SMOOTH",
+"754 127 OFFCURVE",
+"731 144 OFFCURVE",
+"703 144 CURVE SMOOTH",
+"674 144 OFFCURVE",
+"651 127 OFFCURVE",
+"651 88 CURVE SMOOTH",
+"651 49 OFFCURVE",
+"674 32 OFFCURVE",
+"703 32 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"847 177 OFFCURVE",
+"870 194 OFFCURVE",
+"870 233 CURVE SMOOTH",
+"870 272 OFFCURVE",
+"847 289 OFFCURVE",
+"819 289 CURVE SMOOTH",
+"790 289 OFFCURVE",
+"767 272 OFFCURVE",
+"767 233 CURVE SMOOTH",
+"767 194 OFFCURVE",
+"790 177 OFFCURVE",
+"819 177 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"640 939 LINE",
+"507 710 OFFCURVE",
+"404 577 OFFCURVE",
+"246 416 CURVE",
+"299 363 LINE",
+"444 509 OFFCURVE",
+"568 666 OFFCURVE",
+"706 904 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"738 458 LINE",
+"643 308 OFFCURVE",
+"547 198 OFFCURVE",
+"425 92 CURVE",
+"473 36 LINE",
+"606 153 OFFCURVE",
+"707 271 OFFCURVE",
+"802 421 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"425 573 LINE",
+"501 421 OFFCURVE",
+"530 341 OFFCURVE",
+"574 185 CURVE",
+"638 224 LINE",
+"592 389 OFFCURVE",
+"557 472 OFFCURVE",
+"472 655 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"229 145 OFFCURVE",
+"207 90 OFFCURVE",
+"207 32 CURVE SMOOTH",
+"207 -105 OFFCURVE",
+"294 -203 OFFCURVE",
+"482 -203 CURVE",
+"485 -131 LINE",
+"336 -131 OFFCURVE",
+"281 -68 OFFCURVE",
+"281 37 CURVE SMOOTH",
+"281 98 OFFCURVE",
+"304 141 OFFCURVE",
+"360 169 CURVE",
+"340 257 LINE",
+"206 257 OFFCURVE",
+"144 318 OFFCURVE",
+"144 432 CURVE SMOOTH",
+"144 502 OFFCURVE",
+"169 548 OFFCURVE",
+"229 593 CURVE",
+"186 648 LINE",
+"106 593 OFFCURVE",
+"70 515 OFFCURVE",
+"70 429 CURVE SMOOTH",
+"70 297 OFFCURVE",
+"149 200 OFFCURVE",
+"290 199 CURVE",
+"291 194 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 940;
+}
+);
+leftMetricsKey = u1B1D0;
+unicode = 1B262;
+},
+{
+glyphname = u1B263;
+lastChange = "2020-04-13 09:10:36 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"330 169 OFFCURVE",
+"291 260 OFFCURVE",
+"179 353 CURVE",
+"131 299 LINE",
+"225 227 OFFCURVE",
+"254 159 OFFCURVE",
+"254 70 CURVE SMOOTH",
+"254 -19 OFFCURVE",
+"235 -83 OFFCURVE",
+"172 -161 CURVE",
+"230 -203 LINE",
+"301 -114 OFFCURVE",
+"330 -39 OFFCURVE",
+"330 70 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"130 40 OFFCURVE",
+"153 57 OFFCURVE",
+"153 96 CURVE SMOOTH",
+"153 135 OFFCURVE",
+"130 152 OFFCURVE",
+"102 152 CURVE SMOOTH",
+"73 152 OFFCURVE",
+"50 135 OFFCURVE",
+"50 96 CURVE SMOOTH",
+"50 57 OFFCURVE",
+"73 40 OFFCURVE",
+"102 40 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"492 -68 OFFCURVE",
+"515 -51 OFFCURVE",
+"515 -12 CURVE SMOOTH",
+"515 27 OFFCURVE",
+"492 44 OFFCURVE",
+"464 44 CURVE SMOOTH",
+"435 44 OFFCURVE",
+"412 27 OFFCURVE",
+"412 -12 CURVE SMOOTH",
+"412 -51 OFFCURVE",
+"435 -68 OFFCURVE",
+"464 -68 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"614 700 LINE",
+"533 575 OFFCURVE",
+"471 494 OFFCURVE",
+"372 384 CURVE",
+"422 329 LINE",
+"511 428 OFFCURVE",
+"585 520 OFFCURVE",
+"658 626 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"483 905 LINE",
+"419 802 OFFCURVE",
+"339 690 OFFCURVE",
+"256 595 CURVE",
+"339 422 OFFCURVE",
+"399 287 OFFCURVE",
+"454 145 CURVE",
+"546 135 LINE",
+"617 209 OFFCURVE",
+"695 299 OFFCURVE",
+"786 421 CURVE",
+"725 587 OFFCURVE",
+"657 747 OFFCURVE",
+"579 899 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"526 838 LINE",
+"560 769 OFFCURVE",
+"582 726 OFFCURVE",
+"614 652 CURVE SMOOTH",
+"653 562 OFFCURVE",
+"691 466 OFFCURVE",
+"725 366 CURVE",
+"734 476 LINE",
+"701 430 OFFCURVE",
+"670 390 OFFCURVE",
+"640 353 CURVE SMOOTH",
+"592 294 OFFCURVE",
+"552 250 OFFCURVE",
+"510 198 CURVE",
+"506 198 LINE",
+"482 272 OFFCURVE",
+"456 337 OFFCURVE",
+"424 409 CURVE SMOOTH",
+"391 483 OFFCURVE",
+"355 558 OFFCURVE",
+"318 633 CURVE",
+"324 556 LINE",
+"364 608 OFFCURVE",
+"400 654 OFFCURVE",
+"432 698 CURVE SMOOTH",
+"471 751 OFFCURVE",
+"490 779 OFFCURVE",
+"522 838 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 876;
+}
+);
+leftMetricsKey = u1B1D7;
+rightMetricsKey = u1B1C8;
+unicode = 1B263;
+},
+{
+glyphname = u1B264;
+lastChange = "2020-04-13 09:10:39 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"271 -183 LINE",
+"496 -88 OFFCURVE",
+"645 39 OFFCURVE",
+"788 350 CURVE",
+"720 382 LINE",
+"574 71 OFFCURVE",
+"440 -29 OFFCURVE",
+"242 -120 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"466 -58 LINE",
+"418 45 OFFCURVE",
+"368 132 OFFCURVE",
+"304 234 CURVE",
+"240 195 LINE",
+"303 98 OFFCURVE",
+"358 4 OFFCURVE",
+"406 -91 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"214 284 LINE",
+"466 437 OFFCURVE",
+"612 570 OFFCURVE",
+"734 891 CURVE",
+"665 916 LINE",
+"556 633 OFFCURVE",
+"422 484 OFFCURVE",
+"177 346 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"423 446 LINE",
+"352 575 OFFCURVE",
+"294 664 OFFCURVE",
+"229 756 CURVE",
+"170 712 LINE",
+"238 620 OFFCURVE",
+"291 535 OFFCURVE",
+"361 410 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"445 727 OFFCURVE",
+"468 744 OFFCURVE",
+"468 783 CURVE SMOOTH",
+"468 822 OFFCURVE",
+"445 839 OFFCURVE",
+"417 839 CURVE SMOOTH",
+"388 839 OFFCURVE",
+"365 822 OFFCURVE",
+"365 783 CURVE SMOOTH",
+"365 744 OFFCURVE",
+"388 727 OFFCURVE",
+"417 727 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 448 OFFCURVE",
+"163 465 OFFCURVE",
+"163 504 CURVE SMOOTH",
+"163 543 OFFCURVE",
+"140 560 OFFCURVE",
+"112 560 CURVE SMOOTH",
+"83 560 OFFCURVE",
+"60 543 OFFCURVE",
+"60 504 CURVE SMOOTH",
+"60 465 OFFCURVE",
+"83 448 OFFCURVE",
+"112 448 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"503 193 OFFCURVE",
+"526 210 OFFCURVE",
+"526 249 CURVE SMOOTH",
+"526 288 OFFCURVE",
+"503 305 OFFCURVE",
+"475 305 CURVE SMOOTH",
+"446 305 OFFCURVE",
+"423 288 OFFCURVE",
+"423 249 CURVE SMOOTH",
+"423 210 OFFCURVE",
+"446 193 OFFCURVE",
+"475 193 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"199 -36 OFFCURVE",
+"222 -19 OFFCURVE",
+"222 20 CURVE SMOOTH",
+"222 59 OFFCURVE",
+"199 76 OFFCURVE",
+"171 76 CURVE SMOOTH",
+"142 76 OFFCURVE",
+"119 59 OFFCURVE",
+"119 20 CURVE SMOOTH",
+"119 -19 OFFCURVE",
+"142 -36 OFFCURVE",
+"171 -36 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 868;
+}
+);
+leftMetricsKey = u1B256;
+rightMetricsKey = u1B256;
+unicode = 1B264;
+},
+{
+glyphname = u1B265;
+lastChange = "2020-04-13 09:14:19 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"366 930 LINE",
+"283 838 OFFCURVE",
+"191 746 OFFCURVE",
+"70 644 CURVE",
+"111 522 OFFCURVE",
+"135 436 OFFCURVE",
+"155 339 CURVE",
+"229 317 LINE",
+"324 389 OFFCURVE",
+"425 485 OFFCURVE",
+"544 620 CURVE",
+"520 728 OFFCURVE",
+"490 821 OFFCURVE",
+"450 917 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"673 586 LINE",
+"571 481 OFFCURVE",
+"476 388 OFFCURVE",
+"380 302 CURVE",
+"353 286 LINE",
+"271 212 OFFCURVE",
+"188 143 OFFCURVE",
+"100 75 CURVE",
+"144 15 LINE",
+"216 72 OFFCURVE",
+"285 129 OFFCURVE",
+"353 188 CURVE",
+"383 206 LINE",
+"495 305 OFFCURVE",
+"606 412 OFFCURVE",
+"724 533 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"577 -203 LINE",
+"600 -98 OFFCURVE",
+"614 16 OFFCURVE",
+"627 193 CURVE",
+"546 226 LINE",
+"533 210 OFFCURVE",
+"520 194 OFFCURVE",
+"507 179 CURVE SMOOTH",
+"461 127 OFFCURVE",
+"426 85 OFFCURVE",
+"382 34 CURVE",
+"378 36 LINE",
+"394 115 OFFCURVE",
+"402 174 OFFCURVE",
+"406 254 CURVE SMOOTH",
+"409 318 OFFCURVE",
+"410 401 OFFCURVE",
+"410 519 CURVE",
+"342 441 LINE",
+"342 304 OFFCURVE",
+"329 142 OFFCURVE",
+"308 -4 CURVE",
+"383 -44 LINE",
+"397 -35 OFFCURVE",
+"410 -26 OFFCURVE",
+"422 -17 CURVE SMOOTH",
+"451 4 OFFCURVE",
+"490 56 OFFCURVE",
+"553 136 CURVE",
+"558 135 LINE",
+"549 46 OFFCURVE",
+"538 -23 OFFCURVE",
+"523 -107 CURVE SMOOTH",
+"518 -135 OFFCURVE",
+"511 -163 OFFCURVE",
+"505 -191 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"399 860 LINE",
+"416 800 OFFCURVE",
+"433 746 OFFCURVE",
+"451 683 CURVE SMOOTH",
+"459 655 OFFCURVE",
+"466 625 OFFCURVE",
+"472 594 CURVE",
+"476 661 LINE",
+"442 619 OFFCURVE",
+"402 576 OFFCURVE",
+"359 533 CURVE SMOOTH",
+"303 477 OFFCURVE",
+"263 439 OFFCURVE",
+"217 390 CURVE",
+"212 391 LINE",
+"202 468 OFFCURVE",
+"183 538 OFFCURVE",
+"167 585 CURVE SMOOTH",
+"159 609 OFFCURVE",
+"151 633 OFFCURVE",
+"143 658 CURVE",
+"146 611 LINE",
+"185 644 OFFCURVE",
+"222 678 OFFCURVE",
+"258 712 CURVE SMOOTH",
+"304 755 OFFCURVE",
+"346 798 OFFCURVE",
+"394 861 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 794;
+}
+);
+unicode = 1B265;
+},
+{
+glyphname = u1B266;
+lastChange = "2020-04-13 09:14:05 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"80 205 OFFCURVE",
+"109 157 OFFCURVE",
+"177 117 CURVE",
+"248 126 LINE",
+"316 205 OFFCURVE",
+"334 270 OFFCURVE",
+"334 331 CURVE SMOOTH",
+"334 391 OFFCURVE",
+"300 432 OFFCURVE",
+"232 470 CURVE",
+"158 460 LINE",
+"100 378 OFFCURVE",
+"80 311 OFFCURVE",
+"80 262 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 416 LINE",
+"244 384 OFFCURVE",
+"259 349 OFFCURVE",
+"259 320 CURVE SMOOTH",
+"259 277 OFFCURVE",
+"249 232 OFFCURVE",
+"209 168 CURVE",
+"204 167 LINE",
+"169 202 OFFCURVE",
+"154 233 OFFCURVE",
+"154 266 CURVE SMOOTH",
+"154 308 OFFCURVE",
+"167 352 OFFCURVE",
+"199 415 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"277 627 LINE",
+"421 545 OFFCURVE",
+"536 466 OFFCURVE",
+"662 365 CURVE",
+"705 421 LINE",
+"647 466 OFFCURVE",
+"593 505 OFFCURVE",
+"513 561 CURVE",
+"494 560 LINE",
+"447 604 OFFCURVE",
+"394 639 OFFCURVE",
+"314 687 CURVE",
+"327 648 LINE",
+"398 705 OFFCURVE",
+"464 772 OFFCURVE",
+"510 826 CURVE",
+"543 856 LINE",
+"554 869 OFFCURVE",
+"565 881 OFFCURVE",
+"576 895 CURVE",
+"520 939 LINE",
+"434 834 OFFCURVE",
+"359 763 OFFCURVE",
+"277 698 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"392 372 LINE",
+"442 418 OFFCURVE",
+"479 458 OFFCURVE",
+"510 495 CURVE",
+"535 521 LINE",
+"594 594 OFFCURVE",
+"615 650 OFFCURVE",
+"615 701 CURVE SMOOTH",
+"615 763 OFFCURVE",
+"593 818 OFFCURVE",
+"532 896 CURVE",
+"479 826 LINE",
+"514 826 LINE",
+"532 781 OFFCURVE",
+"543 739 OFFCURVE",
+"543 703 CURVE SMOOTH",
+"543 662 OFFCURVE",
+"535 612 OFFCURVE",
+"498 560 CURVE",
+"488 560 LINE",
+"447 514 OFFCURVE",
+"403 470 OFFCURVE",
+"349 421 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"326 144 LINE",
+"430 53 OFFCURVE",
+"516 -32 OFFCURVE",
+"645 -162 CURVE",
+"697 -113 LINE",
+"645 -61 OFFCURVE",
+"600 -9 OFFCURVE",
+"519 62 CURVE",
+"504 62 LINE",
+"462 106 OFFCURVE",
+"421 146 OFFCURVE",
+"371 195 CURVE",
+"376 164 LINE",
+"451 227 OFFCURVE",
+"480 255 OFFCURVE",
+"515 302 CURVE",
+"548 331 LINE",
+"559 343 OFFCURVE",
+"571 357 OFFCURVE",
+"582 371 CURVE",
+"526 417 LINE",
+"443 319 OFFCURVE",
+"396 273 OFFCURVE",
+"326 215 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"626 242 OFFCURVE",
+"605 298 OFFCURVE",
+"529 381 CURVE",
+"493 302 LINE",
+"519 302 LINE",
+"542 256 OFFCURVE",
+"554 216 OFFCURVE",
+"554 178 CURVE SMOOTH",
+"554 144 OFFCURVE",
+"548 114 OFFCURVE",
+"508 62 CURVE",
+"500 62 LINE",
+"438 -9 OFFCURVE",
+"356 -81 OFFCURVE",
+"263 -148 CURVE",
+"310 -203 LINE",
+"399 -134 OFFCURVE",
+"465 -74 OFFCURVE",
+"519 -17 CURVE",
+"550 9 LINE",
+"599 67 OFFCURVE",
+"626 122 OFFCURVE",
+"626 178 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 785;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B201;
+unicode = 1B266;
+},
+{
+glyphname = u1B267;
+lastChange = "2020-04-13 09:13:43 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"405 -143 LINE",
+"384 -92 OFFCURVE",
+"361 -46 OFFCURVE",
+"327 6 CURVE SMOOTH",
+"297 51 OFFCURVE",
+"264 96 OFFCURVE",
+"224 146 CURVE",
+"168 99 LINE",
+"255 -7 OFFCURVE",
+"311 -99 OFFCURVE",
+"360 -192 CURVE",
+"440 -203 LINE",
+"574 -66 OFFCURVE",
+"686 89 OFFCURVE",
+"777 259 CURVE",
+"711 294 LINE",
+"658 189 OFFCURVE",
+"599 98 OFFCURVE",
+"533 11 CURVE SMOOTH",
+"489 -46 OFFCURVE",
+"449 -95 OFFCURVE",
+"410 -144 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"553 383 LINE",
+"487 236 OFFCURVE",
+"426 144 OFFCURVE",
+"303 7 CURVE",
+"345 -47 LINE",
+"476 96 OFFCURVE",
+"554 211 OFFCURVE",
+"620 357 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"298 249 LINE",
+"335 207 OFFCURVE",
+"373 161 OFFCURVE",
+"407 115 CURVE",
+"431 97 LINE",
+"467 48 OFFCURVE",
+"499 -1 OFFCURVE",
+"525 -46 CURVE",
+"555 16 LINE",
+"531 60 OFFCURVE",
+"504 103 OFFCURVE",
+"475 145 CURVE",
+"451 165 LINE",
+"420 209 OFFCURVE",
+"387 251 OFFCURVE",
+"351 294 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"369 939 LINE",
+"294 748 OFFCURVE",
+"209 602 OFFCURVE",
+"80 444 CURVE",
+"135 397 LINE",
+"268 562 OFFCURVE",
+"362 721 OFFCURVE",
+"437 915 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 319 LINE",
+"411 453 OFFCURVE",
+"466 549 OFFCURVE",
+"523 674 CURVE",
+"483 722 LINE",
+"416 587 OFFCURVE",
+"357 488 OFFCURVE",
+"252 362 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"512 388 LINE",
+"485 443 OFFCURVE",
+"461 489 OFFCURVE",
+"434 533 CURVE",
+"416 555 LINE",
+"387 603 OFFCURVE",
+"354 650 OFFCURVE",
+"314 703 CURVE",
+"275 658 LINE",
+"310 612 OFFCURVE",
+"345 557 OFFCURVE",
+"376 499 CURVE",
+"394 474 LINE",
+"415 435 OFFCURVE",
+"433 396 OFFCURVE",
+"450 358 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"384 819 LINE",
+"466 723 OFFCURVE",
+"540 609 OFFCURVE",
+"606 484 CURVE",
+"670 516 LINE",
+"596 656 OFFCURVE",
+"521 761 OFFCURVE",
+"409 885 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 867;
+}
+);
+leftMetricsKey = u1B185;
+rightMetricsKey = u1B185;
+unicode = 1B267;
+},
+{
+glyphname = u1B268;
+lastChange = "2020-04-13 09:13:20 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"567 715 LINE",
+"521 685 OFFCURVE",
+"473 655 OFFCURVE",
+"422 626 CURVE",
+"390 611 LINE",
+"333 580 OFFCURVE",
+"273 549 OFFCURVE",
+"207 519 CURVE",
+"226 452 LINE",
+"293 484 OFFCURVE",
+"354 514 OFFCURVE",
+"412 545 CURVE",
+"444 559 LINE",
+"502 593 OFFCURVE",
+"560 628 OFFCURVE",
+"621 669 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"569 -33 LINE",
+"551 119 OFFCURVE",
+"535 244 OFFCURVE",
+"505 385 CURVE",
+"487 436 LINE",
+"457 572 OFFCURVE",
+"424 685 OFFCURVE",
+"379 811 CURVE",
+"324 764 LINE",
+"364 645 OFFCURVE",
+"398 528 OFFCURVE",
+"427 395 CURVE",
+"436 346 LINE",
+"462 234 OFFCURVE",
+"480 108 OFFCURVE",
+"493 -41 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"513 932 LINE",
+"378 841 OFFCURVE",
+"260 774 OFFCURVE",
+"121 706 CURVE",
+"166 554 OFFCURVE",
+"195 438 OFFCURVE",
+"227 288 CURVE",
+"306 266 LINE",
+"359 289 OFFCURVE",
+"410 312 OFFCURVE",
+"460 337 CURVE",
+"492 350 LINE",
+"559 384 OFFCURVE",
+"626 421 OFFCURVE",
+"698 466 CURVE",
+"662 634 OFFCURVE",
+"627 766 OFFCURVE",
+"580 910 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"526 853 LINE",
+"542 786 OFFCURVE",
+"558 729 OFFCURVE",
+"572 676 CURVE SMOOTH",
+"590 609 OFFCURVE",
+"605 544 OFFCURVE",
+"619 479 CURVE",
+"659 529 LINE",
+"598 491 OFFCURVE",
+"533 454 OFFCURVE",
+"469 421 CURVE",
+"433 404 LINE",
+"389 382 OFFCURVE",
+"343 360 OFFCURVE",
+"294 335 CURVE",
+"289 336 LINE",
+"278 400 OFFCURVE",
+"264 460 OFFCURVE",
+"252 509 CURVE SMOOTH",
+"235 576 OFFCURVE",
+"216 644 OFFCURVE",
+"194 715 CURVE",
+"168 647 LINE",
+"230 676 OFFCURVE",
+"300 714 OFFCURVE",
+"369 754 CURVE SMOOTH",
+"429 789 OFFCURVE",
+"472 817 OFFCURVE",
+"521 854 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"118 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -103 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 788;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B205;
+unicode = 1B268;
+},
+{
+glyphname = u1B269;
+lastChange = "2020-04-13 09:13:17 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"193 289 LINE",
+"151 167 OFFCURVE",
+"101 72 OFFCURVE",
+"40 -14 CURVE",
+"102 -55 LINE",
+"147 11 OFFCURVE",
+"187 93 OFFCURVE",
+"218 170 CURVE",
+"245 215 LINE",
+"252 232 OFFCURVE",
+"258 248 OFFCURVE",
+"265 267 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"192 170 LINE",
+"222 170 LINE",
+"266 99 OFFCURVE",
+"298 47 OFFCURVE",
+"343 -27 CURVE",
+"406 8 LINE",
+"358 91 OFFCURVE",
+"290 183 OFFCURVE",
+"222 257 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"193 41 LINE",
+"189 -42 OFFCURVE",
+"185 -118 OFFCURVE",
+"172 -195 CURVE",
+"245 -203 LINE",
+"253 -129 OFFCURVE",
+"257 -53 OFFCURVE",
+"261 38 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"758 296 OFFCURVE",
+"781 313 OFFCURVE",
+"781 352 CURVE SMOOTH",
+"781 391 OFFCURVE",
+"758 408 OFFCURVE",
+"730 408 CURVE SMOOTH",
+"701 408 OFFCURVE",
+"678 391 OFFCURVE",
+"678 352 CURVE SMOOTH",
+"678 313 OFFCURVE",
+"701 296 OFFCURVE",
+"730 296 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"434 122 OFFCURVE",
+"457 139 OFFCURVE",
+"457 178 CURVE SMOOTH",
+"457 217 OFFCURVE",
+"434 234 OFFCURVE",
+"406 234 CURVE SMOOTH",
+"377 234 OFFCURVE",
+"354 217 OFFCURVE",
+"354 178 CURVE SMOOTH",
+"354 139 OFFCURVE",
+"377 122 OFFCURVE",
+"406 122 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"654 939 LINE",
+"501 796 OFFCURVE",
+"355 702 OFFCURVE",
+"167 594 CURVE",
+"207 532 LINE",
+"395 639 OFFCURVE",
+"541 734 OFFCURVE",
+"708 889 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"615 754 OFFCURVE",
+"634 711 OFFCURVE",
+"634 667 CURVE SMOOTH",
+"634 581 OFFCURVE",
+"561 506 OFFCURVE",
+"268 355 CURVE",
+"304 288 LINE",
+"616 455 OFFCURVE",
+"710 546 OFFCURVE",
+"710 667 CURVE SMOOTH",
+"710 738 OFFCURVE",
+"684 795 OFFCURVE",
+"601 884 CURVE",
+"562 813 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"637 -33 LINE",
+"628 121 OFFCURVE",
+"599 283 OFFCURVE",
+"556 459 CURVE",
+"496 417 LINE",
+"530 253 OFFCURVE",
+"552 114 OFFCURVE",
+"561 -38 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 901;
+}
+);
+leftMetricsKey = u1B1FF;
+rightMetricsKey = u1B1B3;
+unicode = 1B269;
+},
+{
+glyphname = u1B26A;
+lastChange = "2020-04-13 09:13:13 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"189 270 LINE",
+"185 373 OFFCURVE",
+"173 446 OFFCURVE",
+"154 530 CURVE",
+"90 516 LINE",
+"107 432 OFFCURVE",
+"118 354 OFFCURVE",
+"121 267 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"449 133 OFFCURVE",
+"472 150 OFFCURVE",
+"472 189 CURVE SMOOTH",
+"472 228 OFFCURVE",
+"449 245 OFFCURVE",
+"421 245 CURVE SMOOTH",
+"392 245 OFFCURVE",
+"369 228 OFFCURVE",
+"369 189 CURVE SMOOTH",
+"369 150 OFFCURVE",
+"392 133 OFFCURVE",
+"421 133 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"587 -28 OFFCURVE",
+"610 -11 OFFCURVE",
+"610 28 CURVE SMOOTH",
+"610 67 OFFCURVE",
+"587 84 OFFCURVE",
+"559 84 CURVE SMOOTH",
+"530 84 OFFCURVE",
+"507 67 OFFCURVE",
+"507 28 CURVE SMOOTH",
+"507 -11 OFFCURVE",
+"530 -28 OFFCURVE",
+"559 -28 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"448 -203 OFFCURVE",
+"471 -186 OFFCURVE",
+"471 -147 CURVE SMOOTH",
+"471 -108 OFFCURVE",
+"448 -91 OFFCURVE",
+"420 -91 CURVE SMOOTH",
+"391 -91 OFFCURVE",
+"368 -108 OFFCURVE",
+"368 -147 CURVE SMOOTH",
+"368 -186 OFFCURVE",
+"391 -203 OFFCURVE",
+"420 -203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"311 -31 OFFCURVE",
+"334 -14 OFFCURVE",
+"334 25 CURVE SMOOTH",
+"334 64 OFFCURVE",
+"311 81 OFFCURVE",
+"283 81 CURVE SMOOTH",
+"254 81 OFFCURVE",
+"231 64 OFFCURVE",
+"231 25 CURVE SMOOTH",
+"231 -14 OFFCURVE",
+"254 -31 OFFCURVE",
+"283 -31 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"173 564 LINE",
+"382 412 OFFCURVE",
+"482 318 OFFCURVE",
+"617 187 CURVE",
+"669 242 LINE",
+"592 316 OFFCURVE",
+"520 381 OFFCURVE",
+"406 483 CURVE",
+"391 483 LINE",
+"341 534 OFFCURVE",
+"283 576 OFFCURVE",
+"213 628 CURVE",
+"216 579 LINE",
+"289 663 OFFCURVE",
+"344 735 OFFCURVE",
+"384 810 CURVE",
+"411 844 LINE",
+"422 863 OFFCURVE",
+"434 883 OFFCURVE",
+"446 905 CURVE",
+"379 939 LINE",
+"305 808 OFFCURVE",
+"251 732 OFFCURVE",
+"173 640 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"516 729 OFFCURVE",
+"490 798 OFFCURVE",
+"400 880 CURVE",
+"355 810 LINE",
+"388 810 LINE",
+"422 749 OFFCURVE",
+"440 706 OFFCURVE",
+"440 650 CURVE SMOOTH",
+"440 603 OFFCURVE",
+"420 545 OFFCURVE",
+"395 483 CURVE",
+"385 483 LINE",
+"324 363 OFFCURVE",
+"244 263 OFFCURVE",
+"113 128 CURVE",
+"164 75 LINE",
+"282 197 OFFCURVE",
+"363 304 OFFCURVE",
+"420 396 CURVE",
+"447 434 LINE",
+"494 519 OFFCURVE",
+"516 591 OFFCURVE",
+"516 650 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 749;
+}
+);
+leftMetricsKey = u1B19F;
+rightMetricsKey = u1B22F;
+unicode = 1B26A;
+},
+{
+glyphname = u1B26B;
+lastChange = "2020-04-13 09:13:05 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"208 864 LINE",
+"170 709 OFFCURVE",
+"134 614 OFFCURVE",
+"73 492 CURVE",
+"137 461 LINE",
+"198 580 OFFCURVE",
+"237 681 OFFCURVE",
+"278 850 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"30 727 LINE",
+"76 697 OFFCURVE",
+"118 666 OFFCURVE",
+"155 637 CURVE",
+"185 620 LINE",
+"234 580 OFFCURVE",
+"275 543 OFFCURVE",
+"306 510 CURVE",
+"345 565 LINE",
+"307 605 OFFCURVE",
+"263 645 OFFCURVE",
+"213 686 CURVE",
+"185 702 LINE",
+"151 728 OFFCURVE",
+"113 755 OFFCURVE",
+"72 783 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"190 85 OFFCURVE",
+"213 102 OFFCURVE",
+"213 141 CURVE SMOOTH",
+"213 180 OFFCURVE",
+"190 197 OFFCURVE",
+"162 197 CURVE SMOOTH",
+"133 197 OFFCURVE",
+"110 180 OFFCURVE",
+"110 141 CURVE SMOOTH",
+"110 102 OFFCURVE",
+"133 85 OFFCURVE",
+"162 85 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"353 -63 OFFCURVE",
+"376 -46 OFFCURVE",
+"376 -7 CURVE SMOOTH",
+"376 32 OFFCURVE",
+"353 49 OFFCURVE",
+"325 49 CURVE SMOOTH",
+"296 49 OFFCURVE",
+"273 32 OFFCURVE",
+"273 -7 CURVE SMOOTH",
+"273 -46 OFFCURVE",
+"296 -63 OFFCURVE",
+"325 -63 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"527 -203 OFFCURVE",
+"550 -186 OFFCURVE",
+"550 -147 CURVE SMOOTH",
+"550 -108 OFFCURVE",
+"527 -91 OFFCURVE",
+"499 -91 CURVE SMOOTH",
+"470 -91 OFFCURVE",
+"447 -108 OFFCURVE",
+"447 -147 CURVE SMOOTH",
+"447 -186 OFFCURVE",
+"470 -203 OFFCURVE",
+"499 -203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"407 920 LINE",
+"331 686 OFFCURVE",
+"268 522 OFFCURVE",
+"189 370 CURVE",
+"204 298 LINE",
+"309 227 OFFCURVE",
+"437 124 OFFCURVE",
+"555 10 CURVE",
+"631 44 LINE",
+"606 366 OFFCURVE",
+"562 628 OFFCURVE",
+"495 924 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"449 848 LINE",
+"461 745 OFFCURVE",
+"478 652 OFFCURVE",
+"493 560 CURVE SMOOTH",
+"506 482 OFFCURVE",
+"518 406 OFFCURVE",
+"528 327 CURVE SMOOTH",
+"537 259 OFFCURVE",
+"545 167 OFFCURVE",
+"562 90 CURVE",
+"557 89 LINE",
+"504 150 OFFCURVE",
+"459 198 OFFCURVE",
+"406 241 CURVE SMOOTH",
+"360 279 OFFCURVE",
+"312 315 OFFCURVE",
+"251 359 CURVE",
+"250 319 LINE",
+"288 396 OFFCURVE",
+"319 464 OFFCURVE",
+"348 538 CURVE SMOOTH",
+"382 624 OFFCURVE",
+"416 725 OFFCURVE",
+"445 848 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 761;
+}
+);
+rightMetricsKey = u1B20F;
+unicode = 1B26B;
+},
+{
+glyphname = u1B26C;
+lastChange = "2020-04-13 09:12:41 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"813 363 LINE",
+"853 472 OFFCURVE",
+"884 589 OFFCURVE",
+"913 719 CURVE",
+"839 737 LINE",
+"832 704 OFFCURVE",
+"824 673 OFFCURVE",
+"817 643 CURVE SMOOTH",
+"797 557 OFFCURVE",
+"770 481 OFFCURVE",
+"752 402 CURVE",
+"747 401 LINE",
+"676 441 OFFCURVE",
+"632 462 OFFCURVE",
+"555 496 CURVE",
+"519 508 LINE",
+"450 538 OFFCURVE",
+"383 565 OFFCURVE",
+"321 590 CURVE",
+"327 563 LINE",
+"361 678 OFFCURVE",
+"387 772 OFFCURVE",
+"417 925 CURVE",
+"342 939 LINE",
+"317 807 OFFCURVE",
+"288 691 OFFCURVE",
+"241 542 CURVE",
+"328 508 OFFCURVE",
+"413 473 OFFCURVE",
+"496 437 CURVE",
+"531 425 LINE",
+"604 392 OFFCURVE",
+"676 359 OFFCURVE",
+"734 331 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"382 -114 LINE",
+"503 231 OFFCURVE",
+"578 484 OFFCURVE",
+"665 815 CURVE",
+"593 833 LINE",
+"512 517 OFFCURVE",
+"430 249 OFFCURVE",
+"313 -85 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"297 194 OFFCURVE",
+"335 178 OFFCURVE",
+"406 145 CURVE",
+"440 132 LINE",
+"505 102 OFFCURVE",
+"573 68 OFFCURVE",
+"649 30 CURVE",
+"640 72 LINE",
+"612 -41 OFFCURVE",
+"595 -86 OFFCURVE",
+"558 -178 CURVE",
+"627 -203 LINE",
+"662 -122 OFFCURVE",
+"681 -66 OFFCURVE",
+"715 79 CURVE",
+"626 125 OFFCURVE",
+"546 164 OFFCURVE",
+"473 198 CURVE",
+"433 213 LINE",
+"363 245 OFFCURVE",
+"300 270 OFFCURVE",
+"247 294 CURVE",
+"164 265 LINE",
+"138 154 OFFCURVE",
+"111 74 OFFCURVE",
+"80 -4 CURVE",
+"149 -30 LINE",
+"162 6 OFFCURVE",
+"174 41 OFFCURVE",
+"185 77 CURVE SMOOTH",
+"200 126 OFFCURVE",
+"212 167 OFFCURVE",
+"226 221 CURVE",
+"231 222 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"736 232 LINE",
+"661 270 OFFCURVE",
+"586 307 OFFCURVE",
+"510 342 CURVE",
+"470 357 LINE",
+"399 388 OFFCURVE",
+"327 419 OFFCURVE",
+"251 448 CURVE",
+"228 381 LINE",
+"305 352 OFFCURVE",
+"378 321 OFFCURVE",
+"451 288 CURVE",
+"489 274 LINE",
+"560 242 OFFCURVE",
+"631 206 OFFCURVE",
+"704 169 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 1003;
+}
+);
+leftMetricsKey = u1B21A;
+rightMetricsKey = u1B21A;
+unicode = 1B26C;
+},
+{
+glyphname = u1B26D;
+lastChange = "2020-04-13 09:12:34 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"519 73 OFFCURVE",
+"522 157 OFFCURVE",
+"520 284 CURVE",
+"450 284 LINE",
+"450 164 OFFCURVE",
+"449 77 OFFCURVE",
+"439 -37 CURVE",
+"512 -42 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"270 383 OFFCURVE",
+"293 400 OFFCURVE",
+"293 439 CURVE SMOOTH",
+"293 478 OFFCURVE",
+"270 495 OFFCURVE",
+"242 495 CURVE SMOOTH",
+"213 495 OFFCURVE",
+"190 478 OFFCURVE",
+"190 439 CURVE SMOOTH",
+"190 400 OFFCURVE",
+"213 383 OFFCURVE",
+"242 383 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"728 475 OFFCURVE",
+"751 492 OFFCURVE",
+"751 531 CURVE SMOOTH",
+"751 570 OFFCURVE",
+"728 587 OFFCURVE",
+"700 587 CURVE SMOOTH",
+"671 587 OFFCURVE",
+"648 570 OFFCURVE",
+"648 531 CURVE SMOOTH",
+"648 492 OFFCURVE",
+"671 475 OFFCURVE",
+"700 475 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"266 610 LINE",
+"379 514 OFFCURVE",
+"513 383 OFFCURVE",
+"629 254 CURVE",
+"683 304 LINE",
+"630 364 OFFCURVE",
+"575 420 OFFCURVE",
+"484 508 CURVE",
+"465 508 LINE",
+"430 561 OFFCURVE",
+"386 602 OFFCURVE",
+"308 670 CURVE",
+"311 620 LINE",
+"379 694 OFFCURVE",
+"430 755 OFFCURVE",
+"465 816 CURVE",
+"490 843 LINE",
+"503 862 OFFCURVE",
+"516 882 OFFCURVE",
+"529 903 CURVE",
+"465 939 LINE",
+"396 834 OFFCURVE",
+"332 751 OFFCURVE",
+"266 681 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"584 751 OFFCURVE",
+"552 809 OFFCURVE",
+"491 884 CURVE",
+"436 816 LINE",
+"469 816 LINE",
+"499 759 OFFCURVE",
+"512 710 OFFCURVE",
+"512 656 CURVE SMOOTH",
+"512 613 OFFCURVE",
+"498 567 OFFCURVE",
+"469 508 CURVE",
+"460 508 LINE",
+"407 418 OFFCURVE",
+"339 333 OFFCURVE",
+"255 235 CURVE",
+"310 189 LINE",
+"389 282 OFFCURVE",
+"447 361 OFFCURVE",
+"489 423 CURVE",
+"512 453 LINE",
+"564 537 OFFCURVE",
+"584 598 OFFCURVE",
+"584 655 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"118 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -103 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 831;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B177;
+unicode = 1B26D;
+},
+{
+glyphname = u1B26E;
+lastChange = "2020-04-13 09:12:28 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"562 117 LINE",
+"553 91 OFFCURVE",
+"545 67 OFFCURVE",
+"536 43 CURVE SMOOTH",
+"509 -30 OFFCURVE",
+"484 -78 OFFCURVE",
+"447 -141 CURVE",
+"442 -142 LINE",
+"405 -95 OFFCURVE",
+"373 -57 OFFCURVE",
+"323 -4 CURVE SMOOTH",
+"279 43 OFFCURVE",
+"229 92 OFFCURVE",
+"168 148 CURVE",
+"120 92 LINE",
+"256 -30 OFFCURVE",
+"338 -117 OFFCURVE",
+"408 -203 CURVE",
+"493 -185 LINE",
+"553 -96 OFFCURVE",
+"592 -12 OFFCURVE",
+"629 95 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"207 -193 OFFCURVE",
+"230 -176 OFFCURVE",
+"230 -137 CURVE SMOOTH",
+"230 -98 OFFCURVE",
+"207 -81 OFFCURVE",
+"179 -81 CURVE SMOOTH",
+"150 -81 OFFCURVE",
+"127 -98 OFFCURVE",
+"127 -137 CURVE SMOOTH",
+"127 -176 OFFCURVE",
+"150 -193 OFFCURVE",
+"179 -193 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"435 34 OFFCURVE",
+"458 51 OFFCURVE",
+"458 90 CURVE SMOOTH",
+"458 129 OFFCURVE",
+"435 146 OFFCURVE",
+"407 146 CURVE SMOOTH",
+"378 146 OFFCURVE",
+"355 129 OFFCURVE",
+"355 90 CURVE SMOOTH",
+"355 51 OFFCURVE",
+"378 34 OFFCURVE",
+"407 34 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"402 939 LINE",
+"298 802 OFFCURVE",
+"191 683 OFFCURVE",
+"70 568 CURVE",
+"122 513 LINE",
+"251 635 OFFCURVE",
+"352 750 OFFCURVE",
+"464 895 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"302 729 LINE",
+"458 503 OFFCURVE",
+"580 295 OFFCURVE",
+"690 77 CURVE",
+"758 110 LINE",
+"649 323 OFFCURVE",
+"523 528 OFFCURVE",
+"358 782 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"507 772 LINE",
+"478 735 OFFCURVE",
+"448 698 OFFCURVE",
+"418 662 CURVE",
+"389 634 LINE",
+"306 537 OFFCURVE",
+"220 445 OFFCURVE",
+"148 375 CURVE",
+"199 325 LINE",
+"277 402 OFFCURVE",
+"356 486 OFFCURVE",
+"433 575 CURVE",
+"460 600 LINE",
+"496 642 OFFCURVE",
+"531 686 OFFCURVE",
+"565 730 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"607 604 LINE",
+"580 569 OFFCURVE",
+"551 534 OFFCURVE",
+"522 499 CURVE",
+"493 472 LINE",
+"408 372 OFFCURVE",
+"319 279 OFFCURVE",
+"245 207 CURVE",
+"296 156 LINE",
+"374 233 OFFCURVE",
+"454 317 OFFCURVE",
+"532 406 CURVE",
+"560 432 LINE",
+"596 474 OFFCURVE",
+"631 517 OFFCURVE",
+"665 561 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 838;
+}
+);
+leftMetricsKey = u1B1F8;
+rightMetricsKey = u1B1F8;
+unicode = 1B26E;
+},
+{
+glyphname = u1B26F;
+lastChange = "2020-04-13 09:12:10 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"295 328 LINE",
+"211 222 OFFCURVE",
+"146 157 OFFCURVE",
+"40 76 CURVE",
+"83 17 LINE",
+"193 105 OFFCURVE",
+"266 174 OFFCURVE",
+"353 285 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"173 170 LINE",
+"233 57 OFFCURVE",
+"256 -62 OFFCURVE",
+"272 -203 CURVE",
+"345 -194 LINE",
+"325 -47 OFFCURVE",
+"294 91 OFFCURVE",
+"225 225 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"166 -174 OFFCURVE",
+"189 -157 OFFCURVE",
+"189 -118 CURVE SMOOTH",
+"189 -79 OFFCURVE",
+"166 -62 OFFCURVE",
+"138 -62 CURVE SMOOTH",
+"109 -62 OFFCURVE",
+"86 -79 OFFCURVE",
+"86 -118 CURVE SMOOTH",
+"86 -157 OFFCURVE",
+"109 -174 OFFCURVE",
+"138 -174 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"427 46 OFFCURVE",
+"449 62 OFFCURVE",
+"449 99 CURVE SMOOTH",
+"449 136 OFFCURVE",
+"427 152 OFFCURVE",
+"400 152 CURVE SMOOTH",
+"372 152 OFFCURVE",
+"350 136 OFFCURVE",
+"350 99 CURVE SMOOTH",
+"350 62 OFFCURVE",
+"372 46 OFFCURVE",
+"400 46 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"766 666 LINE",
+"717 603 OFFCURVE",
+"668 545 OFFCURVE",
+"616 490 CURVE",
+"591 469 LINE",
+"532 409 OFFCURVE",
+"471 352 OFFCURVE",
+"408 299 CURVE",
+"454 243 LINE",
+"512 292 OFFCURVE",
+"564 339 OFFCURVE",
+"613 388 CURVE",
+"636 406 LINE",
+"698 471 OFFCURVE",
+"757 539 OFFCURVE",
+"823 620 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"688 939 LINE",
+"575 771 OFFCURVE",
+"460 645 OFFCURVE",
+"329 525 CURVE",
+"381 468 LINE",
+"504 584 OFFCURVE",
+"634 722 OFFCURVE",
+"753 898 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"809 377 LINE",
+"702 249 OFFCURVE",
+"603 153 OFFCURVE",
+"481 60 CURVE",
+"526 0 LINE",
+"665 110 OFFCURVE",
+"758 205 OFFCURVE",
+"867 332 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"521 634 LINE",
+"572 472 OFFCURVE",
+"603 318 OFFCURVE",
+"621 157 CURVE",
+"690 187 LINE",
+"671 357 OFFCURVE",
+"635 515 OFFCURVE",
+"580 709 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 947;
+}
+);
+rightMetricsKey = u1B1A7;
+unicode = 1B26F;
+},
+{
+glyphname = u1B270;
+lastChange = "2020-04-13 09:11:55 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"667 314 OFFCURVE",
+"689 268 OFFCURVE",
+"719 203 CURVE SMOOTH",
+"731 177 OFFCURVE",
+"742 149 OFFCURVE",
+"754 117 CURVE",
+"823 144 LINE",
+"781 258 OFFCURVE",
+"740 340 OFFCURVE",
+"684 441 CURVE",
+"602 449 LINE",
+"494 335 OFFCURVE",
+"391 238 OFFCURVE",
+"245 125 CURVE",
+"308 6 OFFCURVE",
+"352 -95 OFFCURVE",
+"389 -203 CURVE",
+"459 -179 LINE",
+"417 -60 OFFCURVE",
+"380 26 OFFCURVE",
+"321 139 CURVE",
+"325 94 LINE",
+"391 143 OFFCURVE",
+"452 195 OFFCURVE",
+"512 251 CURVE SMOOTH",
+"563 299 OFFCURVE",
+"587 328 OFFCURVE",
+"631 383 CURVE",
+"636 382 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"512 142 OFFCURVE",
+"547 59 OFFCURVE",
+"587 -45 CURVE",
+"655 -16 LINE",
+"610 95 OFFCURVE",
+"571 180 OFFCURVE",
+"502 299 CURVE",
+"453 250 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"721 914 LINE",
+"660 801 OFFCURVE",
+"602 707 OFFCURVE",
+"539 622 CURVE SMOOTH",
+"476 537 OFFCURVE",
+"418 473 OFFCURVE",
+"351 400 CURVE",
+"346 401 LINE",
+"328 491 OFFCURVE",
+"302 566 OFFCURVE",
+"266 648 CURVE SMOOTH",
+"259 664 OFFCURVE",
+"251 680 OFFCURVE",
+"243 697 CURVE",
+"174 665 LINE",
+"228 553 OFFCURVE",
+"261 469 OFFCURVE",
+"295 352 CURVE",
+"372 333 LINE",
+"553 509 OFFCURVE",
+"666 658 OFFCURVE",
+"789 879 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"452 656 OFFCURVE",
+"475 673 OFFCURVE",
+"475 712 CURVE SMOOTH",
+"475 751 OFFCURVE",
+"452 768 OFFCURVE",
+"424 768 CURVE SMOOTH",
+"395 768 OFFCURVE",
+"372 751 OFFCURVE",
+"372 712 CURVE SMOOTH",
+"372 673 OFFCURVE",
+"395 656 OFFCURVE",
+"424 656 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 406 OFFCURVE",
+"163 423 OFFCURVE",
+"163 462 CURVE SMOOTH",
+"163 501 OFFCURVE",
+"140 518 OFFCURVE",
+"112 518 CURVE SMOOTH",
+"83 518 OFFCURVE",
+"60 501 OFFCURVE",
+"60 462 CURVE SMOOTH",
+"60 423 OFFCURVE",
+"83 406 OFFCURVE",
+"112 406 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 903;
+}
+);
+leftMetricsKey = u1B193;
+rightMetricsKey = u1B193;
+unicode = 1B270;
+},
+{
+glyphname = u1B271;
+lastChange = "2020-04-13 09:11:53 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"115 427 LINE",
+"227 338 OFFCURVE",
+"335 245 OFFCURVE",
+"451 132 CURVE",
+"499 182 LINE",
+"447 232 OFFCURVE",
+"409 268 OFFCURVE",
+"332 336 CURVE",
+"313 336 LINE",
+"280 379 OFFCURVE",
+"240 416 OFFCURVE",
+"165 477 CURVE",
+"162 445 LINE",
+"227 523 OFFCURVE",
+"268 582 OFFCURVE",
+"304 643 CURVE",
+"332 678 LINE",
+"344 696 OFFCURVE",
+"356 715 OFFCURVE",
+"368 736 CURVE",
+"304 772 LINE",
+"234 650 OFFCURVE",
+"175 572 OFFCURVE",
+"115 498 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 643 LINE",
+"308 643 LINE",
+"336 585 OFFCURVE",
+"351 538 OFFCURVE",
+"351 492 CURVE SMOOTH",
+"351 446 OFFCURVE",
+"342 393 OFFCURVE",
+"317 336 CURVE",
+"308 336 LINE",
+"257 253 OFFCURVE",
+"185 178 OFFCURVE",
+"80 61 CURVE",
+"136 12 LINE",
+"232 119 OFFCURVE",
+"291 192 OFFCURVE",
+"335 254 CURVE",
+"361 283 LINE",
+"407 354 OFFCURVE",
+"423 412 OFFCURVE",
+"423 495 CURVE SMOOTH",
+"423 558 OFFCURVE",
+"402 624 OFFCURVE",
+"338 703 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"302 132 LINE",
+"298 13 OFFCURVE",
+"292 -70 OFFCURVE",
+"273 -192 CURVE",
+"347 -203 LINE",
+"365 -80 OFFCURVE",
+"368 -3 OFFCURVE",
+"372 129 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"443 610 LINE",
+"555 515 OFFCURVE",
+"668 411 OFFCURVE",
+"771 299 CURVE",
+"823 349 LINE",
+"776 397 OFFCURVE",
+"737 435 OFFCURVE",
+"652 515 CURVE",
+"637 515 LINE",
+"601 562 OFFCURVE",
+"560 600 OFFCURVE",
+"494 658 CURVE",
+"491 626 LINE",
+"535 674 OFFCURVE",
+"592 745 OFFCURVE",
+"632 812 CURVE",
+"661 849 LINE",
+"671 866 OFFCURVE",
+"682 884 OFFCURVE",
+"693 903 CURVE",
+"631 939 LINE",
+"561 826 OFFCURVE",
+"510 755 OFFCURVE",
+"443 681 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"606 812 LINE",
+"636 812 LINE",
+"661 762 OFFCURVE",
+"678 714 OFFCURVE",
+"678 670 CURVE SMOOTH",
+"678 620 OFFCURVE",
+"662 568 OFFCURVE",
+"641 515 CURVE",
+"631 515 LINE",
+"588 439 OFFCURVE",
+"523 366 OFFCURVE",
+"451 286 CURVE",
+"504 237 LINE",
+"577 316 OFFCURVE",
+"624 379 OFFCURVE",
+"662 435 CURVE",
+"686 462 LINE",
+"732 537 OFFCURVE",
+"750 599 OFFCURVE",
+"750 670 CURVE SMOOTH",
+"750 746 OFFCURVE",
+"722 810 OFFCURVE",
+"658 883 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"625 299 LINE",
+"625 179 OFFCURVE",
+"620 101 OFFCURVE",
+"607 -31 CURVE",
+"681 -36 LINE",
+"691 92 OFFCURVE",
+"694 166 OFFCURVE",
+"695 299 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 903;
+}
+);
+leftMetricsKey = u1B201;
+rightMetricsKey = u1B201;
+unicode = 1B271;
+},
+{
+glyphname = u1B272;
+lastChange = "2020-04-13 09:11:39 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"543 909 LINE",
+"386 792 OFFCURVE",
+"235 695 OFFCURVE",
+"70 603 CURVE",
+"104 453 OFFCURVE",
+"124 341 OFFCURVE",
+"141 219 CURVE",
+"237 206 LINE",
+"278 270 OFFCURVE",
+"307 329 OFFCURVE",
+"322 366 CURVE SMOOTH",
+"340 410 OFFCURVE",
+"357 458 OFFCURVE",
+"370 529 CURVE",
+"375 530 LINE",
+"418 489 OFFCURVE",
+"444 460 OFFCURVE",
+"469 436 CURVE SMOOTH",
+"489 417 OFFCURVE",
+"507 400 OFFCURVE",
+"526 378 CURVE",
+"618 408 LINE",
+"640 567 OFFCURVE",
+"639 673 OFFCURVE",
+"631 871 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"561 830 LINE",
+"561 768 OFFCURVE",
+"560 708 OFFCURVE",
+"560 656 CURVE SMOOTH",
+"560 641 OFFCURVE",
+"559 626 OFFCURVE",
+"559 612 CURVE SMOOTH",
+"559 566 OFFCURVE",
+"557 503 OFFCURVE",
+"554 450 CURVE",
+"549 449 LINE",
+"508 495 OFFCURVE",
+"476 529 OFFCURVE",
+"447 557 CURVE SMOOTH",
+"428 574 OFFCURVE",
+"413 585 OFFCURVE",
+"395 599 CURVE",
+"320 569 LINE",
+"307 528 OFFCURVE",
+"294 489 OFFCURVE",
+"279 451 CURVE SMOOTH",
+"251 382 OFFCURVE",
+"230 329 OFFCURVE",
+"201 267 CURVE",
+"196 268 LINE",
+"194 359 OFFCURVE",
+"181 422 OFFCURVE",
+"172 475 CURVE SMOOTH",
+"166 512 OFFCURVE",
+"157 554 OFFCURVE",
+"147 603 CURVE",
+"126 550 LINE",
+"219 601 OFFCURVE",
+"314 660 OFFCURVE",
+"403 719 CURVE SMOOTH",
+"463 759 OFFCURVE",
+"503 788 OFFCURVE",
+"556 831 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"522 -85 LINE",
+"500 38 OFFCURVE",
+"467 176 OFFCURVE",
+"430 313 CURVE",
+"357 293 LINE",
+"393 160 OFFCURVE",
+"425 26 OFFCURVE",
+"447 -92 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"627 245 LINE",
+"574 218 OFFCURVE",
+"509 190 OFFCURVE",
+"441 163 CURVE",
+"409 154 LINE",
+"341 128 OFFCURVE",
+"271 103 OFFCURVE",
+"208 84 CURVE",
+"228 12 LINE",
+"291 31 OFFCURVE",
+"361 55 OFFCURVE",
+"431 82 CURVE",
+"459 89 LINE",
+"530 118 OFFCURVE",
+"601 149 OFFCURVE",
+"663 181 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"707 57 LINE",
+"578 -8 OFFCURVE",
+"361 -85 OFFCURVE",
+"209 -130 CURVE",
+"230 -203 LINE",
+"395 -154 OFFCURVE",
+"609 -78 OFFCURVE",
+"742 -10 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 802;
+}
+);
+unicode = 1B272;
+},
+{
+glyphname = u1B273;
+lastChange = "2020-04-13 09:11:28 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"512 939 LINE",
+"474 752 OFFCURVE",
+"423 630 OFFCURVE",
+"342 501 CURVE",
+"405 465 LINE",
+"492 609 OFFCURVE",
+"537 714 OFFCURVE",
+"585 927 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"505 835 LINE",
+"614 699 OFFCURVE",
+"663 619 OFFCURVE",
+"723 502 CURVE",
+"789 536 LINE",
+"718 669 OFFCURVE",
+"650 774 OFFCURVE",
+"547 893 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"533 520 LINE",
+"488 336 OFFCURVE",
+"453 240 OFFCURVE",
+"374 97 CURVE",
+"437 63 LINE",
+"522 213 OFFCURVE",
+"560 319 OFFCURVE",
+"604 505 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"537 408 LINE",
+"620 283 OFFCURVE",
+"666 190 OFFCURVE",
+"714 73 CURVE",
+"784 99 LINE",
+"731 233 OFFCURVE",
+"672 339 OFFCURVE",
+"578 469 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 324 OFFCURVE",
+"105 285 OFFCURVE",
+"173 245 CURVE",
+"244 254 LINE",
+"301 328 OFFCURVE",
+"325 398 OFFCURVE",
+"325 461 CURVE SMOOTH",
+"325 519 OFFCURVE",
+"296 560 OFFCURVE",
+"228 598 CURVE",
+"154 588 LINE",
+"103 513 OFFCURVE",
+"80 442 OFFCURVE",
+"80 380 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"202 541 LINE",
+"237 513 OFFCURVE",
+"255 479 OFFCURVE",
+"255 448 CURVE SMOOTH",
+"255 412 OFFCURVE",
+"241 364 OFFCURVE",
+"205 301 CURVE",
+"200 300 LINE",
+"161 331 OFFCURVE",
+"150 360 OFFCURVE",
+"150 394 CURVE SMOOTH",
+"150 438 OFFCURVE",
+"166 484 OFFCURVE",
+"197 540 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 80 LINE",
+"263 80 LINE",
+"304 -10 OFFCURVE",
+"331 -60 OFFCURVE",
+"367 -161 CURVE",
+"438 -134 LINE",
+"392 -16 OFFCURVE",
+"347 64 OFFCURVE",
+"273 165 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"209 227 LINE",
+"192 61 OFFCURVE",
+"168 -50 OFFCURVE",
+"119 -179 CURVE",
+"194 -203 LINE",
+"229 -102 OFFCURVE",
+"247 -13 OFFCURVE",
+"259 80 CURVE",
+"276 126 LINE",
+"280 156 OFFCURVE",
+"284 186 OFFCURVE",
+"287 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 879;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B199;
+unicode = 1B273;
+},
+{
+glyphname = u1B274;
+lastChange = "2020-04-13 09:11:26 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"512 -102 LINE",
+"613 19 OFFCURVE",
+"686 135 OFFCURVE",
+"770 300 CURVE",
+"701 334 LINE",
+"673 273 OFFCURVE",
+"646 221 OFFCURVE",
+"619 174 CURVE SMOOTH",
+"574 96 OFFCURVE",
+"527 32 OFFCURVE",
+"487 -30 CURVE",
+"482 -29 LINE",
+"462 56 OFFCURVE",
+"431 141 OFFCURVE",
+"401 219 CURVE SMOOTH",
+"358 330 OFFCURVE",
+"289 481 OFFCURVE",
+"200 655 CURVE",
+"200 574 LINE",
+"235 611 OFFCURVE",
+"269 652 OFFCURVE",
+"304 695 CURVE SMOOTH",
+"331 729 OFFCURVE",
+"374 785 OFFCURVE",
+"408 843 CURVE",
+"412 843 LINE",
+"437 789 OFFCURVE",
+"473 725 OFFCURVE",
+"494 682 CURVE SMOOTH",
+"523 623 OFFCURVE",
+"550 561 OFFCURVE",
+"580 488 CURVE",
+"582 594 LINE",
+"497 471 OFFCURVE",
+"437 404 OFFCURVE",
+"342 306 CURVE",
+"385 243 LINE",
+"481 340 OFFCURVE",
+"547 417 OFFCURVE",
+"638 545 CURVE",
+"577 683 OFFCURVE",
+"519 801 OFFCURVE",
+"459 907 CURVE",
+"372 914 LINE",
+"298 803 OFFCURVE",
+"225 710 OFFCURVE",
+"136 612 CURVE",
+"263 364 OFFCURVE",
+"363 129 OFFCURVE",
+"429 -92 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 754 LINE",
+"410 646 OFFCURVE",
+"337 561 OFFCURVE",
+"260 478 CURVE",
+"295 410 LINE",
+"387 506 OFFCURVE",
+"450 584 OFFCURVE",
+"523 691 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"551 217 OFFCURVE",
+"576 165 OFFCURVE",
+"598 115 CURVE",
+"619 81 LINE",
+"642 25 OFFCURVE",
+"661 -30 OFFCURVE",
+"680 -95 CURVE",
+"752 -75 LINE",
+"726 11 OFFCURVE",
+"701 80 OFFCURVE",
+"669 149 CURVE",
+"648 182 LINE",
+"628 223 OFFCURVE",
+"606 265 OFFCURVE",
+"579 312 CURVE",
+"519 276 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"303 -189 LINE",
+"268 -18 OFFCURVE",
+"234 101 OFFCURVE",
+"156 269 CURVE",
+"90 237 LINE",
+"164 80 OFFCURVE",
+"198 -43 OFFCURVE",
+"230 -203 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 850;
+}
+);
+leftMetricsKey = u1B1F2;
+rightMetricsKey = u1B1C2;
+unicode = 1B274;
+},
+{
+glyphname = u1B275;
+lastChange = "2020-04-13 09:11:16 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"358 57 LINE",
+"384 57 LINE",
+"427 -22 OFFCURVE",
+"451 -72 OFFCURVE",
+"488 -169 CURVE",
+"555 -143 LINE",
+"515 -41 OFFCURVE",
+"477 30 OFFCURVE",
+"395 135 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"327 173 LINE",
+"315 24 OFFCURVE",
+"294 -56 OFFCURVE",
+"247 -182 CURVE",
+"319 -203 LINE",
+"354 -103 OFFCURVE",
+"364 -45 OFFCURVE",
+"379 57 CURVE",
+"397 99 LINE",
+"400 120 OFFCURVE",
+"402 142 OFFCURVE",
+"405 166 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"761 557 LINE",
+"734 487 OFFCURVE",
+"704 423 OFFCURVE",
+"671 362 CURVE SMOOTH",
+"628 282 OFFCURVE",
+"599 239 OFFCURVE",
+"555 171 CURVE",
+"550 172 LINE",
+"535 262 OFFCURVE",
+"518 345 OFFCURVE",
+"500 413 CURVE SMOOTH",
+"463 557 OFFCURVE",
+"415 696 OFFCURVE",
+"351 845 CURVE",
+"282 816 LINE",
+"384 583 OFFCURVE",
+"442 394 OFFCURVE",
+"490 118 CURVE",
+"587 97 LINE",
+"674 211 OFFCURVE",
+"769 381 OFFCURVE",
+"831 531 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"559 505 LINE",
+"596 437 OFFCURVE",
+"628 374 OFFCURVE",
+"656 312 CURVE",
+"681 268 LINE",
+"707 209 OFFCURVE",
+"728 150 OFFCURVE",
+"749 89 CURVE",
+"817 113 LINE",
+"789 197 OFFCURVE",
+"760 270 OFFCURVE",
+"727 342 CURVE",
+"701 384 LINE",
+"677 434 OFFCURVE",
+"651 484 OFFCURVE",
+"620 538 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"591 939 LINE",
+"511 760 OFFCURVE",
+"430 623 OFFCURVE",
+"296 432 CURVE",
+"355 388 LINE",
+"487 577 OFFCURVE",
+"568 717 OFFCURVE",
+"661 909 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 174 OFFCURVE",
+"105 135 OFFCURVE",
+"173 95 CURVE",
+"244 104 LINE",
+"301 178 OFFCURVE",
+"325 248 OFFCURVE",
+"325 311 CURVE SMOOTH",
+"325 369 OFFCURVE",
+"296 410 OFFCURVE",
+"228 448 CURVE",
+"154 438 LINE",
+"103 363 OFFCURVE",
+"80 292 OFFCURVE",
+"80 230 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"202 390 LINE",
+"242 356 OFFCURVE",
+"255 329 OFFCURVE",
+"255 298 CURVE SMOOTH",
+"255 262 OFFCURVE",
+"241 215 OFFCURVE",
+"205 152 CURVE",
+"200 151 LINE",
+"162 182 OFFCURVE",
+"150 210 OFFCURVE",
+"150 244 CURVE SMOOTH",
+"150 288 OFFCURVE",
+"162 329 OFFCURVE",
+"197 389 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 911;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B1C2;
+unicode = 1B275;
+},
+{
+glyphname = u1B276;
+lastChange = "2020-04-13 09:11:02 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"513 265 LINE",
+"472 435 OFFCURVE",
+"427 591 OFFCURVE",
+"349 773 CURVE",
+"294 713 LINE",
+"361 547 OFFCURVE",
+"413 382 OFFCURVE",
+"446 225 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"590 736 LINE",
+"526 685 OFFCURVE",
+"462 637 OFFCURVE",
+"395 592 CURVE",
+"371 581 LINE",
+"301 533 OFFCURVE",
+"228 487 OFFCURVE",
+"147 440 CURVE",
+"182 376 LINE",
+"257 420 OFFCURVE",
+"327 464 OFFCURVE",
+"395 510 CURVE",
+"419 520 LINE",
+"492 570 OFFCURVE",
+"564 624 OFFCURVE",
+"637 681 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"509 939 LINE",
+"353 814 OFFCURVE",
+"215 721 OFFCURVE",
+"60 635 CURVE",
+"96 572 LINE",
+"248 657 OFFCURVE",
+"395 751 OFFCURVE",
+"557 884 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"615 448 OFFCURVE",
+"637 464 OFFCURVE",
+"637 501 CURVE SMOOTH",
+"637 539 OFFCURVE",
+"615 555 OFFCURVE",
+"588 555 CURVE SMOOTH",
+"561 555 OFFCURVE",
+"539 539 OFFCURVE",
+"539 501 CURVE SMOOTH",
+"539 464 OFFCURVE",
+"561 448 OFFCURVE",
+"588 448 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"322 266 OFFCURVE",
+"344 282 OFFCURVE",
+"344 320 CURVE SMOOTH",
+"344 357 OFFCURVE",
+"322 373 OFFCURVE",
+"296 373 CURVE SMOOTH",
+"268 373 OFFCURVE",
+"246 357 OFFCURVE",
+"246 320 CURVE SMOOTH",
+"246 282 OFFCURVE",
+"268 266 OFFCURVE",
+"296 266 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"287 103 LINE",
+"435 23 OFFCURVE",
+"553 -48 OFFCURVE",
+"689 -141 CURVE",
+"730 -82 LINE",
+"678 -45 OFFCURVE",
+"631 -19 OFFCURVE",
+"539 37 CURVE",
+"525 37 LINE",
+"474 75 OFFCURVE",
+"427 109 OFFCURVE",
+"349 152 CURVE",
+"338 118 LINE",
+"455 194 OFFCURVE",
+"515 240 OFFCURVE",
+"565 288 CURVE",
+"604 313 LINE",
+"621 326 OFFCURVE",
+"638 340 OFFCURVE",
+"655 355 CURVE",
+"607 410 LINE",
+"495 309 OFFCURVE",
+"401 242 OFFCURVE",
+"287 174 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"545 288 LINE",
+"569 288 LINE",
+"578 255 OFFCURVE",
+"582 220 OFFCURVE",
+"582 193 CURVE SMOOTH",
+"582 146 OFFCURVE",
+"567 90 OFFCURVE",
+"529 37 CURVE",
+"520 37 LINE",
+"458 -34 OFFCURVE",
+"381 -82 OFFCURVE",
+"292 -143 CURVE",
+"332 -203 LINE",
+"428 -139 OFFCURVE",
+"497 -79 OFFCURVE",
+"546 -29 CURVE",
+"570 -9 LINE",
+"637 68 OFFCURVE",
+"656 131 OFFCURVE",
+"656 193 CURVE SMOOTH",
+"656 240 OFFCURVE",
+"644 288 OFFCURVE",
+"601 352 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 840;
+}
+);
+leftMetricsKey = u1B187;
+rightMetricsKey = u1B17C;
+unicode = 1B276;
+},
+{
+glyphname = u1B277;
+lastChange = "2020-04-13 09:14:23 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"555 498 LINE",
+"552 254 OFFCURVE",
+"545 145 OFFCURVE",
+"516 -3 CURVE",
+"588 -13 LINE",
+"611 157 OFFCURVE",
+"618 236 OFFCURVE",
+"611 394 CURVE",
+"618 530 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"587 394 LINE",
+"615 394 LINE",
+"656 319 OFFCURVE",
+"686 263 OFFCURVE",
+"719 180 CURVE",
+"784 206 LINE",
+"742 309 OFFCURVE",
+"683 398 OFFCURVE",
+"614 498 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"451 336 LINE",
+"513 381 OFFCURVE",
+"568 427 OFFCURVE",
+"623 475 CURVE SMOOTH",
+"656 504 OFFCURVE",
+"696 539 OFFCURVE",
+"724 577 CURVE",
+"729 576 LINE",
+"741 524 OFFCURVE",
+"754 471 OFFCURVE",
+"762 431 CURVE SMOOTH",
+"774 374 OFFCURVE",
+"783 319 OFFCURVE",
+"793 256 CURVE",
+"863 267 LINE",
+"842 399 OFFCURVE",
+"822 498 OFFCURVE",
+"789 630 CURVE",
+"694 645 LINE",
+"610 551 OFFCURVE",
+"526 480 OFFCURVE",
+"417 400 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"643 939 LINE",
+"552 789 OFFCURVE",
+"453 669 OFFCURVE",
+"326 550 CURVE",
+"396 392 OFFCURVE",
+"417 299 OFFCURVE",
+"417 167 CURVE SMOOTH",
+"417 37 OFFCURVE",
+"390 -60 OFFCURVE",
+"341 -177 CURVE",
+"410 -203 LINE",
+"463 -84 OFFCURVE",
+"491 32 OFFCURVE",
+"491 167 CURVE SMOOTH",
+"491 299 OFFCURVE",
+"465 414 OFFCURVE",
+"399 568 CURVE",
+"385 511 LINE",
+"505 623 OFFCURVE",
+"614 743 OFFCURVE",
+"710 902 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 55 OFFCURVE",
+"109 7 OFFCURVE",
+"177 -33 CURVE",
+"248 -24 LINE",
+"316 55 OFFCURVE",
+"334 120 OFFCURVE",
+"334 181 CURVE SMOOTH",
+"334 241 OFFCURVE",
+"300 282 OFFCURVE",
+"232 320 CURVE",
+"158 310 LINE",
+"100 228 OFFCURVE",
+"80 161 OFFCURVE",
+"80 112 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 266 LINE",
+"244 234 OFFCURVE",
+"259 199 OFFCURVE",
+"259 170 CURVE SMOOTH",
+"259 127 OFFCURVE",
+"249 82 OFFCURVE",
+"209 18 CURVE",
+"204 17 LINE",
+"169 52 OFFCURVE",
+"154 83 OFFCURVE",
+"154 116 CURVE SMOOTH",
+"154 158 OFFCURVE",
+"167 202 OFFCURVE",
+"199 265 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 983;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B239;
+unicode = 1B277;
+},
+{
+glyphname = u1B278;
+lastChange = "2020-04-12 10:08:00 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"450 -203 OFFCURVE",
+"473 -186 OFFCURVE",
+"473 -147 CURVE SMOOTH",
+"473 -108 OFFCURVE",
+"450 -91 OFFCURVE",
+"422 -91 CURVE SMOOTH",
+"393 -91 OFFCURVE",
+"370 -108 OFFCURVE",
+"370 -147 CURVE SMOOTH",
+"370 -186 OFFCURVE",
+"393 -203 OFFCURVE",
+"422 -203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"618 -22 OFFCURVE",
+"641 -5 OFFCURVE",
+"641 34 CURVE SMOOTH",
+"641 73 OFFCURVE",
+"618 90 OFFCURVE",
+"590 90 CURVE SMOOTH",
+"561 90 OFFCURVE",
+"538 73 OFFCURVE",
+"538 34 CURVE SMOOTH",
+"538 -5 OFFCURVE",
+"561 -22 OFFCURVE",
+"590 -22 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"747 165 OFFCURVE",
+"770 182 OFFCURVE",
+"770 221 CURVE SMOOTH",
+"770 260 OFFCURVE",
+"747 277 OFFCURVE",
+"719 277 CURVE SMOOTH",
+"690 277 OFFCURVE",
+"667 260 OFFCURVE",
+"667 221 CURVE SMOOTH",
+"667 182 OFFCURVE",
+"690 165 OFFCURVE",
+"719 165 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"490 707 LINE",
+"403 548 OFFCURVE",
+"325 429 OFFCURVE",
+"232 305 CURVE",
+"284 254 LINE",
+"388 393 OFFCURVE",
+"457 496 OFFCURVE",
+"529 624 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"339 920 LINE",
+"271 777 OFFCURVE",
+"181 633 OFFCURVE",
+"90 507 CURVE",
+"181 328 OFFCURVE",
+"245 179 OFFCURVE",
+"305 16 CURVE",
+"397 9 LINE",
+"495 131 OFFCURVE",
+"584 263 OFFCURVE",
+"673 414 CURVE",
+"604 582 OFFCURVE",
+"535 732 OFFCURVE",
+"440 917 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"389 858 LINE",
+"421 781 OFFCURVE",
+"460 711 OFFCURVE",
+"496 635 CURVE SMOOTH",
+"538 546 OFFCURVE",
+"575 455 OFFCURVE",
+"615 351 CURVE",
+"618 472 LINE",
+"574 394 OFFCURVE",
+"531 323 OFFCURVE",
+"488 258 CURVE SMOOTH",
+"444 191 OFFCURVE",
+"402 135 OFFCURVE",
+"361 73 CURVE",
+"357 73 LINE",
+"333 152 OFFCURVE",
+"302 229 OFFCURVE",
+"266 309 CURVE SMOOTH",
+"233 383 OFFCURVE",
+"196 462 OFFCURVE",
+"151 550 CURVE",
+"156 470 LINE",
+"205 542 OFFCURVE",
+"229 576 OFFCURVE",
+"266 636 CURVE SMOOTH",
+"311 709 OFFCURVE",
+"347 770 OFFCURVE",
+"385 858 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 840;
+}
+);
+leftMetricsKey = u1B1C8;
+rightMetricsKey = u1B262;
+unicode = 1B278;
+},
+{
+glyphname = u1B279;
+lastChange = "2020-04-11 20:00:13 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"719 729 LINE",
+"661 690 OFFCURVE",
+"606 656 OFFCURVE",
+"552 625 CURVE",
+"522 611 LINE",
+"464 579 OFFCURVE",
+"404 547 OFFCURVE",
+"335 514 CURVE",
+"350 445 LINE",
+"416 477 OFFCURVE",
+"482 511 OFFCURVE",
+"546 546 CURVE",
+"577 561 LINE",
+"642 597 OFFCURVE",
+"706 637 OFFCURVE",
+"769 679 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"707 -33 LINE",
+"686 136 OFFCURVE",
+"665 274 OFFCURVE",
+"638 397 CURVE",
+"625 440 LINE",
+"598 557 OFFCURVE",
+"565 663 OFFCURVE",
+"525 772 CURVE",
+"512 813 LINE",
+"496 854 OFFCURVE",
+"479 896 OFFCURVE",
+"461 939 CURVE",
+"397 913 LINE",
+"416 866 OFFCURVE",
+"434 817 OFFCURVE",
+"450 774 CURVE",
+"466 734 LINE",
+"507 620 OFFCURVE",
+"539 515 OFFCURVE",
+"564 403 CURVE",
+"572 363 LINE",
+"597 243 OFFCURVE",
+"616 115 OFFCURVE",
+"632 -40 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"640 914 LINE",
+"590 880 OFFCURVE",
+"542 849 OFFCURVE",
+"493 820 CURVE",
+"455 800 LINE",
+"393 764 OFFCURVE",
+"329 731 OFFCURVE",
+"259 696 CURVE",
+"305 551 OFFCURVE",
+"337 434 OFFCURVE",
+"367 301 CURVE",
+"445 278 LINE",
+"489 296 OFFCURVE",
+"540 321 OFFCURVE",
+"591 348 CURVE",
+"631 366 LINE",
+"700 402 OFFCURVE",
+"769 442 OFFCURVE",
+"835 482 CURVE",
+"800 635 OFFCURVE",
+"763 759 OFFCURVE",
+"714 899 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"659 840 LINE",
+"677 780 OFFCURVE",
+"692 730 OFFCURVE",
+"710 670 CURVE SMOOTH",
+"728 609 OFFCURVE",
+"743 549 OFFCURVE",
+"756 492 CURVE",
+"793 544 LINE",
+"727 503 OFFCURVE",
+"663 466 OFFCURVE",
+"601 433 CURVE",
+"574 421 LINE",
+"518 392 OFFCURVE",
+"477 372 OFFCURVE",
+"432 347 CURVE",
+"427 348 LINE",
+"414 415 OFFCURVE",
+"404 463 OFFCURVE",
+"392 508 CURVE SMOOTH",
+"375 570 OFFCURVE",
+"355 635 OFFCURVE",
+"332 705 CURVE",
+"306 639 LINE",
+"369 668 OFFCURVE",
+"429 699 OFFCURVE",
+"488 733 CURVE",
+"515 746 LINE",
+"559 775 OFFCURVE",
+"606 804 OFFCURVE",
+"654 841 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"229 145 OFFCURVE",
+"207 90 OFFCURVE",
+"207 32 CURVE SMOOTH",
+"207 -105 OFFCURVE",
+"294 -203 OFFCURVE",
+"482 -203 CURVE",
+"485 -131 LINE",
+"336 -131 OFFCURVE",
+"281 -68 OFFCURVE",
+"281 37 CURVE SMOOTH",
+"281 98 OFFCURVE",
+"304 141 OFFCURVE",
+"360 169 CURVE",
+"340 257 LINE",
+"206 257 OFFCURVE",
+"144 318 OFFCURVE",
+"144 432 CURVE SMOOTH",
+"144 502 OFFCURVE",
+"169 548 OFFCURVE",
+"229 593 CURVE",
+"186 648 LINE",
+"106 593 OFFCURVE",
+"70 515 OFFCURVE",
+"70 429 CURVE SMOOTH",
+"70 297 OFFCURVE",
+"149 200 OFFCURVE",
+"290 199 CURVE",
+"291 194 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 925;
+}
+);
+leftMetricsKey = u1B1D0;
+rightMetricsKey = u1B20C;
+unicode = 1B279;
+},
+{
+glyphname = u1B27A;
+lastChange = "2020-04-13 09:14:31 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"236 -74 LINE",
+"304 -36 OFFCURVE",
+"362 -2 OFFCURVE",
+"416 32 CURVE",
+"455 54 LINE",
+"503 86 OFFCURVE",
+"557 127 OFFCURVE",
+"611 182 CURVE",
+"616 181 LINE",
+"620 102 OFFCURVE",
+"623 42 OFFCURVE",
+"620 -34 CURVE SMOOTH",
+"619 -56 OFFCURVE",
+"618 -79 OFFCURVE",
+"617 -104 CURVE",
+"690 -105 LINE",
+"695 18 OFFCURVE",
+"690 102 OFFCURVE",
+"677 240 CURVE",
+"607 261 LINE",
+"557 219 OFFCURVE",
+"507 180 OFFCURVE",
+"454 142 CURVE",
+"410 116 LINE",
+"345 73 OFFCURVE",
+"277 31 OFFCURVE",
+"200 -11 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"559 717 LINE",
+"508 666 OFFCURVE",
+"454 621 OFFCURVE",
+"399 574 CURVE",
+"364 548 LINE",
+"304 498 OFFCURVE",
+"240 449 OFFCURVE",
+"172 398 CURVE",
+"192 325 LINE",
+"259 376 OFFCURVE",
+"321 423 OFFCURVE",
+"381 471 CURVE",
+"416 498 LINE",
+"482 552 OFFCURVE",
+"547 608 OFFCURVE",
+"614 669 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"308 713 LINE",
+"345 572 OFFCURVE",
+"372 435 OFFCURVE",
+"389 308 CURVE",
+"392 250 LINE",
+"397 190 OFFCURVE",
+"399 129 OFFCURVE",
+"399 68 CURVE SMOOTH",
+"399 -28 OFFCURVE",
+"396 -107 OFFCURVE",
+"385 -193 CURVE",
+"460 -203 LINE",
+"472 -104 OFFCURVE",
+"475 -28 OFFCURVE",
+"475 75 CURVE SMOOTH",
+"475 154 OFFCURVE",
+"470 235 OFFCURVE",
+"461 317 CURVE",
+"452 358 LINE",
+"435 484 OFFCURVE",
+"406 630 OFFCURVE",
+"364 767 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"501 929 LINE",
+"362 797 OFFCURVE",
+"235 691 OFFCURVE",
+"100 586 CURVE",
+"132 439 OFFCURVE",
+"162 290 OFFCURVE",
+"176 159 CURVE",
+"255 139 LINE",
+"307 173 OFFCURVE",
+"363 212 OFFCURVE",
+"419 253 CURVE",
+"445 270 LINE",
+"515 322 OFFCURVE",
+"587 378 OFFCURVE",
+"669 446 CURVE",
+"647 600 OFFCURVE",
+"615 761 OFFCURVE",
+"575 914 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"520 846 LINE",
+"534 774 OFFCURVE",
+"548 710 OFFCURVE",
+"561 645 CURVE SMOOTH",
+"574 580 OFFCURVE",
+"583 518 OFFCURVE",
+"590 459 CURVE",
+"627 510 LINE",
+"560 453 OFFCURVE",
+"495 401 OFFCURVE",
+"433 353 CURVE",
+"405 335 LINE",
+"340 286 OFFCURVE",
+"291 248 OFFCURVE",
+"243 209 CURVE",
+"238 210 LINE",
+"230 289 OFFCURVE",
+"224 349 OFFCURVE",
+"211 414 CURVE SMOOTH",
+"199 474 OFFCURVE",
+"186 537 OFFCURVE",
+"172 595 CURVE",
+"150 534 LINE",
+"218 584 OFFCURVE",
+"288 640 OFFCURVE",
+"360 702 CURVE SMOOTH",
+"416 751 OFFCURVE",
+"457 787 OFFCURVE",
+"515 847 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 812;
+}
+);
+leftMetricsKey = u1B205;
+rightMetricsKey = u1B239;
+unicode = 1B27A;
+},
+{
+glyphname = u1B27B;
+lastChange = "2020-04-12 10:08:05 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"714 336 LINE",
+"633 218 OFFCURVE",
+"539 108 OFFCURVE",
+"416 -14 CURVE",
+"468 -69 LINE",
+"586 46 OFFCURVE",
+"689 165 OFFCURVE",
+"778 295 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"118 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -103 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"483 730 LINE",
+"402 605 OFFCURVE",
+"340 524 OFFCURVE",
+"241 414 CURVE",
+"291 359 LINE",
+"380 458 OFFCURVE",
+"454 550 OFFCURVE",
+"527 656 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"352 935 LINE",
+"288 832 OFFCURVE",
+"208 720 OFFCURVE",
+"125 625 CURVE",
+"208 452 OFFCURVE",
+"268 317 OFFCURVE",
+"323 175 CURVE",
+"415 165 LINE",
+"486 239 OFFCURVE",
+"564 329 OFFCURVE",
+"655 451 CURVE",
+"594 617 OFFCURVE",
+"526 777 OFFCURVE",
+"448 929 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"395 868 LINE",
+"429 799 OFFCURVE",
+"451 756 OFFCURVE",
+"483 682 CURVE SMOOTH",
+"522 592 OFFCURVE",
+"560 496 OFFCURVE",
+"594 396 CURVE",
+"603 506 LINE",
+"570 460 OFFCURVE",
+"539 420 OFFCURVE",
+"509 383 CURVE SMOOTH",
+"461 324 OFFCURVE",
+"421 280 OFFCURVE",
+"379 228 CURVE",
+"375 228 LINE",
+"351 302 OFFCURVE",
+"325 367 OFFCURVE",
+"293 439 CURVE SMOOTH",
+"260 513 OFFCURVE",
+"224 588 OFFCURVE",
+"187 663 CURVE",
+"193 586 LINE",
+"233 638 OFFCURVE",
+"269 684 OFFCURVE",
+"301 728 CURVE SMOOTH",
+"340 781 OFFCURVE",
+"359 809 OFFCURVE",
+"391 868 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 826;
+}
+);
+leftMetricsKey = u1B1B9;
+unicode = 1B27B;
+},
+{
+glyphname = u1B27C;
+lastChange = "2020-04-13 09:14:36 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"349 402 LINE",
+"438 532 OFFCURVE",
+"505 653 OFFCURVE",
+"611 915 CURVE",
+"543 939 LINE",
+"499 827 OFFCURVE",
+"460 738 OFFCURVE",
+"423 664 CURVE SMOOTH",
+"384 586 OFFCURVE",
+"344 516 OFFCURVE",
+"313 457 CURVE",
+"309 457 LINE",
+"266 532 OFFCURVE",
+"220 591 OFFCURVE",
+"180 641 CURVE SMOOTH",
+"164 661 OFFCURVE",
+"146 681 OFFCURVE",
+"127 702 CURVE",
+"74 653 LINE",
+"155 567 OFFCURVE",
+"203 501 OFFCURVE",
+"267 406 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"822 445 LINE",
+"739 588 OFFCURVE",
+"634 721 OFFCURVE",
+"548 816 CURVE",
+"500 764 LINE",
+"579 676 OFFCURVE",
+"666 559 OFFCURVE",
+"761 403 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"329 698 OFFCURVE",
+"352 715 OFFCURVE",
+"352 754 CURVE SMOOTH",
+"352 793 OFFCURVE",
+"329 810 OFFCURVE",
+"301 810 CURVE SMOOTH",
+"272 810 OFFCURVE",
+"249 793 OFFCURVE",
+"249 754 CURVE SMOOTH",
+"249 715 OFFCURVE",
+"272 698 OFFCURVE",
+"301 698 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 323 OFFCURVE",
+"163 340 OFFCURVE",
+"163 379 CURVE SMOOTH",
+"163 418 OFFCURVE",
+"140 435 OFFCURVE",
+"112 435 CURVE SMOOTH",
+"83 435 OFFCURVE",
+"60 418 OFFCURVE",
+"60 379 CURVE SMOOTH",
+"60 340 OFFCURVE",
+"83 323 OFFCURVE",
+"112 323 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"548 523 LINE",
+"486 407 OFFCURVE",
+"406 310 OFFCURVE",
+"319 226 CURVE",
+"370 174 LINE",
+"461 260 OFFCURVE",
+"541 359 OFFCURVE",
+"611 487 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"632 335 LINE",
+"546 209 OFFCURVE",
+"466 121 OFFCURVE",
+"368 37 CURVE",
+"415 -19 LINE",
+"511 61 OFFCURVE",
+"600 157 OFFCURVE",
+"694 298 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"725 177 LINE",
+"635 38 OFFCURVE",
+"543 -57 OFFCURVE",
+"418 -148 CURVE",
+"461 -203 LINE",
+"589 -108 OFFCURVE",
+"692 -10 OFFCURVE",
+"785 138 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 912;
+}
+);
+leftMetricsKey = u1B264;
+rightMetricsKey = u1B1AD;
+unicode = 1B27C;
+},
+{
+glyphname = u1B27D;
+lastChange = "2020-04-13 09:14:38 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"703 147 LINE",
+"613 61 OFFCURVE",
+"503 -20 OFFCURVE",
+"382 -88 CURVE",
+"418 -150 LINE",
+"551 -75 OFFCURVE",
+"657 4 OFFCURVE",
+"755 93 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"452 394 LINE",
+"483 270 OFFCURVE",
+"507 115 OFFCURVE",
+"526 -47 CURVE",
+"595 -21 LINE",
+"576 163 OFFCURVE",
+"548 312 OFFCURVE",
+"516 445 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 574 LINE",
+"507 464 OFFCURVE",
+"406 372 OFFCURVE",
+"280 278 CURVE",
+"324 220 LINE",
+"450 314 OFFCURVE",
+"539 390 OFFCURVE",
+"667 527 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"413 42 OFFCURVE",
+"436 59 OFFCURVE",
+"436 98 CURVE SMOOTH",
+"436 137 OFFCURVE",
+"413 154 OFFCURVE",
+"385 154 CURVE SMOOTH",
+"356 154 OFFCURVE",
+"333 137 OFFCURVE",
+"333 98 CURVE SMOOTH",
+"333 59 OFFCURVE",
+"356 42 OFFCURVE",
+"385 42 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"704 261 OFFCURVE",
+"727 278 OFFCURVE",
+"727 317 CURVE SMOOTH",
+"727 356 OFFCURVE",
+"704 373 OFFCURVE",
+"676 373 CURVE SMOOTH",
+"647 373 OFFCURVE",
+"624 356 OFFCURVE",
+"624 317 CURVE SMOOTH",
+"624 278 OFFCURVE",
+"647 261 OFFCURVE",
+"676 261 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"132 244 LINE",
+"177 109 OFFCURVE",
+"209 -35 OFFCURVE",
+"223 -203 CURVE",
+"296 -197 LINE",
+"278 -18 OFFCURVE",
+"248 142 OFFCURVE",
+"200 271 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"589 939 LINE",
+"533 825 OFFCURVE",
+"474 727 OFFCURVE",
+"411 639 CURVE SMOOTH",
+"361 570 OFFCURVE",
+"315 516 OFFCURVE",
+"266 455 CURVE",
+"261 456 LINE",
+"239 537 OFFCURVE",
+"215 597 OFFCURVE",
+"191 650 CURVE SMOOTH",
+"174 687 OFFCURVE",
+"155 723 OFFCURVE",
+"134 758 CURVE",
+"70 721 LINE",
+"132 617 OFFCURVE",
+"174 515 OFFCURVE",
+"211 408 CURVE",
+"293 392 LINE",
+"433 532 OFFCURVE",
+"553 698 OFFCURVE",
+"657 910 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 815;
+}
+);
+leftMetricsKey = u1B1B7;
+unicode = 1B27D;
+},
+{
+glyphname = u1B27E;
+lastChange = "2020-04-13 09:14:40 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"60 334 OFFCURVE",
+"87 286 OFFCURVE",
+"172 237 CURVE",
+"240 249 LINE",
+"302 341 OFFCURVE",
+"330 414 OFFCURVE",
+"330 478 CURVE SMOOTH",
+"330 544 OFFCURVE",
+"297 590 OFFCURVE",
+"217 640 CURVE",
+"154 634 LINE",
+"81 516 OFFCURVE",
+"60 457 OFFCURVE",
+"60 396 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"196 580 LINE",
+"238 540 OFFCURVE",
+"258 504 OFFCURVE",
+"258 468 CURVE SMOOTH",
+"258 426 OFFCURVE",
+"241 368 OFFCURVE",
+"200 295 CURVE",
+"196 295 LINE",
+"154 329 OFFCURVE",
+"133 362 OFFCURVE",
+"133 406 CURVE SMOOTH",
+"133 449 OFFCURVE",
+"151 503 OFFCURVE",
+"192 580 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"625 478 OFFCURVE",
+"650 423 OFFCURVE",
+"736 381 CURVE",
+"804 393 LINE",
+"870 485 OFFCURVE",
+"894 558 OFFCURVE",
+"894 622 CURVE SMOOTH",
+"894 688 OFFCURVE",
+"859 734 OFFCURVE",
+"781 784 CURVE",
+"718 778 LINE",
+"645 673 OFFCURVE",
+"625 601 OFFCURVE",
+"625 540 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"833 -12 LINE",
+"720 224 OFFCURVE",
+"610 371 OFFCURVE",
+"467 544 CURVE",
+"459 441 LINE",
+"573 302 OFFCURVE",
+"672 154 OFFCURVE",
+"762 -40 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"456 939 LINE",
+"464 443 OFFCURVE",
+"368 277 OFFCURVE",
+"133 -34 CURVE",
+"196 -75 LINE",
+"427 249 OFFCURVE",
+"530 443 OFFCURVE",
+"532 938 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"761 724 LINE",
+"803 684 OFFCURVE",
+"823 648 OFFCURVE",
+"823 612 CURVE SMOOTH",
+"823 570 OFFCURVE",
+"806 512 OFFCURVE",
+"765 439 CURVE",
+"761 439 LINE",
+"719 473 OFFCURVE",
+"698 506 OFFCURVE",
+"698 550 CURVE SMOOTH",
+"698 593 OFFCURVE",
+"716 647 OFFCURVE",
+"757 724 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"365 -106 OFFCURVE",
+"390 -161 OFFCURVE",
+"476 -203 CURVE",
+"544 -191 LINE",
+"610 -99 OFFCURVE",
+"634 -26 OFFCURVE",
+"634 38 CURVE SMOOTH",
+"634 104 OFFCURVE",
+"599 150 OFFCURVE",
+"521 200 CURVE",
+"458 194 LINE",
+"385 89 OFFCURVE",
+"365 17 OFFCURVE",
+"365 -44 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"501 140 LINE",
+"543 100 OFFCURVE",
+"563 64 OFFCURVE",
+"563 28 CURVE SMOOTH",
+"563 -14 OFFCURVE",
+"546 -72 OFFCURVE",
+"505 -145 CURVE",
+"501 -145 LINE",
+"459 -111 OFFCURVE",
+"438 -78 OFFCURVE",
+"438 -34 CURVE SMOOTH",
+"438 9 OFFCURVE",
+"456 63 OFFCURVE",
+"497 140 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 954;
+}
+);
+leftMetricsKey = u1B1F1;
+rightMetricsKey = u1B1F1;
+unicode = 1B27E;
+},
+{
+glyphname = u1B27F;
+lastChange = "2020-04-13 09:14:50 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"728 939 LINE",
+"608 789 OFFCURVE",
+"486 665 OFFCURVE",
+"334 546 CURVE",
+"380 488 LINE",
+"539 616 OFFCURVE",
+"659 734 OFFCURVE",
+"789 897 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"845 371 LINE",
+"731 250 OFFCURVE",
+"624 156 OFFCURVE",
+"498 69 CURVE",
+"543 10 LINE",
+"663 91 OFFCURVE",
+"786 199 OFFCURVE",
+"902 324 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"538 673 LINE",
+"597 503 OFFCURVE",
+"641 339 OFFCURVE",
+"679 159 CURVE",
+"744 193 LINE",
+"705 383 OFFCURVE",
+"663 535 OFFCURVE",
+"595 726 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"376 400 LINE",
+"278 305 OFFCURVE",
+"165 226 OFFCURVE",
+"50 158 CURVE",
+"85 100 LINE",
+"208 174 OFFCURVE",
+"317 244 OFFCURVE",
+"423 350 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"378 254 OFFCURVE",
+"388 229 OFFCURVE",
+"388 197 CURVE SMOOTH",
+"388 138 OFFCURVE",
+"340 94 OFFCURVE",
+"132 -17 CURVE",
+"168 -77 LINE",
+"399 48 OFFCURVE",
+"458 117 OFFCURVE",
+"458 197 CURVE SMOOTH",
+"458 240 OFFCURVE",
+"439 286 OFFCURVE",
+"373 348 CURVE",
+"335 302 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"103 381 LINE",
+"234 180 OFFCURVE",
+"290 6 OFFCURVE",
+"326 -203 CURVE",
+"396 -186 LINE",
+"382 -105 OFFCURVE",
+"365 -33 OFFCURVE",
+"342 46 CURVE",
+"323 87 LINE",
+"305 137 OFFCURVE",
+"286 185 OFFCURVE",
+"263 233 CURVE",
+"246 279 LINE",
+"222 325 OFFCURVE",
+"195 371 OFFCURVE",
+"165 419 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"811 519 OFFCURVE",
+"834 536 OFFCURVE",
+"834 575 CURVE SMOOTH",
+"834 614 OFFCURVE",
+"811 631 OFFCURVE",
+"783 631 CURVE SMOOTH",
+"754 631 OFFCURVE",
+"731 614 OFFCURVE",
+"731 575 CURVE SMOOTH",
+"731 536 OFFCURVE",
+"754 519 OFFCURVE",
+"783 519 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"540 293 OFFCURVE",
+"563 310 OFFCURVE",
+"563 349 CURVE SMOOTH",
+"563 388 OFFCURVE",
+"540 405 OFFCURVE",
+"512 405 CURVE SMOOTH",
+"483 405 OFFCURVE",
+"460 388 OFFCURVE",
+"460 349 CURVE SMOOTH",
+"460 310 OFFCURVE",
+"483 293 OFFCURVE",
+"512 293 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 962;
+}
+);
+rightMetricsKey = u1B27D;
+unicode = 1B27F;
+},
+{
+glyphname = u1B280;
+lastChange = "2020-04-13 09:14:54 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"598 939 LINE",
+"468 798 OFFCURVE",
+"331 701 OFFCURVE",
+"182 610 CURVE",
+"217 546 LINE",
+"371 641 OFFCURVE",
+"521 748 OFFCURVE",
+"651 890 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"506 552 LINE",
+"497 627 OFFCURVE",
+"482 698 OFFCURVE",
+"466 756 CURVE",
+"402 718 LINE",
+"432 618 OFFCURVE",
+"442 505 OFFCURVE",
+"442 433 CURVE SMOOTH",
+"442 269 OFFCURVE",
+"415 159 OFFCURVE",
+"386 29 CURVE",
+"458 16 LINE",
+"485 140 OFFCURVE",
+"503 243 OFFCURVE",
+"500 392 CURVE",
+"505 479 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"361 -93 OFFCURVE",
+"366 7 OFFCURVE",
+"366 110 CURVE SMOOTH",
+"366 202 OFFCURVE",
+"363 276 OFFCURVE",
+"350 401 CURVE",
+"342 355 LINE",
+"406 397 OFFCURVE",
+"473 448 OFFCURVE",
+"537 499 CURVE SMOOTH",
+"570 526 OFFCURVE",
+"604 561 OFFCURVE",
+"640 598 CURVE",
+"645 597 LINE",
+"655 521 OFFCURVE",
+"660 450 OFFCURVE",
+"664 402 CURVE SMOOTH",
+"672 308 OFFCURVE",
+"675 209 OFFCURVE",
+"675 96 CURVE",
+"749 96 LINE",
+"749 316 OFFCURVE",
+"737 480 OFFCURVE",
+"707 656 CURVE",
+"622 674 LINE",
+"520 574 OFFCURVE",
+"408 488 OFFCURVE",
+"276 400 CURVE",
+"289 269 OFFCURVE",
+"292 209 OFFCURVE",
+"292 110 CURVE SMOOTH",
+"292 1 OFFCURVE",
+"285 -97 OFFCURVE",
+"275 -196 CURVE",
+"349 -203 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"123 321 LINE",
+"131 170 OFFCURVE",
+"130 53 OFFCURVE",
+"120 -63 CURVE",
+"187 -67 LINE",
+"199 62 OFFCURVE",
+"199 177 OFFCURVE",
+"190 325 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"769 675 LINE",
+"806 521 OFFCURVE",
+"822 396 OFFCURVE",
+"826 252 CURVE",
+"894 254 LINE",
+"888 415 OFFCURVE",
+"868 564 OFFCURVE",
+"835 690 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"474 392 LINE",
+"504 392 LINE",
+"533 321 OFFCURVE",
+"550 278 OFFCURVE",
+"578 183 CURVE",
+"645 205 LINE",
+"604 323 OFFCURVE",
+"571 405 OFFCURVE",
+"509 505 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 1014;
+}
+);
+leftMetricsKey = u1B1AB;
+rightMetricsKey = u1B239;
+unicode = 1B280;
+},
+{
+glyphname = u1B281;
+lastChange = "2020-04-13 09:15:11 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"380 325 LINE",
+"406 286 OFFCURVE",
+"435 246 OFFCURVE",
+"455 218 CURVE SMOOTH",
+"484 176 OFFCURVE",
+"513 131 OFFCURVE",
+"545 80 CURVE",
+"546 160 LINE",
+"494 107 OFFCURVE",
+"444 58 OFFCURVE",
+"380 5 CURVE",
+"362 -3 LINE",
+"312 -46 OFFCURVE",
+"257 -93 OFFCURVE",
+"187 -149 CURVE",
+"235 -203 LINE",
+"404 -66 OFFCURVE",
+"502 25 OFFCURVE",
+"599 127 CURVE",
+"539 222 OFFCURVE",
+"484 299 OFFCURVE",
+"424 374 CURVE",
+"353 386 LINE",
+"286 322 OFFCURVE",
+"232 277 OFFCURVE",
+"153 217 CURVE",
+"281 49 OFFCURVE",
+"355 -54 OFFCURVE",
+"455 -205 CURVE",
+"514 -168 LINE",
+"480 -116 OFFCURVE",
+"447 -69 OFFCURVE",
+"415 -23 CURVE",
+"398 0 LINE",
+"337 85 OFFCURVE",
+"282 159 OFFCURVE",
+"217 246 CURVE",
+"231 197 LINE",
+"255 215 OFFCURVE",
+"278 234 OFFCURVE",
+"302 254 CURVE SMOOTH",
+"323 272 OFFCURVE",
+"350 295 OFFCURVE",
+"376 325 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"442 263 LINE",
+"390 209 OFFCURVE",
+"341 165 OFFCURVE",
+"274 113 CURVE",
+"318 72 LINE",
+"393 131 OFFCURVE",
+"450 182 OFFCURVE",
+"491 226 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"150 617 LINE",
+"330 502 OFFCURVE",
+"435 419 OFFCURVE",
+"556 298 CURVE",
+"608 351 LINE",
+"540 416 OFFCURVE",
+"463 484 OFFCURVE",
+"372 551 CURVE",
+"357 551 LINE",
+"318 589 OFFCURVE",
+"273 626 OFFCURVE",
+"189 680 CURVE",
+"193 632 LINE",
+"259 701 OFFCURVE",
+"318 770 OFFCURVE",
+"358 825 CURVE",
+"388 855 LINE",
+"399 867 OFFCURVE",
+"409 880 OFFCURVE",
+"420 894 CURVE",
+"362 939 LINE",
+"291 844 OFFCURVE",
+"228 771 OFFCURVE",
+"150 693 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"487 764 OFFCURVE",
+"458 821 OFFCURVE",
+"376 894 CURVE",
+"328 825 LINE",
+"362 825 LINE",
+"398 778 OFFCURVE",
+"411 731 OFFCURVE",
+"411 689 CURVE SMOOTH",
+"411 652 OFFCURVE",
+"395 599 OFFCURVE",
+"361 551 CURVE",
+"349 551 LINE",
+"277 471 OFFCURVE",
+"197 410 OFFCURVE",
+"80 325 CURVE",
+"122 265 LINE",
+"243 353 OFFCURVE",
+"320 421 OFFCURVE",
+"375 477 CURVE",
+"410 508 LINE",
+"470 576 OFFCURVE",
+"487 629 OFFCURVE",
+"487 688 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 688;
+}
+);
+leftMetricsKey = u1B213;
+rightMetricsKey = u1B213;
+unicode = 1B281;
+},
+{
+glyphname = u1B282;
+lastChange = "2020-04-13 09:15:16 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"340 548 OFFCURVE",
+"363 565 OFFCURVE",
+"363 604 CURVE SMOOTH",
+"363 643 OFFCURVE",
+"340 660 OFFCURVE",
+"312 660 CURVE SMOOTH",
+"283 660 OFFCURVE",
+"260 643 OFFCURVE",
+"260 604 CURVE SMOOTH",
+"260 565 OFFCURVE",
+"283 548 OFFCURVE",
+"312 548 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"260 309 OFFCURVE",
+"283 326 OFFCURVE",
+"283 365 CURVE SMOOTH",
+"283 404 OFFCURVE",
+"260 421 OFFCURVE",
+"232 421 CURVE SMOOTH",
+"203 421 OFFCURVE",
+"180 404 OFFCURVE",
+"180 365 CURVE SMOOTH",
+"180 326 OFFCURVE",
+"203 309 OFFCURVE",
+"232 309 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"734 480 OFFCURVE",
+"757 497 OFFCURVE",
+"757 536 CURVE SMOOTH",
+"757 575 OFFCURVE",
+"734 592 OFFCURVE",
+"706 592 CURVE SMOOTH",
+"677 592 OFFCURVE",
+"654 575 OFFCURVE",
+"654 536 CURVE SMOOTH",
+"654 497 OFFCURVE",
+"677 480 OFFCURVE",
+"706 480 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"700 221 OFFCURVE",
+"723 238 OFFCURVE",
+"723 277 CURVE SMOOTH",
+"723 316 OFFCURVE",
+"700 333 OFFCURVE",
+"672 333 CURVE SMOOTH",
+"643 333 OFFCURVE",
+"620 316 OFFCURVE",
+"620 277 CURVE SMOOTH",
+"620 238 OFFCURVE",
+"643 221 OFFCURVE",
+"672 221 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"586 -23 OFFCURVE",
+"609 -6 OFFCURVE",
+"609 33 CURVE SMOOTH",
+"609 72 OFFCURVE",
+"586 89 OFFCURVE",
+"558 89 CURVE SMOOTH",
+"529 89 OFFCURVE",
+"506 72 OFFCURVE",
+"506 33 CURVE SMOOTH",
+"506 -6 OFFCURVE",
+"529 -23 OFFCURVE",
+"558 -23 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"505 939 LINE",
+"505 559 OFFCURVE",
+"444 319 OFFCURVE",
+"323 140 CURVE",
+"383 101 LINE",
+"505 280 OFFCURVE",
+"580 554 OFFCURVE",
+"580 937 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"118 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -103 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 837;
+}
+);
+leftMetricsKey = u1B23A;
+rightMetricsKey = u1B1FA;
+unicode = 1B282;
+},
+{
+glyphname = u1B283;
+lastChange = "2020-04-13 09:15:56 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"450 939 LINE",
+"420 791 OFFCURVE",
+"379 686 OFFCURVE",
+"276 556 CURVE",
+"331 516 LINE",
+"440 658 OFFCURVE",
+"486 762 OFFCURVE",
+"519 925 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"251 774 LINE",
+"307 750 OFFCURVE",
+"354 727 OFFCURVE",
+"397 703 CURVE",
+"421 693 LINE",
+"464 666 OFFCURVE",
+"504 636 OFFCURVE",
+"545 598 CURVE",
+"589 650 LINE",
+"543 692 OFFCURVE",
+"500 724 OFFCURVE",
+"456 753 CURVE",
+"423 768 LINE",
+"378 794 OFFCURVE",
+"332 817 OFFCURVE",
+"278 839 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"479 549 LINE",
+"439 401 OFFCURVE",
+"381 295 OFFCURVE",
+"304 198 CURVE",
+"362 159 LINE",
+"439 258 OFFCURVE",
+"501 364 OFFCURVE",
+"546 530 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"293 401 LINE",
+"340 378 OFFCURVE",
+"380 354 OFFCURVE",
+"416 329 CURVE",
+"440 317 LINE",
+"482 286 OFFCURVE",
+"521 252 OFFCURVE",
+"560 213 CURVE",
+"609 262 LINE",
+"568 304 OFFCURVE",
+"522 343 OFFCURVE",
+"473 379 CURVE",
+"447 392 LINE",
+"408 418 OFFCURVE",
+"368 442 OFFCURVE",
+"325 464 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"489 183 LINE",
+"454 27 OFFCURVE",
+"409 -66 OFFCURVE",
+"345 -166 CURVE",
+"404 -203 LINE",
+"479 -95 OFFCURVE",
+"521 7 OFFCURVE",
+"561 166 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"303 28 LINE",
+"353 10 OFFCURVE",
+"396 -9 OFFCURVE",
+"437 -30 CURVE",
+"463 -40 LINE",
+"509 -65 OFFCURVE",
+"552 -93 OFFCURVE",
+"594 -125 CURVE",
+"636 -71 LINE",
+"590 -35 OFFCURVE",
+"547 -5 OFFCURVE",
+"501 20 CURVE",
+"464 35 LINE",
+"421 57 OFFCURVE",
+"376 75 OFFCURVE",
+"326 93 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"114 604 LINE",
+"164 475 OFFCURVE",
+"177 363 OFFCURVE",
+"177 276 CURVE SMOOTH",
+"177 164 OFFCURVE",
+"158 64 OFFCURVE",
+"100 -44 CURVE",
+"160 -72 LINE",
+"229 56 OFFCURVE",
+"249 160 OFFCURVE",
+"249 276 CURVE SMOOTH",
+"249 382 OFFCURVE",
+"230 490 OFFCURVE",
+"179 626 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"659 716 OFFCURVE",
+"638 607 OFFCURVE",
+"638 491 CURVE SMOOTH",
+"638 354 OFFCURVE",
+"665 245 OFFCURVE",
+"717 135 CURVE",
+"781 162 LINE",
+"732 276 OFFCURVE",
+"710 358 OFFCURVE",
+"710 496 CURVE SMOOTH",
+"710 607 OFFCURVE",
+"728 699 OFFCURVE",
+"776 822 CURVE",
+"710 844 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 881;
+}
+);
+leftMetricsKey = u1B174;
+rightMetricsKey = u1B174;
+unicode = 1B283;
+},
+{
+glyphname = u1B284;
+lastChange = "2020-04-13 09:16:01 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"581 939 LINE",
+"515 689 OFFCURVE",
+"413 507 OFFCURVE",
+"256 362 CURVE",
+"305 320 LINE",
+"478 465 OFFCURVE",
+"576 643 OFFCURVE",
+"653 922 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"634 493 OFFCURVE",
+"655 508 OFFCURVE",
+"655 543 CURVE SMOOTH",
+"655 579 OFFCURVE",
+"634 594 OFFCURVE",
+"608 594 CURVE SMOOTH",
+"582 594 OFFCURVE",
+"561 579 OFFCURVE",
+"561 543 CURVE SMOOTH",
+"561 508 OFFCURVE",
+"582 493 OFFCURVE",
+"608 493 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"568 312 OFFCURVE",
+"591 329 OFFCURVE",
+"591 368 CURVE SMOOTH",
+"591 407 OFFCURVE",
+"568 424 OFFCURVE",
+"540 424 CURVE SMOOTH",
+"511 424 OFFCURVE",
+"488 407 OFFCURVE",
+"488 368 CURVE SMOOTH",
+"488 329 OFFCURVE",
+"511 312 OFFCURVE",
+"540 312 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"656 154 OFFCURVE",
+"677 169 OFFCURVE",
+"677 205 CURVE SMOOTH",
+"677 240 OFFCURVE",
+"656 255 OFFCURVE",
+"631 255 CURVE SMOOTH",
+"604 255 OFFCURVE",
+"583 240 OFFCURVE",
+"583 205 CURVE SMOOTH",
+"583 169 OFFCURVE",
+"604 154 OFFCURVE",
+"631 154 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"185 641 OFFCURVE",
+"220 500 OFFCURVE",
+"220 326 CURVE SMOOTH",
+"220 164 OFFCURVE",
+"190 41 OFFCURVE",
+"133 -109 CURVE",
+"201 -133 LINE",
+"265 26 OFFCURVE",
+"296 164 OFFCURVE",
+"296 330 CURVE SMOOTH",
+"296 482 OFFCURVE",
+"257 668 OFFCURVE",
+"185 818 CURVE",
+"120 792 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 -182 LINE",
+"535 74 OFFCURVE",
+"461 210 OFFCURVE",
+"297 403 CURVE",
+"246 357 LINE",
+"406 164 OFFCURVE",
+"476 25 OFFCURVE",
+"540 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"557 806 LINE",
+"692 757 OFFCURVE",
+"741 692 OFFCURVE",
+"741 603 CURVE SMOOTH",
+"741 525 OFFCURVE",
+"717 479 OFFCURVE",
+"663 432 CURVE",
+"674 370 LINE",
+"753 333 OFFCURVE",
+"784 281 OFFCURVE",
+"784 188 CURVE SMOOTH",
+"784 118 OFFCURVE",
+"758 69 OFFCURVE",
+"685 16 CURVE",
+"728 -36 LINE",
+"814 28 OFFCURVE",
+"858 98 OFFCURVE",
+"858 198 CURVE SMOOTH",
+"858 296 OFFCURVE",
+"811 372 OFFCURVE",
+"729 407 CURVE",
+"729 411 LINE",
+"786 454 OFFCURVE",
+"815 522 OFFCURVE",
+"815 603 CURVE SMOOTH",
+"815 725 OFFCURVE",
+"744 806 OFFCURVE",
+"593 866 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 958;
+}
+);
+leftMetricsKey = u1B19A;
+unicode = 1B284;
+},
+{
+glyphname = u1B285;
+lastChange = "2020-04-13 09:16:26 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"464 146 LINE",
+"440 387 OFFCURVE",
+"401 551 OFFCURVE",
+"323 763 CURVE",
+"267 724 LINE",
+"339 543 OFFCURVE",
+"382 368 OFFCURVE",
+"395 136 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"450 939 LINE",
+"326 810 OFFCURVE",
+"215 720 OFFCURVE",
+"60 619 CURVE",
+"100 560 LINE",
+"247 655 OFFCURVE",
+"379 758 OFFCURVE",
+"507 895 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"539 744 LINE",
+"482 691 OFFCURVE",
+"422 641 OFFCURVE",
+"360 593 CURVE",
+"338 581 LINE",
+"266 527 OFFCURVE",
+"191 476 OFFCURVE",
+"114 431 CURVE",
+"149 369 LINE",
+"223 413 OFFCURVE",
+"292 459 OFFCURVE",
+"360 508 CURVE",
+"383 520 LINE",
+"452 573 OFFCURVE",
+"521 630 OFFCURVE",
+"591 695 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"87 104 LINE",
+"183 22 OFFCURVE",
+"260 -58 OFFCURVE",
+"337 -151 CURVE",
+"395 -106 LINE",
+"358 -63 OFFCURVE",
+"328 -32 OFFCURVE",
+"263 33 CURVE",
+"249 33 LINE",
+"220 74 OFFCURVE",
+"187 106 OFFCURVE",
+"131 154 CURVE",
+"131 122 LINE",
+"189 176 OFFCURVE",
+"228 218 OFFCURVE",
+"257 262 CURVE",
+"288 290 LINE",
+"300 305 OFFCURVE",
+"311 321 OFFCURVE",
+"322 337 CURVE",
+"265 374 LINE",
+"206 295 OFFCURVE",
+"147 229 OFFCURVE",
+"87 175 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"230 262 LINE",
+"261 262 LINE",
+"272 220 OFFCURVE",
+"276 185 OFFCURVE",
+"276 150 CURVE SMOOTH",
+"276 116 OFFCURVE",
+"269 78 OFFCURVE",
+"253 33 CURVE",
+"244 33 LINE",
+"204 -38 OFFCURVE",
+"161 -91 OFFCURVE",
+"101 -159 CURVE",
+"153 -203 LINE",
+"206 -143 OFFCURVE",
+"239 -93 OFFCURVE",
+"268 -49 CURVE",
+"291 -22 LINE",
+"329 42 OFFCURVE",
+"343 91 OFFCURVE",
+"343 140 CURVE SMOOTH",
+"343 194 OFFCURVE",
+"330 247 OFFCURVE",
+"288 322 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"464 350 LINE",
+"541 260 OFFCURVE",
+"618 158 OFFCURVE",
+"673 64 CURVE",
+"735 102 LINE",
+"709 143 OFFCURVE",
+"691 173 OFFCURVE",
+"637 247 CURVE",
+"625 247 LINE",
+"595 300 OFFCURVE",
+"562 344 OFFCURVE",
+"510 409 CURVE",
+"509 370 LINE",
+"552 413 OFFCURVE",
+"591 456 OFFCURVE",
+"620 502 CURVE",
+"659 539 LINE",
+"670 555 OFFCURVE",
+"682 571 OFFCURVE",
+"694 588 CURVE",
+"638 624 LINE",
+"578 539 OFFCURVE",
+"524 478 OFFCURVE",
+"464 421 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"603 502 LINE",
+"624 502 LINE",
+"647 464 OFFCURVE",
+"660 431 OFFCURVE",
+"660 387 CURVE SMOOTH",
+"660 345 OFFCURVE",
+"649 295 OFFCURVE",
+"629 247 CURVE",
+"618 247 LINE",
+"573 170 OFFCURVE",
+"526 111 OFFCURVE",
+"466 41 CURVE",
+"519 -3 LINE",
+"572 58 OFFCURVE",
+"605 109 OFFCURVE",
+"635 153 CURVE",
+"660 183 LINE",
+"713 267 OFFCURVE",
+"725 325 OFFCURVE",
+"725 384 CURVE SMOOTH",
+"725 441 OFFCURVE",
+"710 490 OFFCURVE",
+"662 559 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 845;
+}
+);
+rightMetricsKey = u1B17C;
+unicode = 1B285;
+},
+{
+glyphname = u1B286;
+lastChange = "2020-04-13 09:16:28 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"385 622 LINE",
+"361 697 OFFCURVE",
+"327 778 OFFCURVE",
+"276 872 CURVE",
+"210 839 LINE",
+"261 742 OFFCURVE",
+"295 660 OFFCURVE",
+"328 570 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"588 763 LINE",
+"614 698 OFFCURVE",
+"636 645 OFFCURVE",
+"659 578 CURVE SMOOTH",
+"674 535 OFFCURVE",
+"687 492 OFFCURVE",
+"701 447 CURVE",
+"773 467 LINE",
+"735 603 OFFCURVE",
+"701 688 OFFCURVE",
+"641 825 CURVE",
+"554 833 LINE",
+"411 687 OFFCURVE",
+"269 578 OFFCURVE",
+"90 459 CURVE",
+"137 318 OFFCURVE",
+"161 225 OFFCURVE",
+"178 108 CURVE",
+"251 123 LINE",
+"231 248 OFFCURVE",
+"209 340 OFFCURVE",
+"164 470 CURVE",
+"153 412 LINE",
+"248 474 OFFCURVE",
+"337 541 OFFCURVE",
+"424 613 CURVE SMOOTH",
+"486 665 OFFCURVE",
+"529 706 OFFCURVE",
+"584 763 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"697 217 OFFCURVE",
+"655 370 OFFCURVE",
+"601 523 CURVE",
+"516 536 LINE",
+"443 470 OFFCURVE",
+"377 416 OFFCURVE",
+"273 346 CURVE",
+"330 170 OFFCURVE",
+"370 24 OFFCURVE",
+"399 -121 CURVE",
+"478 -143 LINE",
+"574 -80 OFFCURVE",
+"635 -36 OFFCURVE",
+"733 54 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"664 95 LINE",
+"642 73 OFFCURVE",
+"621 53 OFFCURVE",
+"599 35 CURVE SMOOTH",
+"543 -11 OFFCURVE",
+"505 -37 OFFCURVE",
+"461 -72 CURVE",
+"456 -71 LINE",
+"449 12 OFFCURVE",
+"430 81 OFFCURVE",
+"413 141 CURVE SMOOTH",
+"392 216 OFFCURVE",
+"367 294 OFFCURVE",
+"339 379 CURVE",
+"340 304 LINE",
+"366 321 OFFCURVE",
+"392 339 OFFCURVE",
+"416 356 CURVE SMOOTH",
+"455 384 OFFCURVE",
+"495 420 OFFCURVE",
+"538 465 CURVE",
+"543 464 LINE",
+"564 387 OFFCURVE",
+"587 322 OFFCURVE",
+"607 249 CURVE SMOOTH",
+"626 181 OFFCURVE",
+"644 108 OFFCURVE",
+"663 24 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"621 349 LINE",
+"540 274 OFFCURVE",
+"473 223 OFFCURVE",
+"380 158 CURVE",
+"395 79 LINE",
+"499 151 OFFCURVE",
+"574 204 OFFCURVE",
+"662 284 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 873;
+}
+);
+unicode = 1B286;
+},
+{
+glyphname = u1B287;
+lastChange = "2020-04-13 09:16:52 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"516 -42 LINE",
+"630 79 OFFCURVE",
+"699 162 OFFCURVE",
+"783 290 CURVE",
+"719 331 LINE",
+"683 271 OFFCURVE",
+"650 223 OFFCURVE",
+"615 177 CURVE SMOOTH",
+"576 126 OFFCURVE",
+"535 77 OFFCURVE",
+"491 25 CURVE",
+"486 26 LINE",
+"459 123 OFFCURVE",
+"425 222 OFFCURVE",
+"391 308 CURVE SMOOTH",
+"347 418 OFFCURVE",
+"300 525 OFFCURVE",
+"226 670 CURVE",
+"241 604 LINE",
+"272 638 OFFCURVE",
+"302 671 OFFCURVE",
+"331 707 CURVE SMOOTH",
+"355 737 OFFCURVE",
+"390 788 OFFCURVE",
+"424 846 CURVE",
+"428 846 LINE",
+"457 788 OFFCURVE",
+"484 738 OFFCURVE",
+"508 689 CURVE SMOOTH",
+"538 628 OFFCURVE",
+"566 564 OFFCURVE",
+"597 488 CURVE",
+"587 579 LINE",
+"502 456 OFFCURVE",
+"442 389 OFFCURVE",
+"347 291 CURVE",
+"403 243 LINE",
+"499 340 OFFCURVE",
+"565 417 OFFCURVE",
+"656 545 CURVE",
+"595 683 OFFCURVE",
+"536 801 OFFCURVE",
+"466 914 CURVE",
+"390 914 LINE",
+"316 803 OFFCURVE",
+"253 725 OFFCURVE",
+"164 627 CURVE",
+"291 379 OFFCURVE",
+"351 215 OFFCURVE",
+"437 -32 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"497 754 LINE",
+"429 651 OFFCURVE",
+"356 564 OFFCURVE",
+"279 481 CURVE",
+"312 413 LINE",
+"404 509 OFFCURVE",
+"467 589 OFFCURVE",
+"540 691 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"553 239 OFFCURVE",
+"578 189 OFFCURVE",
+"600 139 CURVE",
+"618 112 LINE",
+"642 53 OFFCURVE",
+"663 -5 OFFCURVE",
+"683 -74 CURVE",
+"754 -55 LINE",
+"727 33 OFFCURVE",
+"702 102 OFFCURVE",
+"670 172 CURVE",
+"652 197 LINE",
+"632 240 OFFCURVE",
+"609 283 OFFCURVE",
+"581 332 CURVE",
+"522 297 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"118 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -103 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 863;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B274;
+unicode = 1B287;
+},
+{
+glyphname = u1B288;
+lastChange = "2020-04-13 09:17:06 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"752 164 OFFCURVE",
+"709 294 OFFCURVE",
+"659 406 CURVE",
+"585 422 LINE",
+"492 333 OFFCURVE",
+"388 249 OFFCURVE",
+"267 166 CURVE",
+"322 43 OFFCURVE",
+"368 -86 OFFCURVE",
+"395 -183 CURVE",
+"472 -203 LINE",
+"590 -132 OFFCURVE",
+"676 -65 OFFCURVE",
+"785 38 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"717 74 LINE",
+"674 34 OFFCURVE",
+"633 -2 OFFCURVE",
+"592 -34 CURVE SMOOTH",
+"537 -77 OFFCURVE",
+"505 -98 OFFCURVE",
+"457 -133 CURVE",
+"452 -132 LINE",
+"436 -61 OFFCURVE",
+"417 -5 OFFCURVE",
+"399 41 CURVE SMOOTH",
+"381 87 OFFCURVE",
+"361 136 OFFCURVE",
+"337 190 CURVE",
+"336 126 LINE",
+"384 159 OFFCURVE",
+"428 192 OFFCURVE",
+"469 224 CURVE SMOOTH",
+"527 270 OFFCURVE",
+"559 299 OFFCURVE",
+"603 348 CURVE",
+"608 347 LINE",
+"632 278 OFFCURVE",
+"650 229 OFFCURVE",
+"669 172 CURVE SMOOTH",
+"687 118 OFFCURVE",
+"702 66 OFFCURVE",
+"717 9 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"670 261 LINE",
+"573 169 OFFCURVE",
+"473 98 OFFCURVE",
+"359 21 CURVE",
+"391 -39 LINE",
+"510 37 OFFCURVE",
+"597 100 OFFCURVE",
+"697 189 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"302 356 LINE",
+"282 416 OFFCURVE",
+"261 462 OFFCURVE",
+"232 519 CURVE SMOOTH",
+"208 566 OFFCURVE",
+"179 615 OFFCURVE",
+"143 674 CURVE",
+"80 631 LINE",
+"159 512 OFFCURVE",
+"199 433 OFFCURVE",
+"252 306 CURVE",
+"327 289 LINE",
+"484 416 OFFCURVE",
+"591 519 OFFCURVE",
+"736 683 CURVE",
+"677 730 LINE",
+"602 639 OFFCURVE",
+"532 566 OFFCURVE",
+"457 495 CURVE SMOOTH",
+"405 445 OFFCURVE",
+"358 403 OFFCURVE",
+"307 355 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"550 939 LINE",
+"436 781 OFFCURVE",
+"347 677 OFFCURVE",
+"198 548 CURVE",
+"235 487 LINE",
+"390 624 OFFCURVE",
+"481 728 OFFCURVE",
+"611 900 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"217 838 LINE",
+"256 777 OFFCURVE",
+"292 718 OFFCURVE",
+"330 652 CURVE",
+"350 627 LINE",
+"386 562 OFFCURVE",
+"420 498 OFFCURVE",
+"450 432 CURVE",
+"494 497 LINE",
+"469 554 OFFCURVE",
+"439 614 OFFCURVE",
+"402 680 CURVE",
+"378 712 LINE",
+"349 763 OFFCURVE",
+"316 817 OFFCURVE",
+"278 877 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 875;
+}
+);
+leftMetricsKey = u1B1A2;
+rightMetricsKey = u1B1C8;
+unicode = 1B288;
+},
+{
+glyphname = u1B289;
+lastChange = "2020-04-13 09:20:20 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"641 570 LINE",
+"559 429 OFFCURVE",
+"496 345 OFFCURVE",
+"396 224 CURVE",
+"442 171 LINE",
+"535 278 OFFCURVE",
+"607 370 OFFCURVE",
+"683 490 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"158 779 LINE",
+"262 525 OFFCURVE",
+"348 280 OFFCURVE",
+"451 -43 CURVE",
+"534 -55 LINE",
+"617 35 OFFCURVE",
+"704 138 OFFCURVE",
+"786 260 CURVE",
+"732 457 OFFCURVE",
+"685 584 OFFCURVE",
+"605 799 CURVE",
+"554 719 LINE",
+"617 562 OFFCURVE",
+"669 410 OFFCURVE",
+"711 245 CURVE",
+"739 325 LINE",
+"706 272 OFFCURVE",
+"673 226 OFFCURVE",
+"640 183 CURVE SMOOTH",
+"596 125 OFFCURVE",
+"547 65 OFFCURVE",
+"509 16 CURVE",
+"504 17 LINE",
+"484 103 OFFCURVE",
+"456 180 OFFCURVE",
+"431 255 CURVE SMOOTH",
+"364 453 OFFCURVE",
+"303 619 OFFCURVE",
+"226 808 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"343 385 LINE",
+"448 514 OFFCURVE",
+"529 629 OFFCURVE",
+"686 904 CURVE",
+"618 939 LINE",
+"474 683 OFFCURVE",
+"403 578 OFFCURVE",
+"321 476 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"150 397 OFFCURVE",
+"173 414 OFFCURVE",
+"173 453 CURVE SMOOTH",
+"173 492 OFFCURVE",
+"150 509 OFFCURVE",
+"122 509 CURVE SMOOTH",
+"93 509 OFFCURVE",
+"70 492 OFFCURVE",
+"70 453 CURVE SMOOTH",
+"70 414 OFFCURVE",
+"93 397 OFFCURVE",
+"122 397 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"418 784 OFFCURVE",
+"441 801 OFFCURVE",
+"441 840 CURVE SMOOTH",
+"441 879 OFFCURVE",
+"418 896 OFFCURVE",
+"390 896 CURVE SMOOTH",
+"361 896 OFFCURVE",
+"338 879 OFFCURVE",
+"338 840 CURVE SMOOTH",
+"338 801 OFFCURVE",
+"361 784 OFFCURVE",
+"390 784 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"200 126 LINE",
+"217 45 LINE",
+"249 -17 OFFCURVE",
+"270 -64 OFFCURVE",
+"308 -165 CURVE",
+"379 -138 LINE",
+"333 -20 OFFCURVE",
+"288 60 OFFCURVE",
+"214 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"173 226 LINE",
+"156 60 OFFCURVE",
+"129 -53 OFFCURVE",
+"81 -183 CURVE",
+"153 -203 LINE",
+"188 -103 OFFCURVE",
+"202 -28 OFFCURVE",
+"212 44 CURVE",
+"231 49 LINE",
+"237 82 OFFCURVE",
+"243 186 OFFCURVE",
+"246 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 876;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B23E;
+unicode = 1B289;
+},
+{
+glyphname = u1B28A;
+lastChange = "2020-04-13 09:20:16 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"274 38 LINE",
+"288 48 OFFCURVE",
+"306 57 OFFCURVE",
+"317 65 CURVE SMOOTH",
+"374 104 OFFCURVE",
+"418 135 OFFCURVE",
+"480 188 CURVE",
+"485 187 LINE",
+"478 104 OFFCURVE",
+"472 51 OFFCURVE",
+"462 -19 CURVE SMOOTH",
+"454 -76 OFFCURVE",
+"445 -131 OFFCURVE",
+"435 -190 CURVE",
+"506 -203 LINE",
+"529 -77 OFFCURVE",
+"546 45 OFFCURVE",
+"552 227 CURVE",
+"474 264 LINE",
+"449 246 OFFCURVE",
+"425 228 OFFCURVE",
+"405 212 CURVE SMOOTH",
+"354 173 OFFCURVE",
+"314 143 OFFCURVE",
+"273 111 CURVE",
+"268 112 LINE",
+"269 172 OFFCURVE",
+"261 231 OFFCURVE",
+"252 297 CURVE SMOOTH",
+"235 424 OFFCURVE",
+"212 563 OFFCURVE",
+"184 702 CURVE",
+"176 646 LINE",
+"212 672 OFFCURVE",
+"247 696 OFFCURVE",
+"280 721 CURVE SMOOTH",
+"346 771 OFFCURVE",
+"380 800 OFFCURVE",
+"431 850 CURVE",
+"436 849 LINE",
+"453 774 OFFCURVE",
+"467 715 OFFCURVE",
+"480 645 CURVE SMOOTH",
+"491 585 OFFCURVE",
+"502 521 OFFCURVE",
+"513 450 CURVE",
+"528 534 LINE",
+"420 447 OFFCURVE",
+"306 382 OFFCURVE",
+"203 321 CURVE",
+"237 256 LINE",
+"356 325 OFFCURVE",
+"471 394 OFFCURVE",
+"584 480 CURVE",
+"558 636 OFFCURVE",
+"533 765 OFFCURVE",
+"498 900 CURVE",
+"411 919 LINE",
+"314 837 OFFCURVE",
+"221 767 OFFCURVE",
+"110 691 CURVE",
+"159 461 OFFCURVE",
+"185 272 OFFCURVE",
+"206 71 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"491 748 LINE",
+"379 652 OFFCURVE",
+"284 586 OFFCURVE",
+"179 519 CURVE",
+"215 458 LINE",
+"318 525 OFFCURVE",
+"406 587 OFFCURVE",
+"508 664 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"325 -134 OFFCURVE",
+"348 -117 OFFCURVE",
+"348 -78 CURVE SMOOTH",
+"348 -39 OFFCURVE",
+"325 -22 OFFCURVE",
+"297 -22 CURVE SMOOTH",
+"268 -22 OFFCURVE",
+"245 -39 OFFCURVE",
+"245 -78 CURVE SMOOTH",
+"245 -117 OFFCURVE",
+"268 -134 OFFCURVE",
+"297 -134 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"718 -18 OFFCURVE",
+"741 -1 OFFCURVE",
+"741 38 CURVE SMOOTH",
+"741 77 OFFCURVE",
+"718 94 OFFCURVE",
+"690 94 CURVE SMOOTH",
+"661 94 OFFCURVE",
+"638 77 OFFCURVE",
+"638 38 CURVE SMOOTH",
+"638 -1 OFFCURVE",
+"661 -18 OFFCURVE",
+"690 -18 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 801;
+}
+);
+leftMetricsKey = u1B1BB;
+unicode = 1B28A;
+},
+{
+glyphname = u1B28B;
+lastChange = "2020-04-13 09:20:12 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"377 221 LINE",
+"334 192 OFFCURVE",
+"289 165 OFFCURVE",
+"244 139 CURVE",
+"210 128 LINE",
+"160 102 OFFCURVE",
+"110 78 OFFCURVE",
+"60 55 CURVE",
+"89 -13 LINE",
+"141 10 OFFCURVE",
+"193 35 OFFCURVE",
+"243 62 CURVE",
+"278 74 LINE",
+"327 101 OFFCURVE",
+"374 129 OFFCURVE",
+"418 159 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"353 -92 LINE",
+"318 20 OFFCURVE",
+"272 144 OFFCURVE",
+"207 288 CURVE",
+"139 257 LINE",
+"195 133 OFFCURVE",
+"250 -7 OFFCURVE",
+"287 -126 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"441 22 LINE",
+"360 -40 OFFCURVE",
+"247 -98 OFFCURVE",
+"157 -135 CURVE",
+"186 -203 LINE",
+"299 -157 OFFCURVE",
+"399 -102 OFFCURVE",
+"485 -38 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"527 667 OFFCURVE",
+"440 452 OFFCURVE",
+"349 271 CURVE",
+"417 236 LINE",
+"515 434 OFFCURVE",
+"591 619 OFFCURVE",
+"664 923 CURVE",
+"590 939 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"308 598 OFFCURVE",
+"393 554 OFFCURVE",
+"475 508 CURVE",
+"511 492 LINE",
+"591 444 OFFCURVE",
+"668 395 OFFCURVE",
+"749 338 CURVE",
+"795 400 LINE",
+"717 455 OFFCURVE",
+"629 511 OFFCURVE",
+"535 565 CURVE",
+"501 579 LINE",
+"418 625 OFFCURVE",
+"331 670 OFFCURVE",
+"244 711 CURVE",
+"214 641 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"427 755 OFFCURVE",
+"450 772 OFFCURVE",
+"450 811 CURVE SMOOTH",
+"450 850 OFFCURVE",
+"427 867 OFFCURVE",
+"399 867 CURVE SMOOTH",
+"370 867 OFFCURVE",
+"347 850 OFFCURVE",
+"347 811 CURVE SMOOTH",
+"347 772 OFFCURVE",
+"370 755 OFFCURVE",
+"399 755 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"772 586 OFFCURVE",
+"795 603 OFFCURVE",
+"795 642 CURVE SMOOTH",
+"795 681 OFFCURVE",
+"772 698 OFFCURVE",
+"744 698 CURVE SMOOTH",
+"715 698 OFFCURVE",
+"692 681 OFFCURVE",
+"692 642 CURVE SMOOTH",
+"692 603 OFFCURVE",
+"715 586 OFFCURVE",
+"744 586 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"278 381 OFFCURVE",
+"301 398 OFFCURVE",
+"301 437 CURVE SMOOTH",
+"301 476 OFFCURVE",
+"278 493 OFFCURVE",
+"250 493 CURVE SMOOTH",
+"221 493 OFFCURVE",
+"198 476 OFFCURVE",
+"198 437 CURVE SMOOTH",
+"198 398 OFFCURVE",
+"221 381 OFFCURVE",
+"250 381 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"609 189 OFFCURVE",
+"632 206 OFFCURVE",
+"632 245 CURVE SMOOTH",
+"632 284 OFFCURVE",
+"609 301 OFFCURVE",
+"581 301 CURVE SMOOTH",
+"552 301 OFFCURVE",
+"529 284 OFFCURVE",
+"529 245 CURVE SMOOTH",
+"529 206 OFFCURVE",
+"552 189 OFFCURVE",
+"581 189 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 885;
+}
+);
+leftMetricsKey = u1B226;
+rightMetricsKey = u1B253;
+unicode = 1B28B;
+},
+{
+glyphname = u1B28C;
+lastChange = "2020-04-13 09:19:44 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"657 88 OFFCURVE",
+"577 213 OFFCURVE",
+"517 300 CURVE",
+"445 311 LINE",
+"379 237 OFFCURVE",
+"319 174 OFFCURVE",
+"242 109 CURVE",
+"310 9 OFFCURVE",
+"383 -98 OFFCURVE",
+"432 -190 CURVE",
+"506 -203 LINE",
+"571 -147 OFFCURVE",
+"637 -82 OFFCURVE",
+"706 -9 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"637 19 LINE",
+"616 -3 OFFCURVE",
+"598 -23 OFFCURVE",
+"579 -41 CURVE SMOOTH",
+"539 -78 OFFCURVE",
+"513 -110 OFFCURVE",
+"482 -140 CURVE",
+"478 -140 LINE",
+"455 -87 OFFCURVE",
+"430 -34 OFFCURVE",
+"407 1 CURVE SMOOTH",
+"376 47 OFFCURVE",
+"346 91 OFFCURVE",
+"320 129 CURVE",
+"310 80 LINE",
+"338 104 OFFCURVE",
+"362 126 OFFCURVE",
+"385 149 CURVE SMOOTH",
+"422 185 OFFCURVE",
+"439 203 OFFCURVE",
+"471 244 CURVE",
+"475 244 LINE",
+"502 195 OFFCURVE",
+"528 145 OFFCURVE",
+"549 112 CURVE SMOOTH",
+"580 63 OFFCURVE",
+"609 13 OFFCURVE",
+"631 -27 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"547 175 LINE",
+"483 103 OFFCURVE",
+"440 60 OFFCURVE",
+"374 1 CURVE",
+"403 -63 LINE",
+"472 -3 OFFCURVE",
+"527 51 OFFCURVE",
+"579 107 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"402 939 LINE",
+"298 802 OFFCURVE",
+"191 683 OFFCURVE",
+"70 568 CURVE",
+"121 515 LINE",
+"250 637 OFFCURVE",
+"351 752 OFFCURVE",
+"463 897 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"301 737 LINE",
+"457 526 OFFCURVE",
+"568 356 OFFCURVE",
+"718 116 CURVE",
+"778 154 LINE",
+"627 395 OFFCURVE",
+"522 551 OFFCURVE",
+"357 782 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"492 802 LINE",
+"464 766 OFFCURVE",
+"434 728 OFFCURVE",
+"403 692 CURVE",
+"378 670 LINE",
+"293 569 OFFCURVE",
+"202 472 OFFCURVE",
+"117 390 CURVE",
+"167 341 LINE",
+"256 429 OFFCURVE",
+"340 517 OFFCURVE",
+"419 608 CURVE",
+"445 632 LINE",
+"481 674 OFFCURVE",
+"515 717 OFFCURVE",
+"549 761 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"573 667 LINE",
+"543 631 OFFCURVE",
+"514 596 OFFCURVE",
+"486 563 CURVE",
+"468 549 LINE",
+"369 433 OFFCURVE",
+"276 332 OFFCURVE",
+"178 233 CURVE",
+"227 183 LINE",
+"329 287 OFFCURVE",
+"415 380 OFFCURVE",
+"505 484 CURVE",
+"531 507 LINE",
+"562 544 OFFCURVE",
+"595 583 OFFCURVE",
+"629 625 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 858;
+}
+);
+leftMetricsKey = u1B1F8;
+rightMetricsKey = u1B1F8;
+unicode = 1B28C;
+},
+{
+glyphname = u1B28D;
+lastChange = "2020-04-13 09:19:28 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"613 508 LINE",
+"521 410 OFFCURVE",
+"457 366 OFFCURVE",
+"356 292 CURVE",
+"412 181 OFFCURVE",
+"429 114 OFFCURVE",
+"429 34 CURVE SMOOTH",
+"429 -46 OFFCURVE",
+"416 -101 OFFCURVE",
+"383 -178 CURVE",
+"449 -203 LINE",
+"488 -120 OFFCURVE",
+"503 -51 OFFCURVE",
+"503 34 CURVE SMOOTH",
+"503 111 OFFCURVE",
+"482 193 OFFCURVE",
+"428 310 CURVE",
+"428 256 LINE",
+"511 317 OFFCURVE",
+"587 370 OFFCURVE",
+"666 460 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"578 677 LINE",
+"469 573 OFFCURVE",
+"366 490 OFFCURVE",
+"241 397 CURVE",
+"281 337 LINE",
+"417 439 OFFCURVE",
+"508 511 OFFCURVE",
+"628 625 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 861 LINE",
+"313 687 OFFCURVE",
+"364 565 OFFCURVE",
+"400 450 CURVE",
+"460 496 LINE",
+"421 615 OFFCURVE",
+"384 714 OFFCURVE",
+"289 895 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"634 71 LINE",
+"624 124 OFFCURVE",
+"613 157 OFFCURVE",
+"590 204 CURVE",
+"532 175 LINE",
+"555 121 OFFCURVE",
+"567 91 OFFCURVE",
+"587 28 CURVE",
+"678 19 LINE",
+"715 91 OFFCURVE",
+"734 152 OFFCURVE",
+"734 201 CURVE SMOOTH",
+"734 280 OFFCURVE",
+"703 353 OFFCURVE",
+"600 452 CURVE",
+"565 394 LINE",
+"643 314 OFFCURVE",
+"658 272 OFFCURVE",
+"658 194 CURVE SMOOTH",
+"658 156 OFFCURVE",
+"652 122 OFFCURVE",
+"638 71 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 -35 OFFCURVE",
+"109 -83 OFFCURVE",
+"177 -123 CURVE",
+"248 -114 LINE",
+"316 -35 OFFCURVE",
+"334 30 OFFCURVE",
+"334 91 CURVE SMOOTH",
+"334 151 OFFCURVE",
+"300 192 OFFCURVE",
+"232 230 CURVE",
+"158 220 LINE",
+"100 138 OFFCURVE",
+"80 71 OFFCURVE",
+"80 22 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 176 LINE",
+"244 144 OFFCURVE",
+"259 109 OFFCURVE",
+"259 80 CURVE SMOOTH",
+"259 37 OFFCURVE",
+"249 -8 OFFCURVE",
+"209 -72 CURVE",
+"204 -73 LINE",
+"169 -38 OFFCURVE",
+"154 -7 OFFCURVE",
+"154 26 CURVE SMOOTH",
+"154 68 OFFCURVE",
+"167 112 OFFCURVE",
+"199 175 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"564 939 LINE",
+"485 856 OFFCURVE",
+"417 790 OFFCURVE",
+"348 730 CURVE",
+"322 718 LINE",
+"266 670 OFFCURVE",
+"208 625 OFFCURVE",
+"141 577 CURVE",
+"182 519 LINE",
+"241 562 OFFCURVE",
+"295 603 OFFCURVE",
+"347 645 CURVE",
+"376 659 LINE",
+"452 724 OFFCURVE",
+"529 796 OFFCURVE",
+"619 892 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 834;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B18D;
+unicode = 1B28D;
+},
+{
+glyphname = u1B28E;
+lastChange = "2020-04-13 09:19:12 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"239 -20 LINE",
+"300 18 OFFCURVE",
+"357 56 OFFCURVE",
+"410 95 CURVE",
+"431 105 LINE",
+"435 108 OFFCURVE",
+"438 110 OFFCURVE",
+"442 113 CURVE SMOOTH",
+"489 149 OFFCURVE",
+"540 189 OFFCURVE",
+"584 242 CURVE",
+"588 242 LINE",
+"608 171 OFFCURVE",
+"622 120 OFFCURVE",
+"634 51 CURVE SMOOTH",
+"641 12 OFFCURVE",
+"646 -27 OFFCURVE",
+"650 -68 CURVE",
+"725 -56 LINE",
+"704 80 OFFCURVE",
+"680 188 OFFCURVE",
+"639 299 CURVE",
+"564 310 LINE",
+"519 265 OFFCURVE",
+"474 226 OFFCURVE",
+"426 189 CURVE",
+"397 174 LINE",
+"339 132 OFFCURVE",
+"276 91 OFFCURVE",
+"200 43 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"352 306 LINE",
+"393 111 OFFCURVE",
+"414 -18 OFFCURVE",
+"421 -203 CURVE",
+"497 -197 LINE",
+"485 -1 OFFCURVE",
+"469 125 OFFCURVE",
+"422 321 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"543 909 LINE",
+"386 792 OFFCURVE",
+"235 695 OFFCURVE",
+"70 603 CURVE",
+"104 453 OFFCURVE",
+"124 341 OFFCURVE",
+"141 219 CURVE",
+"237 206 LINE",
+"278 270 OFFCURVE",
+"307 329 OFFCURVE",
+"322 366 CURVE SMOOTH",
+"340 410 OFFCURVE",
+"357 458 OFFCURVE",
+"370 529 CURVE",
+"375 530 LINE",
+"418 489 OFFCURVE",
+"444 460 OFFCURVE",
+"469 436 CURVE SMOOTH",
+"489 417 OFFCURVE",
+"507 400 OFFCURVE",
+"526 378 CURVE",
+"618 408 LINE",
+"640 567 OFFCURVE",
+"639 673 OFFCURVE",
+"631 871 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"561 830 LINE",
+"561 768 OFFCURVE",
+"560 708 OFFCURVE",
+"560 656 CURVE SMOOTH",
+"560 641 OFFCURVE",
+"559 626 OFFCURVE",
+"559 612 CURVE SMOOTH",
+"559 566 OFFCURVE",
+"557 503 OFFCURVE",
+"554 450 CURVE",
+"549 449 LINE",
+"508 495 OFFCURVE",
+"476 529 OFFCURVE",
+"447 557 CURVE SMOOTH",
+"428 574 OFFCURVE",
+"413 585 OFFCURVE",
+"395 599 CURVE",
+"320 569 LINE",
+"307 528 OFFCURVE",
+"294 489 OFFCURVE",
+"279 451 CURVE SMOOTH",
+"251 382 OFFCURVE",
+"230 329 OFFCURVE",
+"201 267 CURVE",
+"196 268 LINE",
+"194 359 OFFCURVE",
+"181 422 OFFCURVE",
+"172 475 CURVE SMOOTH",
+"166 512 OFFCURVE",
+"157 554 OFFCURVE",
+"147 603 CURVE",
+"126 550 LINE",
+"219 601 OFFCURVE",
+"314 660 OFFCURVE",
+"403 719 CURVE SMOOTH",
+"463 759 OFFCURVE",
+"503 788 OFFCURVE",
+"556 831 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 845;
+}
+);
+leftMetricsKey = u1B272;
+rightMetricsKey = u1B239;
+unicode = 1B28E;
+},
+{
+glyphname = u1B28F;
+lastChange = "2020-04-13 09:18:59 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"284 319 LINE",
+"231 219 OFFCURVE",
+"153 108 OFFCURVE",
+"60 18 CURVE",
+"109 -32 LINE",
+"197 54 OFFCURVE",
+"290 183 OFFCURVE",
+"348 287 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"65 218 LINE",
+"113 191 OFFCURVE",
+"155 166 OFFCURVE",
+"194 140 CURVE",
+"223 116 LINE",
+"272 81 OFFCURVE",
+"317 45 OFFCURVE",
+"363 1 CURVE",
+"412 52 LINE",
+"361 99 OFFCURVE",
+"311 139 OFFCURVE",
+"257 176 CURVE",
+"227 202 LINE",
+"188 227 OFFCURVE",
+"147 252 OFFCURVE",
+"102 278 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"207 19 LINE",
+"207 -62 OFFCURVE",
+"202 -136 OFFCURVE",
+"192 -194 CURVE",
+"264 -203 LINE",
+"272 -138 OFFCURVE",
+"277 -70 OFFCURVE",
+"277 19 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"585 392 LINE",
+"511 557 OFFCURVE",
+"429 702 OFFCURVE",
+"307 898 CURVE",
+"244 857 LINE",
+"358 684 OFFCURVE",
+"451 510 OFFCURVE",
+"517 361 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"656 848 LINE",
+"570 760 OFFCURVE",
+"502 697 OFFCURVE",
+"431 637 CURVE",
+"409 626 LINE",
+"350 577 OFFCURVE",
+"288 529 OFFCURVE",
+"211 470 CURVE",
+"256 410 LINE",
+"333 468 OFFCURVE",
+"393 514 OFFCURVE",
+"449 561 CURVE",
+"471 572 LINE",
+"544 634 OFFCURVE",
+"613 699 OFFCURVE",
+"709 795 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"701 558 LINE",
+"605 465 OFFCURVE",
+"503 385 OFFCURVE",
+"375 296 CURVE",
+"416 235 LINE",
+"544 323 OFFCURVE",
+"655 410 OFFCURVE",
+"754 506 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"505 827 OFFCURVE",
+"528 844 OFFCURVE",
+"528 883 CURVE SMOOTH",
+"528 922 OFFCURVE",
+"505 939 OFFCURVE",
+"477 939 CURVE SMOOTH",
+"448 939 OFFCURVE",
+"425 922 OFFCURVE",
+"425 883 CURVE SMOOTH",
+"425 844 OFFCURVE",
+"448 827 OFFCURVE",
+"477 827 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"218 600 OFFCURVE",
+"241 617 OFFCURVE",
+"241 656 CURVE SMOOTH",
+"241 695 OFFCURVE",
+"218 712 OFFCURVE",
+"190 712 CURVE SMOOTH",
+"161 712 OFFCURVE",
+"138 695 OFFCURVE",
+"138 656 CURVE SMOOTH",
+"138 617 OFFCURVE",
+"161 600 OFFCURVE",
+"190 600 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"772 369 LINE",
+"670 279 OFFCURVE",
+"547 186 OFFCURVE",
+"446 118 CURVE",
+"487 56 LINE",
+"606 138 OFFCURVE",
+"712 216 OFFCURVE",
+"822 314 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 892;
+}
+);
+leftMetricsKey = u1B1C9;
+rightMetricsKey = u1B1C6;
+unicode = 1B28F;
+},
+{
+glyphname = u1B290;
+lastChange = "2020-04-13 09:18:39 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"196 148 OFFCURVE",
+"173 102 OFFCURVE",
+"173 46 CURVE SMOOTH",
+"173 -54 OFFCURVE",
+"238 -114 OFFCURVE",
+"340 -133 CURVE",
+"358 -66 LINE",
+"277 -46 OFFCURVE",
+"245 -8 OFFCURVE",
+"245 55 CURVE SMOOTH",
+"245 102 OFFCURVE",
+"264 133 OFFCURVE",
+"313 157 CURVE",
+"292 249 LINE",
+"190 243 OFFCURVE",
+"140 280 OFFCURVE",
+"140 356 CURVE SMOOTH",
+"140 395 OFFCURVE",
+"152 424 OFFCURVE",
+"185 451 CURVE",
+"139 500 LINE",
+"90 461 OFFCURVE",
+"70 408 OFFCURVE",
+"70 354 CURVE SMOOTH",
+"70 295 OFFCURVE",
+"91 251 OFFCURVE",
+"130 221 CURVE SMOOTH",
+"161 197 OFFCURVE",
+"194 189 OFFCURVE",
+"245 189 CURVE",
+"246 184 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"613 508 LINE",
+"521 410 OFFCURVE",
+"457 366 OFFCURVE",
+"356 292 CURVE",
+"412 181 OFFCURVE",
+"429 114 OFFCURVE",
+"429 34 CURVE SMOOTH",
+"429 -46 OFFCURVE",
+"416 -101 OFFCURVE",
+"383 -178 CURVE",
+"449 -203 LINE",
+"488 -120 OFFCURVE",
+"503 -51 OFFCURVE",
+"503 34 CURVE SMOOTH",
+"503 111 OFFCURVE",
+"482 193 OFFCURVE",
+"428 310 CURVE",
+"428 256 LINE",
+"511 317 OFFCURVE",
+"587 370 OFFCURVE",
+"666 460 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"564 939 LINE",
+"485 856 OFFCURVE",
+"417 790 OFFCURVE",
+"348 730 CURVE",
+"322 718 LINE",
+"266 670 OFFCURVE",
+"208 625 OFFCURVE",
+"141 577 CURVE",
+"182 519 LINE",
+"241 562 OFFCURVE",
+"295 603 OFFCURVE",
+"347 645 CURVE",
+"376 659 LINE",
+"452 724 OFFCURVE",
+"529 796 OFFCURVE",
+"619 892 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"578 677 LINE",
+"469 573 OFFCURVE",
+"366 490 OFFCURVE",
+"241 397 CURVE",
+"281 337 LINE",
+"417 439 OFFCURVE",
+"508 511 OFFCURVE",
+"628 625 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 861 LINE",
+"313 687 OFFCURVE",
+"364 565 OFFCURVE",
+"400 450 CURVE",
+"460 496 LINE",
+"421 615 OFFCURVE",
+"384 714 OFFCURVE",
+"289 895 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"634 71 LINE",
+"624 124 OFFCURVE",
+"613 157 OFFCURVE",
+"590 204 CURVE",
+"532 175 LINE",
+"555 121 OFFCURVE",
+"567 91 OFFCURVE",
+"587 28 CURVE",
+"678 19 LINE",
+"715 91 OFFCURVE",
+"734 152 OFFCURVE",
+"734 201 CURVE SMOOTH",
+"734 280 OFFCURVE",
+"703 353 OFFCURVE",
+"600 452 CURVE",
+"565 394 LINE",
+"643 314 OFFCURVE",
+"658 272 OFFCURVE",
+"658 194 CURVE SMOOTH",
+"658 156 OFFCURVE",
+"652 122 OFFCURVE",
+"638 71 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 834;
+}
+);
+leftMetricsKey = u1B1D0;
+rightMetricsKey = u1B18D;
+unicode = 1B290;
+},
+{
+glyphname = u1B291;
+lastChange = "2020-04-13 09:18:25 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"612 -118 OFFCURVE",
+"635 -101 OFFCURVE",
+"635 -62 CURVE SMOOTH",
+"635 -23 OFFCURVE",
+"612 -6 OFFCURVE",
+"584 -6 CURVE SMOOTH",
+"555 -6 OFFCURVE",
+"532 -23 OFFCURVE",
+"532 -62 CURVE SMOOTH",
+"532 -101 OFFCURVE",
+"555 -118 OFFCURVE",
+"584 -118 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"755 25 OFFCURVE",
+"778 42 OFFCURVE",
+"778 81 CURVE SMOOTH",
+"778 120 OFFCURVE",
+"755 137 OFFCURVE",
+"727 137 CURVE SMOOTH",
+"698 137 OFFCURVE",
+"675 120 OFFCURVE",
+"675 81 CURVE SMOOTH",
+"675 42 OFFCURVE",
+"698 25 OFFCURVE",
+"727 25 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"885 176 OFFCURVE",
+"908 193 OFFCURVE",
+"908 232 CURVE SMOOTH",
+"908 271 OFFCURVE",
+"885 288 OFFCURVE",
+"857 288 CURVE SMOOTH",
+"828 288 OFFCURVE",
+"805 271 OFFCURVE",
+"805 232 CURVE SMOOTH",
+"805 193 OFFCURVE",
+"828 176 OFFCURVE",
+"857 176 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"229 145 OFFCURVE",
+"207 90 OFFCURVE",
+"207 32 CURVE SMOOTH",
+"207 -105 OFFCURVE",
+"294 -203 OFFCURVE",
+"482 -203 CURVE",
+"485 -131 LINE",
+"336 -131 OFFCURVE",
+"281 -68 OFFCURVE",
+"281 37 CURVE SMOOTH",
+"281 98 OFFCURVE",
+"304 141 OFFCURVE",
+"360 169 CURVE",
+"340 257 LINE",
+"206 257 OFFCURVE",
+"144 318 OFFCURVE",
+"144 432 CURVE SMOOTH",
+"144 502 OFFCURVE",
+"169 548 OFFCURVE",
+"229 593 CURVE",
+"186 648 LINE",
+"106 593 OFFCURVE",
+"70 515 OFFCURVE",
+"70 429 CURVE SMOOTH",
+"70 297 OFFCURVE",
+"149 200 OFFCURVE",
+"290 199 CURVE",
+"291 194 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"680 623 LINE",
+"637 568 OFFCURVE",
+"599 521 OFFCURVE",
+"559 478 CURVE",
+"535 458 LINE",
+"488 407 OFFCURVE",
+"440 359 OFFCURVE",
+"383 307 CURVE",
+"429 256 LINE",
+"480 304 OFFCURVE",
+"521 344 OFFCURVE",
+"561 385 CURVE",
+"588 408 LINE",
+"636 459 OFFCURVE",
+"682 513 OFFCURVE",
+"737 585 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"661 939 LINE",
+"543 748 OFFCURVE",
+"434 624 OFFCURVE",
+"284 479 CURVE",
+"333 429 LINE",
+"469 558 OFFCURVE",
+"600 706 OFFCURVE",
+"723 905 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"765 436 LINE",
+"664 298 OFFCURVE",
+"564 185 OFFCURVE",
+"436 85 CURVE",
+"479 31 LINE",
+"617 142 OFFCURVE",
+"724 259 OFFCURVE",
+"825 397 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"470 589 LINE",
+"520 459 OFFCURVE",
+"550 343 OFFCURVE",
+"582 201 CURVE",
+"646 237 LINE",
+"612 388 OFFCURVE",
+"573 519 OFFCURVE",
+"517 670 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 978;
+}
+);
+leftMetricsKey = u1B1D0;
+rightMetricsKey = u1B262;
+unicode = 1B291;
+},
+{
+glyphname = u1B292;
+lastChange = "2020-04-13 09:18:15 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"674 81 LINE",
+"655 265 OFFCURVE",
+"635 383 OFFCURVE",
+"596 527 CURVE",
+"506 554 LINE",
+"399 477 OFFCURVE",
+"290 422 OFFCURVE",
+"160 366 CURVE",
+"184 261 OFFCURVE",
+"194 156 OFFCURVE",
+"194 48 CURVE SMOOTH",
+"194 -44 OFFCURVE",
+"192 -111 OFFCURVE",
+"178 -194 CURVE",
+"249 -203 LINE",
+"263 -122 OFFCURVE",
+"268 -48 OFFCURVE",
+"268 47 CURVE SMOOTH",
+"268 151 OFFCURVE",
+"256 252 OFFCURVE",
+"234 373 CURVE",
+"222 317 LINE",
+"270 336 OFFCURVE",
+"317 357 OFFCURVE",
+"362 380 CURVE SMOOTH",
+"418 409 OFFCURVE",
+"460 433 OFFCURVE",
+"526 481 CURVE",
+"531 480 LINE",
+"551 399 OFFCURVE",
+"563 349 OFFCURVE",
+"576 276 CURVE SMOOTH",
+"587 212 OFFCURVE",
+"595 145 OFFCURVE",
+"602 71 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"280 249 LINE",
+"318 223 OFFCURVE",
+"362 190 OFFCURVE",
+"405.998 154.007 CURVE",
+"434 136 LINE",
+"468 107 OFFCURVE",
+"501 77 OFFCURVE",
+"529 46 CURVE",
+"577 90 LINE",
+"541 128 OFFCURVE",
+"501 166 OFFCURVE",
+"460 201 CURVE",
+"431 220 LINE",
+"393 252 OFFCURVE",
+"355 281 OFFCURVE",
+"317 306 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"451 396 LINE",
+"426 234 OFFCURVE",
+"383 112 OFFCURVE",
+"317 -23 CURVE",
+"380 -53 LINE",
+"447 81 OFFCURVE",
+"493 217 OFFCURVE",
+"520 383 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"198 720 OFFCURVE",
+"221 737 OFFCURVE",
+"221 776 CURVE SMOOTH",
+"221 815 OFFCURVE",
+"198 832 OFFCURVE",
+"170 832 CURVE SMOOTH",
+"141 832 OFFCURVE",
+"118 815 OFFCURVE",
+"118 776 CURVE SMOOTH",
+"118 737 OFFCURVE",
+"141 720 OFFCURVE",
+"170 720 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"717 759 OFFCURVE",
+"740 776 OFFCURVE",
+"740 815 CURVE SMOOTH",
+"740 854 OFFCURVE",
+"717 871 OFFCURVE",
+"689 871 CURVE SMOOTH",
+"660 871 OFFCURVE",
+"637 854 OFFCURVE",
+"637 815 CURVE SMOOTH",
+"637 776 OFFCURVE",
+"660 759 OFFCURVE",
+"689 759 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"430 939 LINE",
+"344 714 OFFCURVE",
+"249 609 OFFCURVE",
+"80 475 CURVE",
+"125 419 LINE",
+"302 562 OFFCURVE",
+"403 673 OFFCURVE",
+"502 915 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"402 760 LINE",
+"529 650 OFFCURVE",
+"632 541 OFFCURVE",
+"736 419 CURVE",
+"789 470 LINE",
+"677 599 OFFCURVE",
+"566 711 OFFCURVE",
+"433 823 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 879;
+}
+);
+leftMetricsKey = u1B185;
+rightMetricsKey = u1B185;
+unicode = 1B292;
+},
+{
+glyphname = u1B293;
+lastChange = "2020-04-13 09:18:05 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"198 720 OFFCURVE",
+"221 737 OFFCURVE",
+"221 776 CURVE SMOOTH",
+"221 815 OFFCURVE",
+"198 832 OFFCURVE",
+"170 832 CURVE SMOOTH",
+"141 832 OFFCURVE",
+"118 815 OFFCURVE",
+"118 776 CURVE SMOOTH",
+"118 737 OFFCURVE",
+"141 720 OFFCURVE",
+"170 720 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"717 759 OFFCURVE",
+"740 776 OFFCURVE",
+"740 815 CURVE SMOOTH",
+"740 854 OFFCURVE",
+"717 871 OFFCURVE",
+"689 871 CURVE SMOOTH",
+"660 871 OFFCURVE",
+"637 854 OFFCURVE",
+"637 815 CURVE SMOOTH",
+"637 776 OFFCURVE",
+"660 759 OFFCURVE",
+"689 759 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"441 525 LINE",
+"467 484 OFFCURVE",
+"486 458 OFFCURVE",
+"514 419 CURVE SMOOTH",
+"550 368 OFFCURVE",
+"585 314 OFFCURVE",
+"618 256 CURVE",
+"626 343 LINE",
+"572 267 OFFCURVE",
+"518 195 OFFCURVE",
+"452 113 CURVE",
+"421 78 LINE",
+"362 5 OFFCURVE",
+"295 -75 OFFCURVE",
+"223 -157 CURVE",
+"278 -203 LINE",
+"344 -126 OFFCURVE",
+"404 -55 OFFCURVE",
+"469 22 CURVE",
+"490 47 LINE",
+"566 141 OFFCURVE",
+"627 219 OFFCURVE",
+"682 296 CURVE",
+"623 391 OFFCURVE",
+"546 500 OFFCURVE",
+"478 587 CURVE",
+"398 587 LINE",
+"341 501 OFFCURVE",
+"287 438 OFFCURVE",
+"207 347 CURVE",
+"341 164 OFFCURVE",
+"434 31 OFFCURVE",
+"569 -177 CURVE",
+"633 -136 LINE",
+"512 52 OFFCURVE",
+"390 224 OFFCURVE",
+"278 377 CURVE",
+"291 337 LINE",
+"316 365 OFFCURVE",
+"338 391 OFFCURVE",
+"360 417 CURVE SMOOTH",
+"381 442 OFFCURVE",
+"405 475 OFFCURVE",
+"437 525 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"516 452 LINE",
+"459 372 OFFCURVE",
+"413 317 OFFCURVE",
+"349 251 CURVE",
+"386 199 LINE",
+"458 274 OFFCURVE",
+"505 331 OFFCURVE",
+"559 406 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"430 939 LINE",
+"344 714 OFFCURVE",
+"249 609 OFFCURVE",
+"80 475 CURVE",
+"125 419 LINE",
+"302 562 OFFCURVE",
+"403 673 OFFCURVE",
+"502 915 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"402 760 LINE",
+"529 650 OFFCURVE",
+"632 541 OFFCURVE",
+"736 419 CURVE",
+"789 470 LINE",
+"677 599 OFFCURVE",
+"566 711 OFFCURVE",
+"433 823 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 879;
+}
+);
+leftMetricsKey = u1B185;
+rightMetricsKey = u1B185;
+unicode = 1B293;
+},
+{
+glyphname = u1B294;
+lastChange = "2020-04-13 09:18:00 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"645 789 LINE",
+"550 741 OFFCURVE",
+"463 703 OFFCURVE",
+"377 669 CURVE",
+"337 656 LINE",
+"249 624 OFFCURVE",
+"160 596 OFFCURVE",
+"60 569 CURVE",
+"79 497 LINE",
+"180 526 OFFCURVE",
+"267 552 OFFCURVE",
+"351 583 CURVE",
+"396 597 LINE",
+"487 632 OFFCURVE",
+"577 672 OFFCURVE",
+"681 724 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"684 574 LINE",
+"596 531 OFFCURVE",
+"509 495 OFFCURVE",
+"420 464 CURVE",
+"379 453 LINE",
+"287 424 OFFCURVE",
+"193 400 OFFCURVE",
+"91 379 CURVE",
+"108 307 LINE",
+"212 329 OFFCURVE",
+"302 352 OFFCURVE",
+"389 379 CURVE",
+"435 392 LINE",
+"528 423 OFFCURVE",
+"618 460 OFFCURVE",
+"720 508 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"146 687 OFFCURVE",
+"169 704 OFFCURVE",
+"169 743 CURVE SMOOTH",
+"169 782 OFFCURVE",
+"146 799 OFFCURVE",
+"118 799 CURVE SMOOTH",
+"89 799 OFFCURVE",
+"66 782 OFFCURVE",
+"66 743 CURVE SMOOTH",
+"66 704 OFFCURVE",
+"89 687 OFFCURVE",
+"118 687 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"527 827 OFFCURVE",
+"550 844 OFFCURVE",
+"550 883 CURVE SMOOTH",
+"550 922 OFFCURVE",
+"527 939 OFFCURVE",
+"499 939 CURVE SMOOTH",
+"470 939 OFFCURVE",
+"447 922 OFFCURVE",
+"447 883 CURVE SMOOTH",
+"447 844 OFFCURVE",
+"470 827 OFFCURVE",
+"499 827 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"92 10 OFFCURVE",
+"118 -39 OFFCURVE",
+"185 -73 CURVE",
+"260 -64 LINE",
+"310 3 OFFCURVE",
+"331 58 OFFCURVE",
+"331 100 CURVE SMOOTH",
+"331 149 OFFCURVE",
+"310 189 OFFCURVE",
+"240 241 CURVE",
+"166 233 LINE",
+"113 165 OFFCURVE",
+"92 106 OFFCURVE",
+"92 58 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"210 184 LINE",
+"247 153 OFFCURVE",
+"261 129 OFFCURVE",
+"261 99 CURVE SMOOTH",
+"261 62 OFFCURVE",
+"247 25 OFFCURVE",
+"217 -23 CURVE",
+"213 -23 LINE",
+"178 5 OFFCURVE",
+"162 35 OFFCURVE",
+"162 68 CURVE SMOOTH",
+"162 99 OFFCURVE",
+"174 136 OFFCURVE",
+"206 184 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"540 129 OFFCURVE",
+"566 80 OFFCURVE",
+"633 46 CURVE",
+"708 53 LINE",
+"758 120 OFFCURVE",
+"779 177 OFFCURVE",
+"779 219 CURVE SMOOTH",
+"779 268 OFFCURVE",
+"758 306 OFFCURVE",
+"688 358 CURVE",
+"614 352 LINE",
+"561 284 OFFCURVE",
+"540 225 OFFCURVE",
+"540 177 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"229 910 LINE",
+"370 595 OFFCURVE",
+"396 281 OFFCURVE",
+"396 68 CURVE SMOOTH",
+"396 -57 OFFCURVE",
+"392 -115 OFFCURVE",
+"382 -193 CURVE",
+"457 -203 LINE",
+"467 -124 OFFCURVE",
+"472 -57 OFFCURVE",
+"472 68 CURVE SMOOTH",
+"472 327 OFFCURVE",
+"425 635 OFFCURVE",
+"298 939 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"657 303 LINE",
+"694 272 OFFCURVE",
+"708 248 OFFCURVE",
+"708 218 CURVE SMOOTH",
+"708 181 OFFCURVE",
+"694 144 OFFCURVE",
+"664 96 CURVE",
+"660 96 LINE",
+"625 124 OFFCURVE",
+"609 154 OFFCURVE",
+"609 187 CURVE SMOOTH",
+"609 218 OFFCURVE",
+"621 255 OFFCURVE",
+"653 303 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 869;
+}
+);
+leftMetricsKey = u1B187;
+rightMetricsKey = u1B187;
+unicode = 1B294;
+},
+{
+glyphname = u1B295;
+lastChange = "2020-04-13 09:17:57 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"720 254 LINE",
+"753 254 LINE",
+"781 188 OFFCURVE",
+"799 148 OFFCURVE",
+"830 62 CURVE",
+"896 89 LINE",
+"860 177 OFFCURVE",
+"823 246 OFFCURVE",
+"769 326 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"709 385 LINE",
+"686 240 OFFCURVE",
+"671 175 OFFCURVE",
+"632 57 CURVE",
+"699 39 LINE",
+"723 113 OFFCURVE",
+"735 166 OFFCURVE",
+"749 254 CURVE",
+"766 301 LINE",
+"770 325 OFFCURVE",
+"774 351 OFFCURVE",
+"777 378 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"176 267 LINE",
+"204 267 LINE",
+"231 217 OFFCURVE",
+"256 165 OFFCURVE",
+"287 79 CURVE",
+"353 106 LINE",
+"317 194 OFFCURVE",
+"280 263 OFFCURVE",
+"226 343 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"166 402 LINE",
+"143 257 OFFCURVE",
+"125 175 OFFCURVE",
+"80 41 CURVE",
+"146 22 LINE",
+"176 112 OFFCURVE",
+"186 179 OFFCURVE",
+"200 267 CURVE",
+"222 317 LINE",
+"226 341 OFFCURVE",
+"232 365 OFFCURVE",
+"235 392 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"539 713 LINE",
+"482 606 OFFCURVE",
+"429 529 OFFCURVE",
+"349 422 CURVE",
+"391 353 LINE",
+"466 454 OFFCURVE",
+"532 548 OFFCURVE",
+"590 649 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"454 842 LINE",
+"497 765 OFFCURVE",
+"524 719 OFFCURVE",
+"566 647 CURVE SMOOTH",
+"587 611 OFFCURVE",
+"628 533 OFFCURVE",
+"674 440 CURVE",
+"679 544 LINE",
+"612 433 OFFCURVE",
+"542 324 OFFCURVE",
+"465 211 CURVE",
+"440 183 LINE",
+"366 75 OFFCURVE",
+"285 -37 OFFCURVE",
+"195 -158 CURVE",
+"254 -203 LINE",
+"335 -95 OFFCURVE",
+"411 9 OFFCURVE",
+"482 111 CURVE",
+"506 137 LINE",
+"588 257 OFFCURVE",
+"664 373 OFFCURVE",
+"736 489 CURVE",
+"654 649 OFFCURVE",
+"579 779 OFFCURVE",
+"492 910 CURVE",
+"405 908 LINE",
+"345 791 OFFCURVE",
+"281 688 OFFCURVE",
+"191 559 CURVE",
+"372 274 OFFCURVE",
+"467 102 OFFCURVE",
+"589 -161 CURVE",
+"658 -130 LINE",
+"534 138 OFFCURVE",
+"427 329 OFFCURVE",
+"251 607 CURVE",
+"257 520 LINE",
+"293 573 OFFCURVE",
+"316 606 OFFCURVE",
+"346 653 CURVE SMOOTH",
+"387 717 OFFCURVE",
+"420 774 OFFCURVE",
+"450 842 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 976;
+}
+);
+leftMetricsKey = u1B21E;
+unicode = 1B295;
+},
+{
+glyphname = u1B296;
+lastChange = "2020-04-13 09:17:43 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"735 189 OFFCURVE",
+"689 347 OFFCURVE",
+"646 466 CURVE",
+"568 479 LINE",
+"492 393 OFFCURVE",
+"403 314 OFFCURVE",
+"284 222 CURVE",
+"337 75 OFFCURVE",
+"367 -34 OFFCURVE",
+"400 -166 CURVE",
+"478 -183 LINE",
+"579 -115 OFFCURVE",
+"677 -40 OFFCURVE",
+"762 47 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"696 87 LINE",
+"661 51 OFFCURVE",
+"626 19 OFFCURVE",
+"588 -11 CURVE SMOOTH",
+"541 -48 OFFCURVE",
+"508 -78 OFFCURVE",
+"462 -115 CURVE",
+"457 -114 LINE",
+"445 -44 OFFCURVE",
+"428 23 OFFCURVE",
+"409 83 CURVE SMOOTH",
+"393 134 OFFCURVE",
+"375 188 OFFCURVE",
+"354 246 CURVE",
+"352 184 LINE",
+"390 212 OFFCURVE",
+"429 243 OFFCURVE",
+"466 275 CURVE SMOOTH",
+"510 313 OFFCURVE",
+"546 354 OFFCURVE",
+"590 410 CURVE",
+"595 409 LINE",
+"612 342 OFFCURVE",
+"629 284 OFFCURVE",
+"646 220 CURVE SMOOTH",
+"664 154 OFFCURVE",
+"680 86 OFFCURVE",
+"693 18 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"641 290 LINE",
+"558 201 OFFCURVE",
+"482 142 OFFCURVE",
+"381 67 CURVE",
+"408 0 LINE",
+"514 75 OFFCURVE",
+"597 139 OFFCURVE",
+"689 235 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"495 332 LINE",
+"435 509 OFFCURVE",
+"363 674 OFFCURVE",
+"250 886 CURVE",
+"183 851 LINE",
+"293 646 OFFCURVE",
+"369 478 OFFCURVE",
+"432 289 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"502 939 LINE",
+"444 866 OFFCURVE",
+"377 794 OFFCURVE",
+"306 725 CURVE",
+"282 707 LINE",
+"211 639 OFFCURVE",
+"136 574 OFFCURVE",
+"60 513 CURVE",
+"106 455 LINE",
+"174 509 OFFCURVE",
+"247 572 OFFCURVE",
+"318 639 CURVE",
+"342 656 LINE",
+"420 732 OFFCURVE",
+"497 814 OFFCURVE",
+"562 895 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"272 322 OFFCURVE",
+"295 339 OFFCURVE",
+"295 378 CURVE SMOOTH",
+"295 417 OFFCURVE",
+"272 434 OFFCURVE",
+"244 434 CURVE SMOOTH",
+"215 434 OFFCURVE",
+"192 417 OFFCURVE",
+"192 378 CURVE SMOOTH",
+"192 339 OFFCURVE",
+"215 322 OFFCURVE",
+"244 322 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"570 566 OFFCURVE",
+"593 583 OFFCURVE",
+"593 622 CURVE SMOOTH",
+"593 661 OFFCURVE",
+"570 678 OFFCURVE",
+"542 678 CURVE SMOOTH",
+"513 678 OFFCURVE",
+"490 661 OFFCURVE",
+"490 622 CURVE SMOOTH",
+"490 583 OFFCURVE",
+"513 566 OFFCURVE",
+"542 566 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 852;
+}
+);
+leftMetricsKey = u1B214;
+rightMetricsKey = u1B1C8;
+unicode = 1B296;
+},
+{
+glyphname = u1B297;
+lastChange = "2020-04-13 09:17:32 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"220 15 OFFCURVE",
+"243 32 OFFCURVE",
+"243 71 CURVE SMOOTH",
+"243 110 OFFCURVE",
+"220 127 OFFCURVE",
+"192 127 CURVE SMOOTH",
+"163 127 OFFCURVE",
+"140 110 OFFCURVE",
+"140 71 CURVE SMOOTH",
+"140 32 OFFCURVE",
+"163 15 OFFCURVE",
+"192 15 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"703 26 OFFCURVE",
+"726 43 OFFCURVE",
+"726 82 CURVE SMOOTH",
+"726 121 OFFCURVE",
+"703 138 OFFCURVE",
+"675 138 CURVE SMOOTH",
+"646 138 OFFCURVE",
+"623 121 OFFCURVE",
+"623 82 CURVE SMOOTH",
+"623 43 OFFCURVE",
+"646 26 OFFCURVE",
+"675 26 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"419 524 LINE",
+"448 481 OFFCURVE",
+"468 450 OFFCURVE",
+"501 403 CURVE SMOOTH",
+"536 353 OFFCURVE",
+"569 301 OFFCURVE",
+"601 246 CURVE",
+"601 340 LINE",
+"547 264 OFFCURVE",
+"493 192 OFFCURVE",
+"428 112 CURVE",
+"398 77 LINE",
+"339 3 OFFCURVE",
+"274 -72 OFFCURVE",
+"201 -155 CURVE",
+"256 -203 LINE",
+"324 -125 OFFCURVE",
+"385 -53 OFFCURVE",
+"441 16 CURVE",
+"465 43 LINE",
+"544 141 OFFCURVE",
+"605 219 OFFCURVE",
+"660 296 CURVE",
+"601 391 OFFCURVE",
+"524 500 OFFCURVE",
+"456 587 CURVE",
+"376 587 LINE",
+"319 501 OFFCURVE",
+"265 438 OFFCURVE",
+"185 347 CURVE",
+"319 164 OFFCURVE",
+"412 31 OFFCURVE",
+"547 -177 CURVE",
+"610 -138 LINE",
+"489 50 OFFCURVE",
+"368 224 OFFCURVE",
+"256 377 CURVE",
+"269 334 LINE",
+"288 355 OFFCURVE",
+"306 376 OFFCURVE",
+"323 396 CURVE SMOOTH",
+"360 440 OFFCURVE",
+"382 472 OFFCURVE",
+"415 524 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"483 446 LINE",
+"426 366 OFFCURVE",
+"380 311 OFFCURVE",
+"316 245 CURVE",
+"363 193 LINE",
+"435 268 OFFCURVE",
+"482 325 OFFCURVE",
+"536 400 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"382 941 LINE",
+"298 760 OFFCURVE",
+"201 633 OFFCURVE",
+"80 509 CURVE",
+"133 457 LINE",
+"254 583 OFFCURVE",
+"361 716 OFFCURVE",
+"450 914 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"374 819 LINE",
+"485 721 OFFCURVE",
+"584 611 OFFCURVE",
+"670 489 CURVE",
+"729 533 LINE",
+"638 658 OFFCURVE",
+"546 762 OFFCURVE",
+"412 881 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 819;
+}
+);
+leftMetricsKey = u1B185;
+rightMetricsKey = u1B185;
+unicode = 1B297;
+},
+{
+glyphname = u1B298;
+lastChange = "2020-04-13 09:17:26 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"679 327 LINE",
+"633 224 OFFCURVE",
+"587 138 OFFCURVE",
+"533 55 CURVE SMOOTH",
+"487 -16 OFFCURVE",
+"447 -64 OFFCURVE",
+"394 -129 CURVE",
+"389 -128 LINE",
+"371 -50 OFFCURVE",
+"349 14 OFFCURVE",
+"316 83 CURVE SMOOTH",
+"308 100 OFFCURVE",
+"300 116 OFFCURVE",
+"292 132 CURVE",
+"222 95 LINE",
+"270 9 OFFCURVE",
+"299 -57 OFFCURVE",
+"335 -179 CURVE",
+"421 -198 LINE",
+"581 -18 OFFCURVE",
+"662 110 OFFCURVE",
+"748 293 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"469 131 OFFCURVE",
+"492 148 OFFCURVE",
+"492 187 CURVE SMOOTH",
+"492 226 OFFCURVE",
+"469 243 OFFCURVE",
+"441 243 CURVE SMOOTH",
+"412 243 OFFCURVE",
+"389 226 OFFCURVE",
+"389 187 CURVE SMOOTH",
+"389 148 OFFCURVE",
+"412 131 OFFCURVE",
+"441 131 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"166 -120 OFFCURVE",
+"189 -103 OFFCURVE",
+"189 -64 CURVE SMOOTH",
+"189 -25 OFFCURVE",
+"166 -8 OFFCURVE",
+"138 -8 CURVE SMOOTH",
+"109 -8 OFFCURVE",
+"86 -25 OFFCURVE",
+"86 -64 CURVE SMOOTH",
+"86 -103 OFFCURVE",
+"109 -120 OFFCURVE",
+"138 -120 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"543 909 LINE",
+"386 792 OFFCURVE",
+"235 695 OFFCURVE",
+"70 603 CURVE",
+"104 453 OFFCURVE",
+"124 341 OFFCURVE",
+"141 219 CURVE",
+"237 206 LINE",
+"281 273 OFFCURVE",
+"311 322 OFFCURVE",
+"328 359 CURVE SMOOTH",
+"346 397 OFFCURVE",
+"360 447 OFFCURVE",
+"373 518 CURVE",
+"378 519 LINE",
+"414 482 OFFCURVE",
+"443 455 OFFCURVE",
+"469 432 CURVE SMOOTH",
+"488 415 OFFCURVE",
+"507 397 OFFCURVE",
+"526 378 CURVE",
+"618 408 LINE",
+"640 567 OFFCURVE",
+"639 673 OFFCURVE",
+"631 871 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"561 830 LINE",
+"561 768 OFFCURVE",
+"560 708 OFFCURVE",
+"560 656 CURVE SMOOTH",
+"560 641 OFFCURVE",
+"559 626 OFFCURVE",
+"559 612 CURVE SMOOTH",
+"559 566 OFFCURVE",
+"557 503 OFFCURVE",
+"554 450 CURVE",
+"549 449 LINE",
+"508 495 OFFCURVE",
+"476 529 OFFCURVE",
+"447 557 CURVE SMOOTH",
+"428 574 OFFCURVE",
+"413 585 OFFCURVE",
+"395 599 CURVE",
+"320 569 LINE",
+"307 528 OFFCURVE",
+"294 489 OFFCURVE",
+"279 451 CURVE SMOOTH",
+"251 382 OFFCURVE",
+"230 329 OFFCURVE",
+"201 267 CURVE",
+"196 268 LINE",
+"194 359 OFFCURVE",
+"181 422 OFFCURVE",
+"172 475 CURVE SMOOTH",
+"166 512 OFFCURVE",
+"157 554 OFFCURVE",
+"147 603 CURVE",
+"126 550 LINE",
+"219 601 OFFCURVE",
+"314 660 OFFCURVE",
+"403 719 CURVE SMOOTH",
+"463 759 OFFCURVE",
+"503 788 OFFCURVE",
+"556 831 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 828;
+}
+);
+leftMetricsKey = u1B272;
+rightMetricsKey = u1B193;
+unicode = 1B298;
+},
+{
+glyphname = u1B299;
+lastChange = "2020-04-13 09:17:23 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"171 339 LINE",
+"308 200 OFFCURVE",
+"435 19 OFFCURVE",
+"515 -203 CURVE",
+"587 -178 LINE",
+"540 -58 OFFCURVE",
+"474 75 OFFCURVE",
+"403 175 CURVE",
+"389 175 LINE",
+"351 245 OFFCURVE",
+"306 308 OFFCURVE",
+"229 389 CURVE",
+"230 366 LINE",
+"289 446 OFFCURVE",
+"335 519 OFFCURVE",
+"370 592 CURVE",
+"381 592 LINE",
+"463 729 OFFCURVE",
+"497 808 OFFCURVE",
+"535 918 CURVE",
+"464 939 LINE",
+"391 733 OFFCURVE",
+"295 567 OFFCURVE",
+"171 410 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"209 716 OFFCURVE",
+"305 654 OFFCURVE",
+"360 592 CURVE",
+"374 592 LINE",
+"432 520 OFFCURVE",
+"451 449 OFFCURVE",
+"451 383 CURVE SMOOTH",
+"451 311 OFFCURVE",
+"431 236 OFFCURVE",
+"393 175 CURVE",
+"381 175 LINE",
+"319 84 OFFCURVE",
+"230 20 OFFCURVE",
+"123 -50 CURVE",
+"166 -111 LINE",
+"406 46 OFFCURVE",
+"525 191 OFFCURVE",
+"525 383 CURVE SMOOTH",
+"525 562 OFFCURVE",
+"399 706 OFFCURVE",
+"116 832 CURVE",
+"87 770 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"244 715 LINE",
+"278 781 OFFCURVE",
+"295 839 OFFCURVE",
+"314 925 CURVE",
+"246 939 LINE",
+"229 854 OFFCURVE",
+"211 798 OFFCURVE",
+"183 740 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"379 -188 OFFCURVE",
+"402 -171 OFFCURVE",
+"402 -132 CURVE SMOOTH",
+"402 -93 OFFCURVE",
+"379 -76 OFFCURVE",
+"351 -76 CURVE SMOOTH",
+"322 -76 OFFCURVE",
+"299 -93 OFFCURVE",
+"299 -132 CURVE SMOOTH",
+"299 -171 OFFCURVE",
+"322 -188 OFFCURVE",
+"351 -188 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"160 530 OFFCURVE",
+"183 547 OFFCURVE",
+"183 586 CURVE SMOOTH",
+"183 625 OFFCURVE",
+"160 642 OFFCURVE",
+"132 642 CURVE SMOOTH",
+"103 642 OFFCURVE",
+"80 625 OFFCURVE",
+"80 586 CURVE SMOOTH",
+"80 547 OFFCURVE",
+"103 530 OFFCURVE",
+"132 530 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"193 103 OFFCURVE",
+"216 120 OFFCURVE",
+"216 159 CURVE SMOOTH",
+"216 198 OFFCURVE",
+"193 215 OFFCURVE",
+"165 215 CURVE SMOOTH",
+"136 215 OFFCURVE",
+"113 198 OFFCURVE",
+"113 159 CURVE SMOOTH",
+"113 120 OFFCURVE",
+"136 103 OFFCURVE",
+"165 103 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"666 475 OFFCURVE",
+"689 492 OFFCURVE",
+"689 531 CURVE SMOOTH",
+"689 570 OFFCURVE",
+"666 587 OFFCURVE",
+"638 587 CURVE SMOOTH",
+"609 587 OFFCURVE",
+"586 570 OFFCURVE",
+"586 531 CURVE SMOOTH",
+"586 492 OFFCURVE",
+"609 475 OFFCURVE",
+"638 475 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"656 157 OFFCURVE",
+"679 174 OFFCURVE",
+"679 213 CURVE SMOOTH",
+"679 252 OFFCURVE",
+"656 269 OFFCURVE",
+"628 269 CURVE SMOOTH",
+"599 269 OFFCURVE",
+"576 252 OFFCURVE",
+"576 213 CURVE SMOOTH",
+"576 174 OFFCURVE",
+"599 157 OFFCURVE",
+"628 157 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 809;
+}
+);
+rightMetricsKey = u1B1B5;
+unicode = 1B299;
+},
+{
+glyphname = u1B29A;
+lastChange = "2020-04-13 09:17:10 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"506 939 LINE",
+"359 844 OFFCURVE",
+"210 766 OFFCURVE",
+"60 704 CURVE",
+"88 640 LINE",
+"252 710 OFFCURVE",
+"381 776 OFFCURVE",
+"544 880 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"256 -92 OFFCURVE",
+"279 -75 OFFCURVE",
+"279 -36 CURVE SMOOTH",
+"279 3 OFFCURVE",
+"256 20 OFFCURVE",
+"228 20 CURVE SMOOTH",
+"199 20 OFFCURVE",
+"176 3 OFFCURVE",
+"176 -36 CURVE SMOOTH",
+"176 -75 OFFCURVE",
+"199 -92 OFFCURVE",
+"228 -92 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"667 50 OFFCURVE",
+"690 67 OFFCURVE",
+"690 106 CURVE SMOOTH",
+"690 145 OFFCURVE",
+"667 162 OFFCURVE",
+"639 162 CURVE SMOOTH",
+"610 162 OFFCURVE",
+"587 145 OFFCURVE",
+"587 106 CURVE SMOOTH",
+"587 67 OFFCURVE",
+"610 50 OFFCURVE",
+"639 50 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"280 772 LINE",
+"298 726 OFFCURVE",
+"314 676 OFFCURVE",
+"328 625 CURVE",
+"344 571 LINE",
+"368 471 OFFCURVE",
+"386 351 OFFCURVE",
+"395 244 CURVE",
+"395 196 LINE",
+"398 153 OFFCURVE",
+"399 110 OFFCURVE",
+"399 68 CURVE SMOOTH",
+"399 -57 OFFCURVE",
+"395 -115 OFFCURVE",
+"385 -193 CURVE",
+"460 -203 LINE",
+"470 -124 OFFCURVE",
+"475 -57 OFFCURVE",
+"475 68 CURVE SMOOTH",
+"475 122 OFFCURVE",
+"473 176 OFFCURVE",
+"469 229 CURVE",
+"463 275 LINE",
+"451 381 OFFCURVE",
+"430 499 OFFCURVE",
+"405 601 CURVE",
+"391 661 LINE",
+"378 710 OFFCURVE",
+"363 758 OFFCURVE",
+"347 806 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"586 571 LINE",
+"529 536 OFFCURVE",
+"473 504 OFFCURVE",
+"413 473 CURVE",
+"380 459 LINE",
+"323 431 OFFCURVE",
+"263 404 OFFCURVE",
+"196 377 CURVE",
+"213 309 LINE",
+"276 334 OFFCURVE",
+"335 360 OFFCURVE",
+"394 388 CURVE",
+"431 403 LINE",
+"495 435 OFFCURVE",
+"559 471 OFFCURVE",
+"627 512 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"525 753 LINE",
+"476 722 OFFCURVE",
+"425 692 OFFCURVE",
+"373 662 CURVE",
+"339 647 LINE",
+"274 613 OFFCURVE",
+"205 580 OFFCURVE",
+"131 547 CURVE",
+"159 404 OFFCURVE",
+"177 279 OFFCURVE",
+"191 148 CURVE",
+"263 121 LINE",
+"317 144 OFFCURVE",
+"367 165 OFFCURVE",
+"417 188 CURVE",
+"456 203 LINE",
+"530 238 OFFCURVE",
+"603 275 OFFCURVE",
+"681 321 CURVE",
+"659 475 OFFCURVE",
+"639 585 OFFCURVE",
+"599 738 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"537 676 LINE",
+"555 611 OFFCURVE",
+"566 566 OFFCURVE",
+"576 510 CURVE SMOOTH",
+"587 451 OFFCURVE",
+"595 395 OFFCURVE",
+"602 331 CURVE",
+"639 384 LINE",
+"577 347 OFFCURVE",
+"513 312 OFFCURVE",
+"449 281 CURVE",
+"408 264 LINE",
+"349 236 OFFCURVE",
+"305 217 OFFCURVE",
+"261 197 CURVE",
+"256 198 LINE",
+"247 267 OFFCURVE",
+"244 318 OFFCURVE",
+"236 375 CURVE SMOOTH",
+"228 434 OFFCURVE",
+"217 495 OFFCURVE",
+"204 556 CURVE",
+"181 491 LINE",
+"243 517 OFFCURVE",
+"303 544 OFFCURVE",
+"361 574 CURVE",
+"399 591 LINE",
+"450 619 OFFCURVE",
+"488 645 OFFCURVE",
+"533 678 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 810;
+}
+);
+unicode = 1B29A;
+},
+{
+glyphname = u1B29B;
+lastChange = "2020-04-13 09:20:32 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"623 -143 LINE",
+"605 57 OFFCURVE",
+"543 289 OFFCURVE",
+"474 456 CURVE",
+"406 429 LINE",
+"475 254 OFFCURVE",
+"533 37 OFFCURVE",
+"549 -151 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"741 308 LINE",
+"675 267 OFFCURVE",
+"609 230 OFFCURVE",
+"543 197 CURVE",
+"512 189 LINE",
+"442 155 OFFCURVE",
+"372 124 OFFCURVE",
+"302 96 CURVE",
+"328 27 LINE",
+"391 51 OFFCURVE",
+"458 79 OFFCURVE",
+"530 114 CURVE",
+"559 121 LINE",
+"629 158 OFFCURVE",
+"703 198 OFFCURVE",
+"783 246 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"662 357 OFFCURVE",
+"685 374 OFFCURVE",
+"685 413 CURVE SMOOTH",
+"685 452 OFFCURVE",
+"662 469 OFFCURVE",
+"634 469 CURVE SMOOTH",
+"605 469 OFFCURVE",
+"582 452 OFFCURVE",
+"582 413 CURVE SMOOTH",
+"582 374 OFFCURVE",
+"605 357 OFFCURVE",
+"634 357 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"357 194 OFFCURVE",
+"380 211 OFFCURVE",
+"380 250 CURVE SMOOTH",
+"380 289 OFFCURVE",
+"357 306 OFFCURVE",
+"329 306 CURVE SMOOTH",
+"300 306 OFFCURVE",
+"277 289 OFFCURVE",
+"277 250 CURVE SMOOTH",
+"277 211 OFFCURVE",
+"300 194 OFFCURVE",
+"329 194 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"763 19 OFFCURVE",
+"786 36 OFFCURVE",
+"786 75 CURVE SMOOTH",
+"786 114 OFFCURVE",
+"763 131 OFFCURVE",
+"735 131 CURVE SMOOTH",
+"706 131 OFFCURVE",
+"683 114 OFFCURVE",
+"683 75 CURVE SMOOTH",
+"683 36 OFFCURVE",
+"706 19 OFFCURVE",
+"735 19 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"446 -135 OFFCURVE",
+"469 -118 OFFCURVE",
+"469 -79 CURVE SMOOTH",
+"469 -40 OFFCURVE",
+"446 -23 OFFCURVE",
+"418 -23 CURVE SMOOTH",
+"389 -23 OFFCURVE",
+"366 -40 OFFCURVE",
+"366 -79 CURVE SMOOTH",
+"366 -118 OFFCURVE",
+"389 -135 OFFCURVE",
+"418 -135 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"122 244 LINE",
+"167 109 OFFCURVE",
+"199 -35 OFFCURVE",
+"213 -203 CURVE",
+"286 -197 LINE",
+"268 -18 OFFCURVE",
+"238 142 OFFCURVE",
+"190 271 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"589 939 LINE",
+"533 825 OFFCURVE",
+"474 727 OFFCURVE",
+"411 639 CURVE SMOOTH",
+"361 570 OFFCURVE",
+"315 516 OFFCURVE",
+"266 455 CURVE",
+"261 456 LINE",
+"239 537 OFFCURVE",
+"215 597 OFFCURVE",
+"191 650 CURVE SMOOTH",
+"174 687 OFFCURVE",
+"155 723 OFFCURVE",
+"134 758 CURVE",
+"70 721 LINE",
+"132 617 OFFCURVE",
+"174 515 OFFCURVE",
+"211 408 CURVE",
+"293 392 LINE",
+"433 532 OFFCURVE",
+"553 698 OFFCURVE",
+"657 910 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 846;
+}
+);
+leftMetricsKey = u1B1B7;
+rightMetricsKey = u1B27D;
+unicode = 1B29B;
+},
+{
+glyphname = u1B29C;
+lastChange = "2020-04-13 09:20:56 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"440 785 OFFCURVE",
+"454 752 OFFCURVE",
+"454 705 CURVE SMOOTH",
+"454 643 OFFCURVE",
+"385 576 OFFCURVE",
+"121 434 CURVE",
+"156 369 LINE",
+"439 527 OFFCURVE",
+"530 608 OFFCURVE",
+"530 701 CURVE SMOOTH",
+"530 769 OFFCURVE",
+"502 824 OFFCURVE",
+"433 898 CURVE",
+"391 839 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"468 140 LINE",
+"456 266 OFFCURVE",
+"432 431 OFFCURVE",
+"396 561 CURVE",
+"338 536 LINE",
+"371 408 OFFCURVE",
+"388 269 OFFCURVE",
+"398 133 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"460 939 LINE",
+"336 819 OFFCURVE",
+"215 731 OFFCURVE",
+"60 639 CURVE",
+"96 577 LINE",
+"243 663 OFFCURVE",
+"385 764 OFFCURVE",
+"513 892 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"97 104 LINE",
+"193 22 OFFCURVE",
+"270 -58 OFFCURVE",
+"347 -151 CURVE",
+"405 -106 LINE",
+"368 -63 OFFCURVE",
+"338 -32 OFFCURVE",
+"273 33 CURVE",
+"259 33 LINE",
+"230 74 OFFCURVE",
+"197 106 OFFCURVE",
+"141 154 CURVE",
+"141 122 LINE",
+"199 176 OFFCURVE",
+"238 218 OFFCURVE",
+"267 262 CURVE",
+"298 290 LINE",
+"310 305 OFFCURVE",
+"321 321 OFFCURVE",
+"332 337 CURVE",
+"275 374 LINE",
+"216 295 OFFCURVE",
+"157 229 OFFCURVE",
+"97 175 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"474 350 LINE",
+"551 260 OFFCURVE",
+"628 158 OFFCURVE",
+"683 64 CURVE",
+"745 102 LINE",
+"719 143 OFFCURVE",
+"701 173 OFFCURVE",
+"647 247 CURVE",
+"635 247 LINE",
+"605 300 OFFCURVE",
+"572 344 OFFCURVE",
+"520 409 CURVE",
+"519 370 LINE",
+"562 413 OFFCURVE",
+"601 456 OFFCURVE",
+"630 502 CURVE",
+"669 539 LINE",
+"680 555 OFFCURVE",
+"692 571 OFFCURVE",
+"704 588 CURVE",
+"648 624 LINE",
+"588 539 OFFCURVE",
+"534 478 OFFCURVE",
+"474 421 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"240 262 LINE",
+"271 262 LINE",
+"282 220 OFFCURVE",
+"286 185 OFFCURVE",
+"286 150 CURVE SMOOTH",
+"286 116 OFFCURVE",
+"279 78 OFFCURVE",
+"263 33 CURVE",
+"254 33 LINE",
+"214 -38 OFFCURVE",
+"171 -91 OFFCURVE",
+"111 -159 CURVE",
+"163 -203 LINE",
+"216 -143 OFFCURVE",
+"249 -93 OFFCURVE",
+"278 -49 CURVE",
+"301 -22 LINE",
+"339 42 OFFCURVE",
+"353 91 OFFCURVE",
+"353 140 CURVE SMOOTH",
+"353 194 OFFCURVE",
+"340 247 OFFCURVE",
+"298 322 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"613 502 LINE",
+"634 502 LINE",
+"657 464 OFFCURVE",
+"670 431 OFFCURVE",
+"670 387 CURVE SMOOTH",
+"670 345 OFFCURVE",
+"659 295 OFFCURVE",
+"639 247 CURVE",
+"628 247 LINE",
+"583 170 OFFCURVE",
+"536 111 OFFCURVE",
+"476 41 CURVE",
+"529 -3 LINE",
+"582 58 OFFCURVE",
+"615 109 OFFCURVE",
+"645 153 CURVE",
+"670 183 LINE",
+"723 267 OFFCURVE",
+"735 325 OFFCURVE",
+"735 384 CURVE SMOOTH",
+"735 441 OFFCURVE",
+"720 490 OFFCURVE",
+"672 559 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 855;
+}
+);
+leftMetricsKey = u1B285;
+rightMetricsKey = u1B285;
+unicode = 1B29C;
+},
+{
+glyphname = u1B29D;
+lastChange = "2020-04-13 09:21:10 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"689 251 OFFCURVE",
+"704 202 OFFCURVE",
+"717 120 CURVE SMOOTH",
+"721 95 OFFCURVE",
+"726 69 OFFCURVE",
+"731 41 CURVE",
+"803 55 LINE",
+"781 185 OFFCURVE",
+"759 271 OFFCURVE",
+"723 375 CURVE",
+"651 388 LINE",
+"539 294 OFFCURVE",
+"410 201 OFFCURVE",
+"269 115 CURVE",
+"299 0 OFFCURVE",
+"317 -85 OFFCURVE",
+"331 -203 CURVE",
+"406 -194 LINE",
+"391 -76 OFFCURVE",
+"373 12 OFFCURVE",
+"340 129 CURVE",
+"340 71 LINE",
+"405 110 OFFCURVE",
+"465 150 OFFCURVE",
+"524 193 CURVE SMOOTH",
+"585 238 OFFCURVE",
+"618 265 OFFCURVE",
+"665 312 CURVE",
+"670 311 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"502 86 OFFCURVE",
+"516 26 OFFCURVE",
+"536 -87 CURVE",
+"610 -75 LINE",
+"589 41 OFFCURVE",
+"568 125 OFFCURVE",
+"537 224 CURVE",
+"470 193 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"534 231 LINE",
+"474 444 OFFCURVE",
+"426 592 OFFCURVE",
+"352 774 CURVE",
+"297 716 LINE",
+"364 550 OFFCURVE",
+"412 386 OFFCURVE",
+"465 193 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"480 939 LINE",
+"341 799 OFFCURVE",
+"216 697 OFFCURVE",
+"60 600 CURVE",
+"102 540 LINE",
+"254 637 OFFCURVE",
+"384 734 OFFCURVE",
+"537 893 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"595 743 LINE",
+"539 685 OFFCURVE",
+"472 628 OFFCURVE",
+"402 575 CURVE",
+"379 565 LINE",
+"304 510 OFFCURVE",
+"226 458 OFFCURVE",
+"148 412 CURVE",
+"183 346 LINE",
+"254 388 OFFCURVE",
+"329 437 OFFCURVE",
+"403 490 CURVE",
+"428 502 LINE",
+"508 562 OFFCURVE",
+"584 628 OFFCURVE",
+"649 695 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"631 436 OFFCURVE",
+"654 453 OFFCURVE",
+"654 492 CURVE SMOOTH",
+"654 531 OFFCURVE",
+"631 548 OFFCURVE",
+"603 548 CURVE SMOOTH",
+"574 548 OFFCURVE",
+"551 531 OFFCURVE",
+"551 492 CURVE SMOOTH",
+"551 453 OFFCURVE",
+"574 436 OFFCURVE",
+"603 436 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"322 221 OFFCURVE",
+"345 238 OFFCURVE",
+"345 277 CURVE SMOOTH",
+"345 316 OFFCURVE",
+"322 333 OFFCURVE",
+"294 333 CURVE SMOOTH",
+"265 333 OFFCURVE",
+"242 316 OFFCURVE",
+"242 277 CURVE SMOOTH",
+"242 238 OFFCURVE",
+"265 221 OFFCURVE",
+"294 221 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 883;
+}
+);
+leftMetricsKey = u1B187;
+rightMetricsKey = u1B270;
+unicode = 1B29D;
+},
+{
+glyphname = u1B29E;
+lastChange = "2020-04-13 09:21:17 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"688 547 OFFCURVE",
+"673 639 OFFCURVE",
+"648 725 CURVE",
+"567 750 LINE",
+"417 657 OFFCURVE",
+"276 585 OFFCURVE",
+"114 518 CURVE",
+"135 411 OFFCURVE",
+"144 337 OFFCURVE",
+"150 255 CURVE",
+"221 226 LINE",
+"381 287 OFFCURVE",
+"514 346 OFFCURVE",
+"702 451 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"642 507 LINE",
+"563 460 OFFCURVE",
+"481 419 OFFCURVE",
+"396 380 CURVE SMOOTH",
+"327 348 OFFCURVE",
+"282 328 OFFCURVE",
+"226 299 CURVE",
+"221 300 LINE",
+"219 345 OFFCURVE",
+"212 386 OFFCURVE",
+"207 418 CURVE SMOOTH",
+"203 446 OFFCURVE",
+"198 470 OFFCURVE",
+"190 515 CURVE",
+"164 460 LINE",
+"243 492 OFFCURVE",
+"317 526 OFFCURVE",
+"388 562 CURVE SMOOTH",
+"463 600 OFFCURVE",
+"516 635 OFFCURVE",
+"578 678 CURVE",
+"583 677 LINE",
+"595 634 OFFCURVE",
+"603 592 OFFCURVE",
+"608 568 CURVE SMOOTH",
+"615 531 OFFCURVE",
+"622 492 OFFCURVE",
+"628 446 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"662 -92 OFFCURVE",
+"685 -75 OFFCURVE",
+"685 -36 CURVE SMOOTH",
+"685 3 OFFCURVE",
+"662 20 OFFCURVE",
+"634 20 CURVE SMOOTH",
+"605 20 OFFCURVE",
+"582 3 OFFCURVE",
+"582 -36 CURVE SMOOTH",
+"582 -75 OFFCURVE",
+"605 -92 OFFCURVE",
+"634 -92 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"666 153 OFFCURVE",
+"689 170 OFFCURVE",
+"689 209 CURVE SMOOTH",
+"689 248 OFFCURVE",
+"666 265 OFFCURVE",
+"638 265 CURVE SMOOTH",
+"609 265 OFFCURVE",
+"586 248 OFFCURVE",
+"586 209 CURVE SMOOTH",
+"586 170 OFFCURVE",
+"609 153 OFFCURVE",
+"638 153 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"267 -138 LINE",
+"267 -32 OFFCURVE",
+"261 50 OFFCURVE",
+"247 151 CURVE",
+"177 141 LINE",
+"192 45 OFFCURVE",
+"197 -37 OFFCURVE",
+"197 -139 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"506 939 LINE",
+"359 844 OFFCURVE",
+"210 766 OFFCURVE",
+"60 704 CURVE",
+"88 640 LINE",
+"252 710 OFFCURVE",
+"381 776 OFFCURVE",
+"544 880 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"279 772 LINE",
+"300 717 OFFCURVE",
+"316 658 OFFCURVE",
+"332 596 CURVE",
+"348 555 LINE",
+"362 491 OFFCURVE",
+"374 426 OFFCURVE",
+"383 359 CURVE",
+"387 315 LINE",
+"396 233 OFFCURVE",
+"401 150 OFFCURVE",
+"401 68 CURVE SMOOTH",
+"401 -57 OFFCURVE",
+"397 -115 OFFCURVE",
+"387 -193 CURVE",
+"462 -203 LINE",
+"472 -124 OFFCURVE",
+"477 -57 OFFCURVE",
+"477 68 CURVE SMOOTH",
+"477 163 OFFCURVE",
+"470 257 OFFCURVE",
+"457 349 CURVE",
+"449 397 LINE",
+"439 461 OFFCURVE",
+"427 524 OFFCURVE",
+"412 586 CURVE",
+"399 634 LINE",
+"384 692 OFFCURVE",
+"367 749 OFFCURVE",
+"348 806 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 822;
+}
+);
+leftMetricsKey = u1B29A;
+rightMetricsKey = u1B29A;
+unicode = 1B29E;
+},
+{
+glyphname = u1B29F;
+lastChange = "2020-04-13 09:21:20 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"772 358 OFFCURVE",
+"724 477 OFFCURVE",
+"662 611 CURVE",
+"591 620 LINE",
+"498 504 OFFCURVE",
+"386 400 OFFCURVE",
+"266 306 CURVE",
+"325 166 OFFCURVE",
+"362 59 OFFCURVE",
+"398 -77 CURVE",
+"471 -87 LINE",
+"584 0 OFFCURVE",
+"710 119 OFFCURVE",
+"811 230 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"630 130 LINE",
+"597 232 OFFCURVE",
+"561 330 OFFCURVE",
+"516 434 CURVE",
+"496 480 LINE",
+"442 600 OFFCURVE",
+"375 733 OFFCURVE",
+"287 887 CURVE",
+"224 849 LINE",
+"316 685 OFFCURVE",
+"387 546 OFFCURVE",
+"443 419 CURVE",
+"463 390 LINE",
+"512 271 OFFCURVE",
+"546 174 OFFCURVE",
+"575 79 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"744 273 LINE",
+"696 218 OFFCURVE",
+"648 168 OFFCURVE",
+"597 120 CURVE SMOOTH",
+"542 69 OFFCURVE",
+"502 32 OFFCURVE",
+"454 -12 CURVE",
+"450 -11 LINE",
+"436 61 OFFCURVE",
+"418 119 OFFCURVE",
+"401 166 CURVE SMOOTH",
+"384 213 OFFCURVE",
+"365 261 OFFCURVE",
+"344 314 CURVE",
+"324 253 LINE",
+"384 302 OFFCURVE",
+"441 353 OFFCURVE",
+"496 403 CURVE SMOOTH",
+"537 441 OFFCURVE",
+"572 482 OFFCURVE",
+"616 538 CURVE",
+"621 537 LINE",
+"644 473 OFFCURVE",
+"668 416 OFFCURVE",
+"685 369 CURVE SMOOTH",
+"704 318 OFFCURVE",
+"721 266 OFFCURVE",
+"738 212 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"547 939 LINE",
+"487 857 OFFCURVE",
+"427 784 OFFCURVE",
+"366 717 CURVE",
+"331 682 LINE",
+"265 614 OFFCURVE",
+"197 551 OFFCURVE",
+"126 493 CURVE",
+"172 436 LINE",
+"238 492 OFFCURVE",
+"300 548 OFFCURVE",
+"358 607 CURVE",
+"397 644 LINE",
+"469 720 OFFCURVE",
+"538 802 OFFCURVE",
+"608 899 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"150 197 OFFCURVE",
+"173 214 OFFCURVE",
+"173 253 CURVE SMOOTH",
+"173 292 OFFCURVE",
+"150 309 OFFCURVE",
+"122 309 CURVE SMOOTH",
+"93 309 OFFCURVE",
+"70 292 OFFCURVE",
+"70 253 CURVE SMOOTH",
+"70 214 OFFCURVE",
+"93 197 OFFCURVE",
+"122 197 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"222 7 OFFCURVE",
+"245 24 OFFCURVE",
+"245 63 CURVE SMOOTH",
+"245 102 OFFCURVE",
+"222 119 OFFCURVE",
+"194 119 CURVE SMOOTH",
+"165 119 OFFCURVE",
+"142 102 OFFCURVE",
+"142 63 CURVE SMOOTH",
+"142 24 OFFCURVE",
+"165 7 OFFCURVE",
+"194 7 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"283 -203 OFFCURVE",
+"306 -186 OFFCURVE",
+"306 -147 CURVE SMOOTH",
+"306 -108 OFFCURVE",
+"283 -91 OFFCURVE",
+"255 -91 CURVE SMOOTH",
+"226 -91 OFFCURVE",
+"203 -108 OFFCURVE",
+"203 -147 CURVE SMOOTH",
+"203 -186 OFFCURVE",
+"226 -203 OFFCURVE",
+"255 -203 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 901;
+}
+);
+rightMetricsKey = u1B1C8;
+unicode = 1B29F;
+},
+{
+glyphname = u1B2A0;
+lastChange = "2020-04-13 09:21:24 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"840 371 OFFCURVE",
+"802 519 OFFCURVE",
+"767 624 CURVE",
+"696 635 LINE",
+"643 573 OFFCURVE",
+"582 516 OFFCURVE",
+"505 454 CURVE",
+"542 327 OFFCURVE",
+"559 227 OFFCURVE",
+"586 98 CURVE",
+"659 78 LINE",
+"728 128 OFFCURVE",
+"797 186 OFFCURVE",
+"862 248 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"801 289 LINE",
+"780 268 OFFCURVE",
+"758 247 OFFCURVE",
+"735 226 CURVE SMOOTH",
+"697 191 OFFCURVE",
+"675 173 OFFCURVE",
+"645 150 CURVE",
+"640 151 LINE",
+"631 219 OFFCURVE",
+"618 272 OFFCURVE",
+"609 313 CURVE SMOOTH",
+"597 366 OFFCURVE",
+"584 418 OFFCURVE",
+"567 475 CURVE",
+"570 415 LINE",
+"590 433 OFFCURVE",
+"611 451 OFFCURVE",
+"632 471 CURVE SMOOTH",
+"659 497 OFFCURVE",
+"683 523 OFFCURVE",
+"715 561 CURVE",
+"720 560 LINE",
+"734 505 OFFCURVE",
+"745 463 OFFCURVE",
+"759 410 CURVE SMOOTH",
+"773 356 OFFCURVE",
+"785 299 OFFCURVE",
+"797 231 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"765 476 LINE",
+"699 404 OFFCURVE",
+"643 355 OFFCURVE",
+"588 309 CURVE",
+"602 245 LINE",
+"671 298 OFFCURVE",
+"735 352 OFFCURVE",
+"800 423 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"568 -128 LINE",
+"526 54 OFFCURVE",
+"483 200 OFFCURVE",
+"427 340 CURVE",
+"403 389 LINE",
+"357 498 OFFCURVE",
+"302 606 OFFCURVE",
+"232 729 CURVE",
+"171 692 LINE",
+"256 549 OFFCURVE",
+"319 418 OFFCURVE",
+"370 280 CURVE",
+"397 224 LINE",
+"436 112 OFFCURVE",
+"468 -6 OFFCURVE",
+"499 -140 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 939 LINE",
+"456 741 OFFCURVE",
+"429 570 OFFCURVE",
+"389 391 CURVE",
+"365 328 LINE",
+"319 163 OFFCURVE",
+"260 4 OFFCURVE",
+"178 -171 CURVE",
+"242 -203 LINE",
+"313 -49 OFFCURVE",
+"367 90 OFFCURVE",
+"409 243 CURVE",
+"433 297 LINE",
+"489 494 OFFCURVE",
+"522 693 OFFCURVE",
+"550 933 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"60 163 OFFCURVE",
+"85 118 OFFCURVE",
+"153 84 CURVE",
+"224 93 LINE",
+"287 179 OFFCURVE",
+"305 237 OFFCURVE",
+"305 300 CURVE SMOOTH",
+"305 354 OFFCURVE",
+"281 399 OFFCURVE",
+"208 437 CURVE",
+"134 427 LINE",
+"83 345 OFFCURVE",
+"60 281 OFFCURVE",
+"60 229 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"181 382 LINE",
+"221 354 OFFCURVE",
+"235 323 OFFCURVE",
+"235 294 CURVE SMOOTH",
+"235 251 OFFCURVE",
+"221 199 OFFCURVE",
+"184 137 CURVE",
+"179 136 LINE",
+"146 165 OFFCURVE",
+"130 194 OFFCURVE",
+"130 233 CURVE SMOOTH",
+"130 269 OFFCURVE",
+"143 316 OFFCURVE",
+"176 381 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 952;
+}
+);
+leftMetricsKey = u1B1F1;
+rightMetricsKey = u1B1C8;
+unicode = 1B2A0;
+},
+{
+glyphname = u1B2A1;
+lastChange = "2020-04-13 09:21:41 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"765 791 LINE",
+"725 766 OFFCURVE",
+"692 748 OFFCURVE",
+"659 732 CURVE",
+"634 725 LINE",
+"598 710 OFFCURVE",
+"561 697 OFFCURVE",
+"516 682 CURVE",
+"536 617 LINE",
+"585 633 OFFCURVE",
+"623 647 OFFCURVE",
+"661 664 CURVE",
+"683 670 LINE",
+"720 688 OFFCURVE",
+"757 708 OFFCURVE",
+"803 736 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"571 840 LINE",
+"638 678 OFFCURVE",
+"674 529 OFFCURVE",
+"696 356 CURVE",
+"765 367 LINE",
+"736 560 OFFCURVE",
+"705 699 OFFCURVE",
+"632 868 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"818 619 LINE",
+"774 595 OFFCURVE",
+"737 577 OFFCURVE",
+"702 563 CURVE",
+"681 559 LINE",
+"640 543 OFFCURVE",
+"599 532 OFFCURVE",
+"550 519 CURVE",
+"568 453 LINE",
+"619 467 OFFCURVE",
+"659 479 OFFCURVE",
+"697 492 CURVE",
+"726 499 LINE",
+"764 515 OFFCURVE",
+"804 535 OFFCURVE",
+"854 564 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"150 85 OFFCURVE",
+"173 102 OFFCURVE",
+"173 141 CURVE SMOOTH",
+"173 180 OFFCURVE",
+"150 197 OFFCURVE",
+"122 197 CURVE SMOOTH",
+"93 197 OFFCURVE",
+"70 180 OFFCURVE",
+"70 141 CURVE SMOOTH",
+"70 102 OFFCURVE",
+"93 85 OFFCURVE",
+"122 85 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"313 -63 OFFCURVE",
+"336 -46 OFFCURVE",
+"336 -7 CURVE SMOOTH",
+"336 32 OFFCURVE",
+"313 49 OFFCURVE",
+"285 49 CURVE SMOOTH",
+"256 49 OFFCURVE",
+"233 32 OFFCURVE",
+"233 -7 CURVE SMOOTH",
+"233 -46 OFFCURVE",
+"256 -63 OFFCURVE",
+"285 -63 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"487 -203 OFFCURVE",
+"510 -186 OFFCURVE",
+"510 -147 CURVE SMOOTH",
+"510 -108 OFFCURVE",
+"487 -91 OFFCURVE",
+"459 -91 CURVE SMOOTH",
+"430 -91 OFFCURVE",
+"407 -108 OFFCURVE",
+"407 -147 CURVE SMOOTH",
+"407 -186 OFFCURVE",
+"430 -203 OFFCURVE",
+"459 -203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"367 920 LINE",
+"291 686 OFFCURVE",
+"228 522 OFFCURVE",
+"149 370 CURVE",
+"164 298 LINE",
+"269 227 OFFCURVE",
+"397 124 OFFCURVE",
+"515 10 CURVE",
+"591 44 LINE",
+"566 366 OFFCURVE",
+"522 628 OFFCURVE",
+"455 924 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"409 848 LINE",
+"421 745 OFFCURVE",
+"438 652 OFFCURVE",
+"453 560 CURVE SMOOTH",
+"466 482 OFFCURVE",
+"478 406 OFFCURVE",
+"488 327 CURVE SMOOTH",
+"497 259 OFFCURVE",
+"505 167 OFFCURVE",
+"522 90 CURVE",
+"517 89 LINE",
+"464 150 OFFCURVE",
+"419 198 OFFCURVE",
+"366 241 CURVE SMOOTH",
+"320 279 OFFCURVE",
+"272 315 OFFCURVE",
+"211 359 CURVE",
+"210 319 LINE",
+"248 396 OFFCURVE",
+"279 464 OFFCURVE",
+"308 538 CURVE SMOOTH",
+"342 624 OFFCURVE",
+"376 725 OFFCURVE",
+"405 848 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 904;
+}
+);
+leftMetricsKey = u1B20F;
+unicode = 1B2A1;
+},
+{
+glyphname = u1B2A2;
+lastChange = "2020-04-13 09:21:44 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"603 -203 OFFCURVE",
+"626 -186 OFFCURVE",
+"626 -147 CURVE SMOOTH",
+"626 -108 OFFCURVE",
+"603 -91 OFFCURVE",
+"575 -91 CURVE SMOOTH",
+"546 -91 OFFCURVE",
+"523 -108 OFFCURVE",
+"523 -147 CURVE SMOOTH",
+"523 -186 OFFCURVE",
+"546 -203 OFFCURVE",
+"575 -203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"771 -22 OFFCURVE",
+"794 -5 OFFCURVE",
+"794 34 CURVE SMOOTH",
+"794 73 OFFCURVE",
+"771 90 OFFCURVE",
+"743 90 CURVE SMOOTH",
+"714 90 OFFCURVE",
+"691 73 OFFCURVE",
+"691 34 CURVE SMOOTH",
+"691 -5 OFFCURVE",
+"714 -22 OFFCURVE",
+"743 -22 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"900 165 OFFCURVE",
+"923 182 OFFCURVE",
+"923 221 CURVE SMOOTH",
+"923 260 OFFCURVE",
+"900 277 OFFCURVE",
+"872 277 CURVE SMOOTH",
+"843 277 OFFCURVE",
+"820 260 OFFCURVE",
+"820 221 CURVE SMOOTH",
+"820 182 OFFCURVE",
+"843 165 OFFCURVE",
+"872 165 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"642 707 LINE",
+"555 548 OFFCURVE",
+"477 429 OFFCURVE",
+"384 305 CURVE",
+"434 251 LINE",
+"538 390 OFFCURVE",
+"607 493 OFFCURVE",
+"679 621 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"97 788 LINE",
+"82 575 OFFCURVE",
+"63 478 OFFCURVE",
+"30 337 CURVE",
+"103 321 LINE",
+"116 378 OFFCURVE",
+"126 427 OFFCURVE",
+"134 477 CURVE SMOOTH",
+"142 528 OFFCURVE",
+"151 596 OFFCURVE",
+"158 702 CURVE",
+"163 702 LINE",
+"199 616 OFFCURVE",
+"228 559 OFFCURVE",
+"263 485 CURVE SMOOTH",
+"344 314 OFFCURVE",
+"398 181 OFFCURVE",
+"457 19 CURVE",
+"549 9 LINE",
+"647 130 OFFCURVE",
+"736 262 OFFCURVE",
+"825 414 CURVE",
+"756 582 OFFCURVE",
+"686 729 OFFCURVE",
+"589 924 CURVE",
+"496 927 LINE",
+"436 805 OFFCURVE",
+"367 689 OFFCURVE",
+"275 556 CURVE",
+"307 472 LINE",
+"362 553 OFFCURVE",
+"409 622 OFFCURVE",
+"451 690 CURVE SMOOTH",
+"491 754 OFFCURVE",
+"509 788 OFFCURVE",
+"538 851 CURVE",
+"542 851 LINE",
+"580 771 OFFCURVE",
+"610 715 OFFCURVE",
+"645 640 CURVE SMOOTH",
+"687 550 OFFCURVE",
+"725 460 OFFCURVE",
+"765 355 CURVE",
+"777 482 LINE",
+"735 407 OFFCURVE",
+"693 338 OFFCURVE",
+"652 275 CURVE SMOOTH",
+"606 205 OFFCURVE",
+"557 138 OFFCURVE",
+"514 78 CURVE",
+"510 78 LINE",
+"485 157 OFFCURVE",
+"458 231 OFFCURVE",
+"421 319 CURVE SMOOTH",
+"390 392 OFFCURVE",
+"315 556 OFFCURVE",
+"190 809 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1372;
+width = 993;
+}
+);
+rightMetricsKey = u1B262;
+unicode = 1B2A2;
+},
+{
+glyphname = u1B2A3;
+lastChange = "2020-04-13 09:22:16 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"658 339 LINE",
+"654 426 OFFCURVE",
+"642 516 OFFCURVE",
+"623 607 CURVE",
+"550 629 LINE",
+"441 568 OFFCURVE",
+"318 513 OFFCURVE",
+"175 456 CURVE",
+"196 328 OFFCURVE",
+"204 231 OFFCURVE",
+"210 125 CURVE",
+"282 147 LINE",
+"276 268 OFFCURVE",
+"268 339 OFFCURVE",
+"251 459 CURVE",
+"225 399 LINE",
+"288 422 OFFCURVE",
+"355 449 OFFCURVE",
+"419 478 CURVE SMOOTH",
+"479 505 OFFCURVE",
+"514 527 OFFCURVE",
+"556 556 CURVE",
+"561 555 LINE",
+"565 502 OFFCURVE",
+"576 445 OFFCURVE",
+"580 384 CURVE SMOOTH",
+"582 355 OFFCURVE",
+"584 326 OFFCURVE",
+"585 295 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"743 416 LINE",
+"543 305 OFFCURVE",
+"352 218 OFFCURVE",
+"106 130 CURVE",
+"130 62 LINE",
+"377 150 OFFCURVE",
+"572 239 OFFCURVE",
+"781 354 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"395 58 OFFCURVE",
+"329 -33 OFFCURVE",
+"145 -144 CURVE",
+"183 -203 LINE",
+"358 -96 OFFCURVE",
+"435 -2 OFFCURVE",
+"453 167 CURVE",
+"470 226 LINE",
+"471 248 OFFCURVE",
+"465 270 OFFCURVE",
+"465 294 CURVE SMOOTH",
+"465 354 OFFCURVE",
+"458 434 OFFCURVE",
+"434 537 CURVE",
+"375 482 LINE",
+"390 408 OFFCURVE",
+"395 339 OFFCURVE",
+"395 279 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"749 -86 LINE",
+"667 50 OFFCURVE",
+"586 146 OFFCURVE",
+"469 247 CURVE",
+"432 167 LINE",
+"457 167 LINE",
+"511 119 OFFCURVE",
+"541 85 OFFCURVE",
+"583 30 CURVE SMOOTH",
+"619 -17 OFFCURVE",
+"653 -67 OFFCURVE",
+"687 -124 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"321 573 LINE",
+"294 674 OFFCURVE",
+"267 749 OFFCURVE",
+"219 833 CURVE",
+"158 798 LINE",
+"202 718 OFFCURVE",
+"232 645 OFFCURVE",
+"257 550 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"632 939 LINE",
+"570 899 OFFCURVE",
+"514 865 OFFCURVE",
+"458 833 CURVE",
+"432 822 LINE",
+"370 788 OFFCURVE",
+"310 758 OFFCURVE",
+"245 728 CURVE",
+"222 721 LINE",
+"169 698 OFFCURVE",
+"113 675 OFFCURVE",
+"50 651 CURVE",
+"75 585 LINE",
+"136 609 OFFCURVE",
+"192 632 OFFCURVE",
+"245 656 CURVE",
+"267 663 LINE",
+"334 693 OFFCURVE",
+"397 724 OFFCURVE",
+"460 758 CURVE",
+"495 773 LINE",
+"553 806 OFFCURVE",
+"611 841 OFFCURVE",
+"673 882 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"539 667 LINE",
+"514 771 OFFCURVE",
+"489 834 OFFCURVE",
+"445 924 CURVE",
+"380 893 LINE",
+"419 813 OFFCURVE",
+"450 736 OFFCURVE",
+"472 649 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 851;
+}
+);
+unicode = 1B2A3;
+},
+{
+glyphname = u1B2A4;
+lastChange = "2020-04-13 09:22:19 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"711 258 OFFCURVE",
+"671 418 OFFCURVE",
+"629 534 CURVE",
+"544 546 LINE",
+"479 461 OFFCURVE",
+"409 391 OFFCURVE",
+"322 315 CURVE",
+"374 160 OFFCURVE",
+"408 26 OFFCURVE",
+"432 -98 CURVE",
+"515 -115 LINE",
+"593 -49 OFFCURVE",
+"667 22 OFFCURVE",
+"742 110 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"673 141 LINE",
+"653 118 OFFCURVE",
+"634 97 OFFCURVE",
+"614 76 CURVE SMOOTH",
+"568 28 OFFCURVE",
+"540 2 OFFCURVE",
+"496 -42 CURVE",
+"491 -41 LINE",
+"481 28 OFFCURVE",
+"469 83 OFFCURVE",
+"449 154 CURVE SMOOTH",
+"432 213 OFFCURVE",
+"414 273 OFFCURVE",
+"391 339 CURVE",
+"393 282 LINE",
+"423 309 OFFCURVE",
+"453 337 OFFCURVE",
+"481 365 CURVE SMOOTH",
+"505 389 OFFCURVE",
+"534 425 OFFCURVE",
+"571 471 CURVE",
+"576 470 LINE",
+"594 406 OFFCURVE",
+"607 361 OFFCURVE",
+"624 295 CURVE SMOOTH",
+"642 224 OFFCURVE",
+"659 149 OFFCURVE",
+"671 79 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"628 361 LINE",
+"561 283 OFFCURVE",
+"491 211 OFFCURVE",
+"418 145 CURVE",
+"442 70 LINE",
+"529 147 OFFCURVE",
+"595 214 OFFCURVE",
+"673 297 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"595 939 LINE",
+"541 828 OFFCURVE",
+"484 734 OFFCURVE",
+"423 648 CURVE SMOOTH",
+"371 575 OFFCURVE",
+"322 515 OFFCURVE",
+"275 458 CURVE",
+"270 459 LINE",
+"250 535 OFFCURVE",
+"234 584 OFFCURVE",
+"206 641 CURVE SMOOTH",
+"187 680 OFFCURVE",
+"167 718 OFFCURVE",
+"145 756 CURVE",
+"79 721 LINE",
+"141 617 OFFCURVE",
+"183 515 OFFCURVE",
+"218 412 CURVE",
+"302 393 LINE",
+"442 532 OFFCURVE",
+"560 696 OFFCURVE",
+"664 908 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 -28 OFFCURVE",
+"163 -11 OFFCURVE",
+"163 28 CURVE SMOOTH",
+"163 67 OFFCURVE",
+"140 84 OFFCURVE",
+"112 84 CURVE SMOOTH",
+"83 84 OFFCURVE",
+"60 67 OFFCURVE",
+"60 28 CURVE SMOOTH",
+"60 -11 OFFCURVE",
+"83 -28 OFFCURVE",
+"112 -28 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"155 230 LINE",
+"218 170 OFFCURVE",
+"242 113 OFFCURVE",
+"242 34 CURVE SMOOTH",
+"242 -46 OFFCURVE",
+"221 -101 OFFCURVE",
+"167 -160 CURVE",
+"222 -203 LINE",
+"285 -130 OFFCURVE",
+"316 -62 OFFCURVE",
+"316 32 CURVE SMOOTH",
+"316 131 OFFCURVE",
+"282 203 OFFCURVE",
+"206 278 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 832;
+}
+);
+rightMetricsKey = u1B1C8;
+unicode = 1B2A4;
+},
+{
+glyphname = u1B2A5;
+lastChange = "2020-04-11 20:10:25 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"80 -95 OFFCURVE",
+"109 -143 OFFCURVE",
+"177 -183 CURVE",
+"248 -174 LINE",
+"316 -95 OFFCURVE",
+"334 -30 OFFCURVE",
+"334 31 CURVE SMOOTH",
+"334 91 OFFCURVE",
+"300 132 OFFCURVE",
+"232 170 CURVE",
+"158 160 LINE",
+"100 78 OFFCURVE",
+"80 11 OFFCURVE",
+"80 -38 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 116 LINE",
+"244 84 OFFCURVE",
+"259 49 OFFCURVE",
+"259 20 CURVE SMOOTH",
+"259 -23 OFFCURVE",
+"249 -68 OFFCURVE",
+"209 -132 CURVE",
+"204 -133 LINE",
+"169 -98 OFFCURVE",
+"154 -67 OFFCURVE",
+"154 -34 CURVE SMOOTH",
+"154 8 OFFCURVE",
+"167 52 OFFCURVE",
+"199 115 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"651 570 LINE",
+"569 429 OFFCURVE",
+"506 345 OFFCURVE",
+"406 224 CURVE",
+"452 171 LINE",
+"545 278 OFFCURVE",
+"617 370 OFFCURVE",
+"693 490 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"168 779 LINE",
+"272 525 OFFCURVE",
+"358 280 OFFCURVE",
+"461 -43 CURVE",
+"544 -55 LINE",
+"627 35 OFFCURVE",
+"714 138 OFFCURVE",
+"796 260 CURVE",
+"742 457 OFFCURVE",
+"695 584 OFFCURVE",
+"615 799 CURVE",
+"564 719 LINE",
+"627 562 OFFCURVE",
+"679 410 OFFCURVE",
+"721 245 CURVE",
+"749 325 LINE",
+"716 272 OFFCURVE",
+"683 226 OFFCURVE",
+"650 183 CURVE SMOOTH",
+"606 125 OFFCURVE",
+"557 65 OFFCURVE",
+"519 16 CURVE",
+"514 17 LINE",
+"494 103 OFFCURVE",
+"466 180 OFFCURVE",
+"441 255 CURVE SMOOTH",
+"375 453 OFFCURVE",
+"313 619 OFFCURVE",
+"236 808 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"353 385 LINE",
+"458 514 OFFCURVE",
+"539 629 OFFCURVE",
+"696 904 CURVE",
+"628 939 LINE",
+"484 683 OFFCURVE",
+"413 578 OFFCURVE",
+"331 476 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"160 397 OFFCURVE",
+"183 414 OFFCURVE",
+"183 453 CURVE SMOOTH",
+"183 492 OFFCURVE",
+"160 509 OFFCURVE",
+"132 509 CURVE SMOOTH",
+"103 509 OFFCURVE",
+"80 492 OFFCURVE",
+"80 453 CURVE SMOOTH",
+"80 414 OFFCURVE",
+"103 397 OFFCURVE",
+"132 397 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"428 784 OFFCURVE",
+"451 801 OFFCURVE",
+"451 840 CURVE SMOOTH",
+"451 879 OFFCURVE",
+"428 896 OFFCURVE",
+"400 896 CURVE SMOOTH",
+"371 896 OFFCURVE",
+"348 879 OFFCURVE",
+"348 840 CURVE SMOOTH",
+"348 801 OFFCURVE",
+"371 784 OFFCURVE",
+"400 784 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 886;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B23E;
+unicode = 1B2A5;
+},
+{
+glyphname = u1B2A6;
+lastChange = "2020-04-13 09:22:24 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"730 164 OFFCURVE",
+"708 238 OFFCURVE",
+"676 341 CURVE",
+"598 359 LINE",
+"576 337 OFFCURVE",
+"560 318 OFFCURVE",
+"540 298 CURVE SMOOTH",
+"493 251 OFFCURVE",
+"456 209 OFFCURVE",
+"413 166 CURVE",
+"408 167 LINE",
+"397 231 OFFCURVE",
+"386 278 OFFCURVE",
+"373 330 CURVE SMOOTH",
+"368 350 OFFCURVE",
+"362 371 OFFCURVE",
+"355 395 CURVE",
+"335 320 LINE",
+"430 393 OFFCURVE",
+"493 444 OFFCURVE",
+"584 530 CURVE",
+"531 583 LINE",
+"446 501 OFFCURVE",
+"378 445 OFFCURVE",
+"282 373 CURVE",
+"313 284 OFFCURVE",
+"329 217 OFFCURVE",
+"349 120 CURVE",
+"430 98 LINE",
+"442 107 OFFCURVE",
+"462 127 OFFCURVE",
+"473 137 CURVE SMOOTH",
+"533 191 OFFCURVE",
+"570 229 OFFCURVE",
+"617 284 CURVE",
+"622 283 LINE",
+"635 230 OFFCURVE",
+"645 191 OFFCURVE",
+"658 131 CURVE SMOOTH",
+"664 103 OFFCURVE",
+"671 71 OFFCURVE",
+"678 33 CURVE",
+"700 132 LINE",
+"600 24 OFFCURVE",
+"503 -59 OFFCURVE",
+"384 -146 CURVE",
+"430 -203 LINE",
+"550 -116 OFFCURVE",
+"642 -37 OFFCURVE",
+"747 74 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"385 622 LINE",
+"361 697 OFFCURVE",
+"327 778 OFFCURVE",
+"276 872 CURVE",
+"210 839 LINE",
+"261 742 OFFCURVE",
+"295 660 OFFCURVE",
+"328 570 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"588 763 LINE",
+"614 698 OFFCURVE",
+"636 645 OFFCURVE",
+"659 578 CURVE SMOOTH",
+"674 535 OFFCURVE",
+"687 492 OFFCURVE",
+"701 447 CURVE",
+"773 467 LINE",
+"735 603 OFFCURVE",
+"701 688 OFFCURVE",
+"641 825 CURVE",
+"554 833 LINE",
+"411 687 OFFCURVE",
+"269 578 OFFCURVE",
+"90 459 CURVE",
+"137 318 OFFCURVE",
+"161 225 OFFCURVE",
+"178 108 CURVE",
+"251 123 LINE",
+"231 248 OFFCURVE",
+"209 340 OFFCURVE",
+"164 470 CURVE",
+"153 412 LINE",
+"248 474 OFFCURVE",
+"337 541 OFFCURVE",
+"424 613 CURVE SMOOTH",
+"486 665 OFFCURVE",
+"529 706 OFFCURVE",
+"584 763 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 873;
+}
+);
+leftMetricsKey = u1B286;
+rightMetricsKey = u1B286;
+unicode = 1B2A6;
+},
+{
+glyphname = u1B2A7;
+lastChange = "2020-04-13 09:22:39 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"584 415 OFFCURVE",
+"607 432 OFFCURVE",
+"607 471 CURVE SMOOTH",
+"607 510 OFFCURVE",
+"584 527 OFFCURVE",
+"556 527 CURVE SMOOTH",
+"527 527 OFFCURVE",
+"504 510 OFFCURVE",
+"504 471 CURVE SMOOTH",
+"504 432 OFFCURVE",
+"527 415 OFFCURVE",
+"556 415 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"621 224 OFFCURVE",
+"644 241 OFFCURVE",
+"644 280 CURVE SMOOTH",
+"644 319 OFFCURVE",
+"621 336 OFFCURVE",
+"593 336 CURVE SMOOTH",
+"564 336 OFFCURVE",
+"541 319 OFFCURVE",
+"541 280 CURVE SMOOTH",
+"541 241 OFFCURVE",
+"564 224 OFFCURVE",
+"593 224 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"622 29 OFFCURVE",
+"645 46 OFFCURVE",
+"645 85 CURVE SMOOTH",
+"645 124 OFFCURVE",
+"622 141 OFFCURVE",
+"594 141 CURVE SMOOTH",
+"565 141 OFFCURVE",
+"542 124 OFFCURVE",
+"542 85 CURVE SMOOTH",
+"542 46 OFFCURVE",
+"565 29 OFFCURVE",
+"594 29 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"440 785 OFFCURVE",
+"454 752 OFFCURVE",
+"454 705 CURVE SMOOTH",
+"454 643 OFFCURVE",
+"385 576 OFFCURVE",
+"121 434 CURVE",
+"156 369 LINE",
+"439 527 OFFCURVE",
+"530 608 OFFCURVE",
+"530 701 CURVE SMOOTH",
+"530 769 OFFCURVE",
+"502 824 OFFCURVE",
+"433 898 CURVE",
+"391 839 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"468 140 LINE",
+"456 266 OFFCURVE",
+"432 431 OFFCURVE",
+"396 561 CURVE",
+"338 536 LINE",
+"371 408 OFFCURVE",
+"388 269 OFFCURVE",
+"398 133 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"97 104 LINE",
+"193 22 OFFCURVE",
+"270 -58 OFFCURVE",
+"347 -151 CURVE",
+"405 -106 LINE",
+"368 -63 OFFCURVE",
+"338 -32 OFFCURVE",
+"273 33 CURVE",
+"259 33 LINE",
+"230 74 OFFCURVE",
+"197 106 OFFCURVE",
+"141 154 CURVE",
+"141 122 LINE",
+"199 176 OFFCURVE",
+"238 218 OFFCURVE",
+"267 262 CURVE",
+"298 290 LINE",
+"310 305 OFFCURVE",
+"321 321 OFFCURVE",
+"332 337 CURVE",
+"275 374 LINE",
+"216 295 OFFCURVE",
+"157 229 OFFCURVE",
+"97 175 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"460 939 LINE",
+"336 819 OFFCURVE",
+"215 731 OFFCURVE",
+"60 639 CURVE",
+"96 577 LINE",
+"243 663 OFFCURVE",
+"385 764 OFFCURVE",
+"513 892 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"240 262 LINE",
+"271 262 LINE",
+"282 220 OFFCURVE",
+"286 185 OFFCURVE",
+"286 150 CURVE SMOOTH",
+"286 116 OFFCURVE",
+"279 78 OFFCURVE",
+"263 33 CURVE",
+"254 33 LINE",
+"214 -38 OFFCURVE",
+"171 -91 OFFCURVE",
+"111 -159 CURVE",
+"163 -203 LINE",
+"216 -143 OFFCURVE",
+"249 -93 OFFCURVE",
+"278 -49 CURVE",
+"301 -22 LINE",
+"339 42 OFFCURVE",
+"353 91 OFFCURVE",
+"353 140 CURVE SMOOTH",
+"353 194 OFFCURVE",
+"340 247 OFFCURVE",
+"298 322 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 725;
+}
+);
+leftMetricsKey = u1B29C;
+rightMetricsKey = u1B1FA;
+unicode = 1B2A7;
+},
+{
+glyphname = u1B2A8;
+lastChange = "2020-04-13 09:22:53 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"607 -157 LINE",
+"515 14 OFFCURVE",
+"437 149 OFFCURVE",
+"351 289 CURVE",
+"345 224 LINE",
+"381 249 OFFCURVE",
+"415 275 OFFCURVE",
+"448 300 CURVE SMOOTH",
+"496 336 OFFCURVE",
+"519 361 OFFCURVE",
+"557 399 CURVE",
+"561 399 LINE",
+"588 355 OFFCURVE",
+"619 306 OFFCURVE",
+"646 260 CURVE SMOOTH",
+"674 213 OFFCURVE",
+"703 165 OFFCURVE",
+"733 113 CURVE",
+"728 188 LINE",
+"670 129 OFFCURVE",
+"611 80 OFFCURVE",
+"505 2 CURVE",
+"468 -22 LINE",
+"421 -57 OFFCURVE",
+"365 -98 OFFCURVE",
+"297 -146 CURVE",
+"340 -203 LINE",
+"405 -157 OFFCURVE",
+"460 -118 OFFCURVE",
+"508 -83 CURVE",
+"534 -66 LINE",
+"659 26 OFFCURVE",
+"728 84 OFFCURVE",
+"795 151 CURVE",
+"734 262 OFFCURVE",
+"669 363 OFFCURVE",
+"605 459 CURVE",
+"531 467 LINE",
+"453 390 OFFCURVE",
+"381 335 OFFCURVE",
+"277 261 CURVE",
+"378 102 OFFCURVE",
+"464 -46 OFFCURVE",
+"542 -194 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"624 320 LINE",
+"554 250 OFFCURVE",
+"491 201 OFFCURVE",
+"408 142 CURVE",
+"452 91 LINE",
+"528 147 OFFCURVE",
+"607 209 OFFCURVE",
+"664 262 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"281 426 LINE",
+"266 472 OFFCURVE",
+"244 519 OFFCURVE",
+"208 585 CURVE SMOOTH",
+"188 622 OFFCURVE",
+"166 660 OFFCURVE",
+"142 699 CURVE",
+"80 661 LINE",
+"143 567 OFFCURVE",
+"181 490 OFFCURVE",
+"229 376 CURVE",
+"310 366 LINE",
+"460 475 OFFCURVE",
+"559 559 OFFCURVE",
+"704 723 CURVE",
+"650 770 LINE",
+"576 686 OFFCURVE",
+"509 620 OFFCURVE",
+"436 555 CURVE SMOOTH",
+"384 509 OFFCURVE",
+"336 470 OFFCURVE",
+"285 426 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"514 939 LINE",
+"400 781 OFFCURVE",
+"303 687 OFFCURVE",
+"168 578 CURVE",
+"214 525 LINE",
+"347 634 OFFCURVE",
+"445 725 OFFCURVE",
+"575 897 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 858 LINE",
+"244 796 OFFCURVE",
+"278 741 OFFCURVE",
+"309 688 CURVE",
+"326 668 LINE",
+"360 608 OFFCURVE",
+"391 548 OFFCURVE",
+"423 480 CURVE",
+"467 544 LINE",
+"442 600 OFFCURVE",
+"416 652 OFFCURVE",
+"384 709 CURVE",
+"367 730 LINE",
+"339 779 OFFCURVE",
+"306 832 OFFCURVE",
+"265 896 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 885;
+}
+);
+leftMetricsKey = u1B1A2;
+rightMetricsKey = u1B1BC;
+unicode = 1B2A8;
+},
+{
+glyphname = u1B2A9;
+lastChange = "2020-04-11 20:45:12 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"332 341 LINE",
+"237 240 OFFCURVE",
+"154 166 OFFCURVE",
+"40 83 CURVE",
+"81 24 LINE",
+"201 112 OFFCURVE",
+"287 187 OFFCURVE",
+"385 293 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"203 160 LINE",
+"251 59 OFFCURVE",
+"298 -80 OFFCURVE",
+"323 -203 CURVE",
+"394 -187 LINE",
+"365 -58 OFFCURVE",
+"309 99 OFFCURVE",
+"256 215 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"182 -130 OFFCURVE",
+"205 -113 OFFCURVE",
+"205 -74 CURVE SMOOTH",
+"205 -35 OFFCURVE",
+"182 -18 OFFCURVE",
+"154 -18 CURVE SMOOTH",
+"125 -18 OFFCURVE",
+"102 -35 OFFCURVE",
+"102 -74 CURVE SMOOTH",
+"102 -113 OFFCURVE",
+"125 -130 OFFCURVE",
+"154 -130 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"471 21 OFFCURVE",
+"494 38 OFFCURVE",
+"494 77 CURVE SMOOTH",
+"494 116 OFFCURVE",
+"471 133 OFFCURVE",
+"443 133 CURVE SMOOTH",
+"414 133 OFFCURVE",
+"391 116 OFFCURVE",
+"391 77 CURVE SMOOTH",
+"391 38 OFFCURVE",
+"414 21 OFFCURVE",
+"443 21 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"674 700 LINE",
+"593 575 OFFCURVE",
+"531 494 OFFCURVE",
+"432 384 CURVE",
+"482 329 LINE",
+"571 428 OFFCURVE",
+"645 520 OFFCURVE",
+"718 626 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"543 905 LINE",
+"479 802 OFFCURVE",
+"399 690 OFFCURVE",
+"316 595 CURVE",
+"399 422 OFFCURVE",
+"459 287 OFFCURVE",
+"514 145 CURVE",
+"606 135 LINE",
+"677 209 OFFCURVE",
+"755 299 OFFCURVE",
+"846 421 CURVE",
+"785 587 OFFCURVE",
+"717 747 OFFCURVE",
+"639 899 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"586 838 LINE",
+"620 769 OFFCURVE",
+"642 726 OFFCURVE",
+"674 652 CURVE SMOOTH",
+"713 562 OFFCURVE",
+"751 466 OFFCURVE",
+"785 366 CURVE",
+"794 476 LINE",
+"761 430 OFFCURVE",
+"730 390 OFFCURVE",
+"700 353 CURVE SMOOTH",
+"652 294 OFFCURVE",
+"612 250 OFFCURVE",
+"570 198 CURVE",
+"566 198 LINE",
+"542 272 OFFCURVE",
+"516 337 OFFCURVE",
+"484 409 CURVE SMOOTH",
+"451 483 OFFCURVE",
+"415 558 OFFCURVE",
+"378 633 CURVE",
+"384 556 LINE",
+"424 608 OFFCURVE",
+"460 654 OFFCURVE",
+"492 698 CURVE SMOOTH",
+"531 751 OFFCURVE",
+"550 779 OFFCURVE",
+"582 838 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 936;
+}
+);
+leftMetricsKey = u1B26F;
+rightMetricsKey = u1B1C8;
+unicode = 1B2A9;
+},
+{
+glyphname = u1B2AA;
+lastChange = "2020-04-13 09:23:09 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"160 342 OFFCURVE",
+"183 359 OFFCURVE",
+"183 398 CURVE SMOOTH",
+"183 437 OFFCURVE",
+"160 454 OFFCURVE",
+"132 454 CURVE SMOOTH",
+"103 454 OFFCURVE",
+"80 437 OFFCURVE",
+"80 398 CURVE SMOOTH",
+"80 359 OFFCURVE",
+"103 342 OFFCURVE",
+"132 342 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"634 440 OFFCURVE",
+"657 457 OFFCURVE",
+"657 496 CURVE SMOOTH",
+"657 535 OFFCURVE",
+"634 552 OFFCURVE",
+"606 552 CURVE SMOOTH",
+"577 552 OFFCURVE",
+"554 535 OFFCURVE",
+"554 496 CURVE SMOOTH",
+"554 457 OFFCURVE",
+"577 440 OFFCURVE",
+"606 440 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"419 133 OFFCURVE",
+"442 150 OFFCURVE",
+"442 189 CURVE SMOOTH",
+"442 228 OFFCURVE",
+"419 245 OFFCURVE",
+"391 245 CURVE SMOOTH",
+"362 245 OFFCURVE",
+"339 228 OFFCURVE",
+"339 189 CURVE SMOOTH",
+"339 150 OFFCURVE",
+"362 133 OFFCURVE",
+"391 133 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"557 -28 OFFCURVE",
+"580 -11 OFFCURVE",
+"580 28 CURVE SMOOTH",
+"580 67 OFFCURVE",
+"557 84 OFFCURVE",
+"529 84 CURVE SMOOTH",
+"500 84 OFFCURVE",
+"477 67 OFFCURVE",
+"477 28 CURVE SMOOTH",
+"477 -11 OFFCURVE",
+"500 -28 OFFCURVE",
+"529 -28 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"418 -203 OFFCURVE",
+"441 -186 OFFCURVE",
+"441 -147 CURVE SMOOTH",
+"441 -108 OFFCURVE",
+"418 -91 OFFCURVE",
+"390 -91 CURVE SMOOTH",
+"361 -91 OFFCURVE",
+"338 -108 OFFCURVE",
+"338 -147 CURVE SMOOTH",
+"338 -186 OFFCURVE",
+"361 -203 OFFCURVE",
+"390 -203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"281 -31 OFFCURVE",
+"304 -14 OFFCURVE",
+"304 25 CURVE SMOOTH",
+"304 64 OFFCURVE",
+"281 81 OFFCURVE",
+"253 81 CURVE SMOOTH",
+"224 81 OFFCURVE",
+"201 64 OFFCURVE",
+"201 25 CURVE SMOOTH",
+"201 -14 OFFCURVE",
+"224 -31 OFFCURVE",
+"253 -31 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"143 564 LINE",
+"352 412 OFFCURVE",
+"452 318 OFFCURVE",
+"587 187 CURVE",
+"639 242 LINE",
+"562 316 OFFCURVE",
+"490 381 OFFCURVE",
+"376 483 CURVE",
+"361 483 LINE",
+"311 534 OFFCURVE",
+"253 576 OFFCURVE",
+"183 628 CURVE",
+"186 579 LINE",
+"259 663 OFFCURVE",
+"314 735 OFFCURVE",
+"354 810 CURVE",
+"381 844 LINE",
+"392 863 OFFCURVE",
+"404 883 OFFCURVE",
+"416 905 CURVE",
+"349 939 LINE",
+"275 808 OFFCURVE",
+"221 732 OFFCURVE",
+"143 640 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"486 729 OFFCURVE",
+"460 798 OFFCURVE",
+"370 880 CURVE",
+"325 810 LINE",
+"358 810 LINE",
+"392 749 OFFCURVE",
+"410 706 OFFCURVE",
+"410 650 CURVE SMOOTH",
+"410 603 OFFCURVE",
+"390 545 OFFCURVE",
+"365 483 CURVE",
+"355 483 LINE",
+"297 379 OFFCURVE",
+"209 274 OFFCURVE",
+"87 158 CURVE",
+"138 105 LINE",
+"255 218 OFFCURVE",
+"334 312 OFFCURVE",
+"388 393 CURVE",
+"412 424 LINE",
+"465 509 OFFCURVE",
+"486 582 OFFCURVE",
+"486 650 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 737;
+}
+);
+leftMetricsKey = u1B22F;
+rightMetricsKey = u1B22F;
+unicode = 1B2AA;
+},
+{
+glyphname = u1B2AB;
+lastChange = "2020-04-13 09:23:22 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"511 -169 OFFCURVE",
+"534 -152 OFFCURVE",
+"534 -113 CURVE SMOOTH",
+"534 -74 OFFCURVE",
+"511 -57 OFFCURVE",
+"483 -57 CURVE SMOOTH",
+"454 -57 OFFCURVE",
+"431 -74 OFFCURVE",
+"431 -113 CURVE SMOOTH",
+"431 -152 OFFCURVE",
+"454 -169 OFFCURVE",
+"483 -169 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"160 347 OFFCURVE",
+"183 364 OFFCURVE",
+"183 403 CURVE SMOOTH",
+"183 442 OFFCURVE",
+"160 459 OFFCURVE",
+"132 459 CURVE SMOOTH",
+"103 459 OFFCURVE",
+"80 442 OFFCURVE",
+"80 403 CURVE SMOOTH",
+"80 364 OFFCURVE",
+"103 347 OFFCURVE",
+"132 347 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"281 144 OFFCURVE",
+"304 161 OFFCURVE",
+"304 200 CURVE SMOOTH",
+"304 239 OFFCURVE",
+"281 256 OFFCURVE",
+"253 256 CURVE SMOOTH",
+"224 256 OFFCURVE",
+"201 239 OFFCURVE",
+"201 200 CURVE SMOOTH",
+"201 161 OFFCURVE",
+"224 144 OFFCURVE",
+"253 144 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"313 764 OFFCURVE",
+"336 781 OFFCURVE",
+"336 820 CURVE SMOOTH",
+"336 859 OFFCURVE",
+"313 876 OFFCURVE",
+"285 876 CURVE SMOOTH",
+"256 876 OFFCURVE",
+"233 859 OFFCURVE",
+"233 820 CURVE SMOOTH",
+"233 781 OFFCURVE",
+"256 764 OFFCURVE",
+"285 764 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"778 456 OFFCURVE",
+"801 473 OFFCURVE",
+"801 512 CURVE SMOOTH",
+"801 551 OFFCURVE",
+"778 568 OFFCURVE",
+"750 568 CURVE SMOOTH",
+"721 568 OFFCURVE",
+"698 551 OFFCURVE",
+"698 512 CURVE SMOOTH",
+"698 473 OFFCURVE",
+"721 456 OFFCURVE",
+"750 456 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"732 197 OFFCURVE",
+"755 214 OFFCURVE",
+"755 253 CURVE SMOOTH",
+"755 292 OFFCURVE",
+"732 309 OFFCURVE",
+"704 309 CURVE SMOOTH",
+"675 309 OFFCURVE",
+"652 292 OFFCURVE",
+"652 253 CURVE SMOOTH",
+"652 214 OFFCURVE",
+"675 197 OFFCURVE",
+"704 197 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"319 471 LINE",
+"410 606 OFFCURVE",
+"449 674 OFFCURVE",
+"481 760 CURVE",
+"501 807 LINE",
+"514 841 OFFCURVE",
+"527 878 OFFCURVE",
+"540 919 CURVE",
+"465 939 LINE",
+"406 747 OFFCURVE",
+"347 644 OFFCURVE",
+"271 536 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"524 669 OFFCURVE",
+"538 606 OFFCURVE",
+"538 535 CURVE SMOOTH",
+"538 451 OFFCURVE",
+"521 370 OFFCURVE",
+"481 282 CURVE",
+"471 282 LINE",
+"399 134 OFFCURVE",
+"319 13 OFFCURVE",
+"195 -163 CURVE",
+"259 -203 LINE",
+"364 -47 OFFCURVE",
+"436 69 OFFCURVE",
+"491 165 CURVE",
+"519 207 LINE",
+"588 334 OFFCURVE",
+"614 426 OFFCURVE",
+"614 536 CURVE SMOOTH",
+"614 638 OFFCURVE",
+"584 724 OFFCURVE",
+"505 835 CURVE",
+"447 760 LINE",
+"485 760 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"111 668 LINE",
+"333 391 OFFCURVE",
+"513 117 OFFCURVE",
+"658 -140 CURVE",
+"724 -107 LINE",
+"661 6 OFFCURVE",
+"601 113 OFFCURVE",
+"489 282 CURVE",
+"477 282 LINE",
+"432 357 OFFCURVE",
+"387 426 OFFCURVE",
+"336 496 CURVE SMOOTH",
+"280 573 OFFCURVE",
+"227 641 OFFCURVE",
+"170 714 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 921;
+}
+);
+leftMetricsKey = u1B176;
+rightMetricsKey = u1B1B5;
+unicode = 1B2AB;
+},
+{
+glyphname = u1B2AC;
+lastChange = "2020-04-13 09:24:02 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"261 -30 LINE",
+"245 106 OFFCURVE",
+"220 209 OFFCURVE",
+"164 336 CURVE",
+"100 308 LINE",
+"153 184 OFFCURVE",
+"174 90 OFFCURVE",
+"190 -41 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"533 260 LINE",
+"509 376 OFFCURVE",
+"491 451 OFFCURVE",
+"445 577 CURVE",
+"385 522 LINE",
+"423 418 OFFCURVE",
+"448 334 OFFCURVE",
+"465 225 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"529 939 LINE",
+"373 807 OFFCURVE",
+"246 724 OFFCURVE",
+"101 645 CURVE",
+"138 580 LINE",
+"280 658 OFFCURVE",
+"417 746 OFFCURVE",
+"579 886 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"635 435 OFFCURVE",
+"657 451 OFFCURVE",
+"657 488 CURVE SMOOTH",
+"657 526 OFFCURVE",
+"635 542 OFFCURVE",
+"608 542 CURVE SMOOTH",
+"581 542 OFFCURVE",
+"559 526 OFFCURVE",
+"559 488 CURVE SMOOTH",
+"559 451 OFFCURVE",
+"581 435 OFFCURVE",
+"608 435 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"352 253 OFFCURVE",
+"374 269 OFFCURVE",
+"374 307 CURVE SMOOTH",
+"374 344 OFFCURVE",
+"352 360 OFFCURVE",
+"326 360 CURVE SMOOTH",
+"298 360 OFFCURVE",
+"276 344 OFFCURVE",
+"276 307 CURVE SMOOTH",
+"276 269 OFFCURVE",
+"298 253 OFFCURVE",
+"326 253 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"516 774 OFFCURVE",
+"526 744 OFFCURVE",
+"526 711 CURVE SMOOTH",
+"526 655 OFFCURVE",
+"475 595 OFFCURVE",
+"170 434 CURVE",
+"206 369 LINE",
+"535 540 OFFCURVE",
+"602 623 OFFCURVE",
+"602 710 CURVE SMOOTH",
+"602 762 OFFCURVE",
+"588 796 OFFCURVE",
+"529 862 CURVE",
+"478 818 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"307 103 LINE",
+"455 23 OFFCURVE",
+"573 -48 OFFCURVE",
+"709 -141 CURVE",
+"749 -81 LINE",
+"697 -44 OFFCURVE",
+"651 -17 OFFCURVE",
+"559 39 CURVE",
+"545 39 LINE",
+"494 77 OFFCURVE",
+"446 110 OFFCURVE",
+"368 153 CURVE",
+"357 117 LINE",
+"474 193 OFFCURVE",
+"534 240 OFFCURVE",
+"584 288 CURVE",
+"623 312 LINE",
+"640 325 OFFCURVE",
+"657 339 OFFCURVE",
+"674 354 CURVE",
+"627 410 LINE",
+"515 309 OFFCURVE",
+"421 242 OFFCURVE",
+"307 174 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"564 288 LINE",
+"588 288 LINE",
+"597 253 OFFCURVE",
+"602 220 OFFCURVE",
+"602 193 CURVE SMOOTH",
+"602 146 OFFCURVE",
+"582 93 OFFCURVE",
+"549 39 CURVE",
+"540 39 LINE",
+"478 -32 OFFCURVE",
+"402 -81 OFFCURVE",
+"313 -142 CURVE",
+"352 -203 LINE",
+"451 -137 OFFCURVE",
+"518 -80 OFFCURVE",
+"567 -30 CURVE",
+"595 -3 LINE",
+"658 71 OFFCURVE",
+"676 132 OFFCURVE",
+"676 193 CURVE SMOOTH",
+"676 240 OFFCURVE",
+"664 288 OFFCURVE",
+"621 352 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 859;
+}
+);
+leftMetricsKey = u1B1F3;
+rightMetricsKey = u1B25F;
+unicode = 1B2AC;
+},
+{
+glyphname = u1B2AD;
+lastChange = "2020-04-13 09:29:17 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"241 -74 OFFCURVE",
+"264 -57 OFFCURVE",
+"264 -18 CURVE SMOOTH",
+"264 21 OFFCURVE",
+"241 38 OFFCURVE",
+"213 38 CURVE SMOOTH",
+"184 38 OFFCURVE",
+"161 21 OFFCURVE",
+"161 -18 CURVE SMOOTH",
+"161 -57 OFFCURVE",
+"184 -74 OFFCURVE",
+"213 -74 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"202 144 OFFCURVE",
+"225 161 OFFCURVE",
+"225 200 CURVE SMOOTH",
+"225 239 OFFCURVE",
+"202 256 OFFCURVE",
+"174 256 CURVE SMOOTH",
+"145 256 OFFCURVE",
+"122 239 OFFCURVE",
+"122 200 CURVE SMOOTH",
+"122 161 OFFCURVE",
+"145 144 OFFCURVE",
+"174 144 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"575 508 LINE",
+"483 410 OFFCURVE",
+"419 366 OFFCURVE",
+"318 292 CURVE",
+"374 181 OFFCURVE",
+"391 114 OFFCURVE",
+"391 34 CURVE SMOOTH",
+"391 -46 OFFCURVE",
+"378 -101 OFFCURVE",
+"345 -178 CURVE",
+"411 -203 LINE",
+"450 -120 OFFCURVE",
+"465 -51 OFFCURVE",
+"465 34 CURVE SMOOTH",
+"465 111 OFFCURVE",
+"444 193 OFFCURVE",
+"390 310 CURVE",
+"390 256 LINE",
+"473 317 OFFCURVE",
+"549 370 OFFCURVE",
+"628 460 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"540 677 LINE",
+"431 573 OFFCURVE",
+"328 490 OFFCURVE",
+"203 397 CURVE",
+"243 337 LINE",
+"379 439 OFFCURVE",
+"470 511 OFFCURVE",
+"590 625 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"186 861 LINE",
+"275 687 OFFCURVE",
+"326 565 OFFCURVE",
+"362 450 CURVE",
+"422 496 LINE",
+"383 615 OFFCURVE",
+"346 714 OFFCURVE",
+"251 895 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"596 71 LINE",
+"586 124 OFFCURVE",
+"575 157 OFFCURVE",
+"552 204 CURVE",
+"494 175 LINE",
+"517 121 OFFCURVE",
+"529 91 OFFCURVE",
+"549 28 CURVE",
+"640 19 LINE",
+"677 91 OFFCURVE",
+"696 152 OFFCURVE",
+"696 201 CURVE SMOOTH",
+"696 280 OFFCURVE",
+"665 353 OFFCURVE",
+"562 452 CURVE",
+"527 394 LINE",
+"605 314 OFFCURVE",
+"620 272 OFFCURVE",
+"620 194 CURVE SMOOTH",
+"620 156 OFFCURVE",
+"614 122 OFFCURVE",
+"600 71 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"527 939 LINE",
+"448 856 OFFCURVE",
+"380 790 OFFCURVE",
+"311 730 CURVE",
+"285 718 LINE",
+"229 670 OFFCURVE",
+"171 625 OFFCURVE",
+"104 577 CURVE",
+"145 519 LINE",
+"204 562 OFFCURVE",
+"258 603 OFFCURVE",
+"310 645 CURVE",
+"339 659 LINE",
+"415 724 OFFCURVE",
+"492 796 OFFCURVE",
+"582 892 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 796;
+}
+);
+rightMetricsKey = u1B18D;
+unicode = 1B2AD;
+},
+{
+glyphname = u1B2AE;
+lastChange = "2020-04-13 09:28:58 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"345 162 LINE",
+"296 33 OFFCURVE",
+"259 -36 OFFCURVE",
+"174 -162 CURVE",
+"233 -203 LINE",
+"317 -80 OFFCURVE",
+"361 13 OFFCURVE",
+"410 132 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"120 61 LINE",
+"175 27 OFFCURVE",
+"223 -7 OFFCURVE",
+"267 -41 CURVE",
+"298 -59 LINE",
+"349 -101 OFFCURVE",
+"393 -143 OFFCURVE",
+"432 -186 CURVE",
+"483 -138 LINE",
+"430 -82 OFFCURVE",
+"381 -37 OFFCURVE",
+"325 8 CURVE",
+"304 19 LINE",
+"261 53 OFFCURVE",
+"213 86 OFFCURVE",
+"156 122 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"630 756 LINE",
+"672 621 OFFCURVE",
+"698 501 OFFCURVE",
+"713 363 CURVE",
+"780 372 LINE",
+"766 520 OFFCURVE",
+"744 625 OFFCURVE",
+"696 778 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"199 845 LINE",
+"162 688 OFFCURVE",
+"124 598 OFFCURVE",
+"55 477 CURVE",
+"114 441 LINE",
+"182 560 OFFCURVE",
+"227 661 OFFCURVE",
+"268 830 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"415 920 LINE",
+"339 686 OFFCURVE",
+"253 458 OFFCURVE",
+"174 306 CURVE",
+"189 234 LINE",
+"294 163 OFFCURVE",
+"452 51 OFFCURVE",
+"570 -63 CURVE",
+"646 -29 LINE",
+"621 293 OFFCURVE",
+"570 628 OFFCURVE",
+"503 924 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"457 848 LINE",
+"469 745 OFFCURVE",
+"486 652 OFFCURVE",
+"501 560 CURVE SMOOTH",
+"514 482 OFFCURVE",
+"526 406 OFFCURVE",
+"536 327 CURVE SMOOTH",
+"545 259 OFFCURVE",
+"560 94 OFFCURVE",
+"577 17 CURVE",
+"572 16 LINE",
+"519 77 OFFCURVE",
+"460 129 OFFCURVE",
+"407 172 CURVE SMOOTH",
+"361 210 OFFCURVE",
+"297 251 OFFCURVE",
+"236 295 CURVE",
+"235 255 LINE",
+"273 332 OFFCURVE",
+"327 464 OFFCURVE",
+"356 538 CURVE SMOOTH",
+"390 624 OFFCURVE",
+"424 725 OFFCURVE",
+"453 848 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"834 689 LINE",
+"800 662 OFFCURVE",
+"755 630 OFFCURVE",
+"720 607 CURVE",
+"694 597 LINE",
+"649 570 OFFCURVE",
+"600 544 OFFCURVE",
+"543 518 CURVE",
+"576 455 LINE",
+"627 480 OFFCURVE",
+"672 502 OFFCURVE",
+"715 527 CURVE",
+"743 537 LINE",
+"783 561 OFFCURVE",
+"833 596 OFFCURVE",
+"876 632 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"30 707 LINE",
+"76 677 OFFCURVE",
+"118 646 OFFCURVE",
+"155 617 CURVE",
+"185 600 LINE",
+"234 560 OFFCURVE",
+"275 523 OFFCURVE",
+"306 490 CURVE",
+"345 545 LINE",
+"307 585 OFFCURVE",
+"263 625 OFFCURVE",
+"213 666 CURVE",
+"185 682 LINE",
+"151 708 OFFCURVE",
+"113 735 OFFCURVE",
+"72 763 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 926;
+}
+);
+leftMetricsKey = u1B26B;
+rightMetricsKey = u1B2A1;
+unicode = 1B2AE;
+},
+{
+glyphname = u1B2AF;
+lastChange = "2020-04-13 09:28:10 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"80 15 OFFCURVE",
+"109 -33 OFFCURVE",
+"177 -73 CURVE",
+"248 -64 LINE",
+"316 15 OFFCURVE",
+"334 80 OFFCURVE",
+"334 141 CURVE SMOOTH",
+"334 201 OFFCURVE",
+"300 242 OFFCURVE",
+"232 280 CURVE",
+"158 270 LINE",
+"100 188 OFFCURVE",
+"80 121 OFFCURVE",
+"80 72 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 226 LINE",
+"244 194 OFFCURVE",
+"259 159 OFFCURVE",
+"259 130 CURVE SMOOTH",
+"259 87 OFFCURVE",
+"249 42 OFFCURVE",
+"209 -22 CURVE",
+"204 -23 LINE",
+"169 12 OFFCURVE",
+"154 43 OFFCURVE",
+"154 76 CURVE SMOOTH",
+"154 118 OFFCURVE",
+"167 162 OFFCURVE",
+"199 225 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"321 307 OFFCURVE",
+"344 324 OFFCURVE",
+"344 363 CURVE SMOOTH",
+"344 402 OFFCURVE",
+"321 419 OFFCURVE",
+"293 419 CURVE SMOOTH",
+"264 419 OFFCURVE",
+"241 402 OFFCURVE",
+"241 363 CURVE SMOOTH",
+"241 324 OFFCURVE",
+"264 307 OFFCURVE",
+"293 307 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"626 553 OFFCURVE",
+"649 570 OFFCURVE",
+"649 609 CURVE SMOOTH",
+"649 648 OFFCURVE",
+"626 665 OFFCURVE",
+"598 665 CURVE SMOOTH",
+"569 665 OFFCURVE",
+"546 648 OFFCURVE",
+"546 609 CURVE SMOOTH",
+"546 570 OFFCURVE",
+"569 553 OFFCURVE",
+"598 553 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"221 856 LINE",
+"310 682 OFFCURVE",
+"381 521 OFFCURVE",
+"477 277 CURVE",
+"536 324 LINE",
+"437 572 OFFCURVE",
+"380 710 OFFCURVE",
+"285 891 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"379 176 LINE",
+"498 62 OFFCURVE",
+"592 -42 OFFCURVE",
+"693 -165 CURVE",
+"748 -120 LINE",
+"705 -68 OFFCURVE",
+"654 -9 OFFCURVE",
+"588 65 CURVE",
+"574 65 LINE",
+"534 115 OFFCURVE",
+"495 163 OFFCURVE",
+"428 232 CURVE",
+"424 188 LINE",
+"513 257 OFFCURVE",
+"559 298 OFFCURVE",
+"603 345 CURVE",
+"636 372 LINE",
+"650 387 OFFCURVE",
+"665 403 OFFCURVE",
+"681 421 CURVE",
+"627 474 LINE",
+"525 364 OFFCURVE",
+"465 312 OFFCURVE",
+"379 247 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"705 286 OFFCURVE",
+"686 335 OFFCURVE",
+"626 408 CURVE",
+"578 345 LINE",
+"607 345 LINE",
+"621 307 OFFCURVE",
+"629 266 OFFCURVE",
+"629 227 CURVE SMOOTH",
+"629 178 OFFCURVE",
+"625 131 OFFCURVE",
+"578 65 CURVE",
+"567 65 LINE",
+"495 -15 OFFCURVE",
+"416 -78 OFFCURVE",
+"322 -147 CURVE",
+"366 -203 LINE",
+"466 -131 OFFCURVE",
+"535 -70 OFFCURVE",
+"587 -14 CURVE",
+"615 12 LINE",
+"681 90 OFFCURVE",
+"705 156 OFFCURVE",
+"705 226 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"584 939 LINE",
+"504 845 OFFCURVE",
+"429 765 OFFCURVE",
+"355 694 CURVE",
+"340 686 LINE",
+"263 613 OFFCURVE",
+"187 549 OFFCURVE",
+"110 489 CURVE",
+"155 430 LINE",
+"225 485 OFFCURVE",
+"294 542 OFFCURVE",
+"365 608 CURVE",
+"383 619 LINE",
+"464 695 OFFCURVE",
+"549 783 OFFCURVE",
+"640 890 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 858;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B230;
+unicode = 1B2AF;
+},
+{
+glyphname = u1B2B0;
+lastChange = "2020-04-12 10:09:44 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"410 537 OFFCURVE",
+"433 554 OFFCURVE",
+"433 593 CURVE SMOOTH",
+"433 632 OFFCURVE",
+"410 649 OFFCURVE",
+"382 649 CURVE SMOOTH",
+"353 649 OFFCURVE",
+"330 632 OFFCURVE",
+"330 593 CURVE SMOOTH",
+"330 554 OFFCURVE",
+"353 537 OFFCURVE",
+"382 537 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"500 706 OFFCURVE",
+"523 723 OFFCURVE",
+"523 762 CURVE SMOOTH",
+"523 801 OFFCURVE",
+"500 818 OFFCURVE",
+"472 818 CURVE SMOOTH",
+"443 818 OFFCURVE",
+"420 801 OFFCURVE",
+"420 762 CURVE SMOOTH",
+"420 723 OFFCURVE",
+"443 706 OFFCURVE",
+"472 706 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"269 667 OFFCURVE",
+"292 684 OFFCURVE",
+"292 723 CURVE SMOOTH",
+"292 762 OFFCURVE",
+"271 779 OFFCURVE",
+"241 779 CURVE SMOOTH",
+"212 779 OFFCURVE",
+"189 762 OFFCURVE",
+"189 723 CURVE SMOOTH",
+"189 684 OFFCURVE",
+"212 667 OFFCURVE",
+"241 667 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"360 827 OFFCURVE",
+"383 844 OFFCURVE",
+"383 883 CURVE SMOOTH",
+"383 922 OFFCURVE",
+"360 939 OFFCURVE",
+"332 939 CURVE SMOOTH",
+"303 939 OFFCURVE",
+"280 922 OFFCURVE",
+"280 883 CURVE SMOOTH",
+"280 844 OFFCURVE",
+"303 827 OFFCURVE",
+"332 827 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"491 -203 OFFCURVE",
+"514 -186 OFFCURVE",
+"514 -147 CURVE SMOOTH",
+"514 -108 OFFCURVE",
+"491 -91 OFFCURVE",
+"463 -91 CURVE SMOOTH",
+"434 -91 OFFCURVE",
+"411 -108 OFFCURVE",
+"411 -147 CURVE SMOOTH",
+"411 -186 OFFCURVE",
+"434 -203 OFFCURVE",
+"463 -203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"568 -13 OFFCURVE",
+"591 4 OFFCURVE",
+"591 43 CURVE SMOOTH",
+"591 82 OFFCURVE",
+"568 99 OFFCURVE",
+"540 99 CURVE SMOOTH",
+"511 99 OFFCURVE",
+"488 82 OFFCURVE",
+"488 43 CURVE SMOOTH",
+"488 4 OFFCURVE",
+"511 -13 OFFCURVE",
+"540 -13 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"334 -93 OFFCURVE",
+"357 -76 OFFCURVE",
+"357 -37 CURVE SMOOTH",
+"357 2 OFFCURVE",
+"334 19 OFFCURVE",
+"306 19 CURVE SMOOTH",
+"277 19 OFFCURVE",
+"254 2 OFFCURVE",
+"254 -37 CURVE SMOOTH",
+"254 -76 OFFCURVE",
+"277 -93 OFFCURVE",
+"306 -93 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"411 87 OFFCURVE",
+"434 104 OFFCURVE",
+"434 143 CURVE SMOOTH",
+"434 182 OFFCURVE",
+"411 199 OFFCURVE",
+"383 199 CURVE SMOOTH",
+"354 199 OFFCURVE",
+"331 182 OFFCURVE",
+"331 143 CURVE SMOOTH",
+"331 104 OFFCURVE",
+"354 87 OFFCURVE",
+"383 87 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"114 604 LINE",
+"164 475 OFFCURVE",
+"177 363 OFFCURVE",
+"177 276 CURVE SMOOTH",
+"177 164 OFFCURVE",
+"158 64 OFFCURVE",
+"100 -44 CURVE",
+"160 -72 LINE",
+"229 56 OFFCURVE",
+"249 160 OFFCURVE",
+"249 276 CURVE SMOOTH",
+"249 382 OFFCURVE",
+"230 490 OFFCURVE",
+"179 626 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"569 716 OFFCURVE",
+"548 607 OFFCURVE",
+"548 491 CURVE SMOOTH",
+"548 354 OFFCURVE",
+"575 245 OFFCURVE",
+"627 135 CURVE",
+"691 162 LINE",
+"642 276 OFFCURVE",
+"620 358 OFFCURVE",
+"620 496 CURVE SMOOTH",
+"620 607 OFFCURVE",
+"638 699 OFFCURVE",
+"686 822 CURVE",
+"620 844 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 791;
+}
+);
+leftMetricsKey = u1B174;
+rightMetricsKey = u1B174;
+unicode = 1B2B0;
+},
+{
+glyphname = u1B2B1;
+lastChange = "2020-04-13 09:26:57 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"491 817 OFFCURVE",
+"514 834 OFFCURVE",
+"514 873 CURVE SMOOTH",
+"514 912 OFFCURVE",
+"491 929 OFFCURVE",
+"463 929 CURVE SMOOTH",
+"434 929 OFFCURVE",
+"411 912 OFFCURVE",
+"411 873 CURVE SMOOTH",
+"411 834 OFFCURVE",
+"434 817 OFFCURVE",
+"463 817 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"692 598 OFFCURVE",
+"674 690 OFFCURVE",
+"646 790 CURVE",
+"565 807 LINE",
+"464 733 OFFCURVE",
+"356 667 OFFCURVE",
+"225 594 CURVE",
+"250 480 OFFCURVE",
+"265 393 OFFCURVE",
+"276 288 CURVE",
+"350 260 LINE",
+"478 324 OFFCURVE",
+"590 387 OFFCURVE",
+"706 479 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"643 524 LINE",
+"594 486 OFFCURVE",
+"541 451 OFFCURVE",
+"487 418 CURVE SMOOTH",
+"425 380 OFFCURVE",
+"392 362 OFFCURVE",
+"345 334 CURVE",
+"340 336 LINE",
+"333 406 OFFCURVE",
+"326 473 OFFCURVE",
+"318 509 CURVE SMOOTH",
+"311 541 OFFCURVE",
+"304 576 OFFCURVE",
+"296 615 CURVE",
+"275 538 LINE",
+"335 571 OFFCURVE",
+"389 602 OFFCURVE",
+"440 634 CURVE SMOOTH",
+"497 670 OFFCURVE",
+"536 697 OFFCURVE",
+"582 732 CURVE",
+"587 731 LINE",
+"599 679 OFFCURVE",
+"609 628 OFFCURVE",
+"617 579 CURVE SMOOTH",
+"623 542 OFFCURVE",
+"628 503 OFFCURVE",
+"632 461 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"296 695 OFFCURVE",
+"319 712 OFFCURVE",
+"319 751 CURVE SMOOTH",
+"319 790 OFFCURVE",
+"296 807 OFFCURVE",
+"268 807 CURVE SMOOTH",
+"239 807 OFFCURVE",
+"216 790 OFFCURVE",
+"216 751 CURVE SMOOTH",
+"216 712 OFFCURVE",
+"239 695 OFFCURVE",
+"268 695 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"231 21 LINE",
+"229 164 OFFCURVE",
+"215 267 OFFCURVE",
+"190 391 CURVE",
+"120 377 LINE",
+"146 251 OFFCURVE",
+"156 156 OFFCURVE",
+"159 21 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"401 342 LINE",
+"409 274 OFFCURVE",
+"411 232 OFFCURVE",
+"411 182 CURVE SMOOTH",
+"411 17 OFFCURVE",
+"379 -37 OFFCURVE",
+"239 -148 CURVE",
+"285 -203 LINE",
+"447 -81 OFFCURVE",
+"481 11 OFFCURVE",
+"481 182 CURVE SMOOTH",
+"481 242 OFFCURVE",
+"473 292 OFFCURVE",
+"449 392 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"649 -46 LINE",
+"719 24 OFFCURVE",
+"770 115 OFFCURVE",
+"819 237 CURVE",
+"750 261 LINE",
+"744 245 OFFCURVE",
+"739 230 OFFCURVE",
+"734 216 CURVE SMOOTH",
+"702 126 OFFCURVE",
+"668 89 OFFCURVE",
+"634 29 CURVE",
+"629 30 LINE",
+"634 108 OFFCURVE",
+"631 178 OFFCURVE",
+"625 228 CURVE SMOOTH",
+"616 302 OFFCURVE",
+"601 374 OFFCURVE",
+"582 448 CURVE",
+"526 402 LINE",
+"552 264 OFFCURVE",
+"566 165 OFFCURVE",
+"574 -22 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 869;
+}
+);
+leftMetricsKey = u1B17E;
+unicode = 1B2B1;
+},
+{
+glyphname = u1B2B2;
+lastChange = "2020-04-13 09:26:54 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"257 260 LINE",
+"242 86 OFFCURVE",
+"213 -41 OFFCURVE",
+"152 -172 CURVE",
+"216 -203 LINE",
+"281 -61 OFFCURVE",
+"313 69 OFFCURVE",
+"328 253 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"130 35 OFFCURVE",
+"153 52 OFFCURVE",
+"153 91 CURVE SMOOTH",
+"153 130 OFFCURVE",
+"130 147 OFFCURVE",
+"102 147 CURVE SMOOTH",
+"73 147 OFFCURVE",
+"50 130 OFFCURVE",
+"50 91 CURVE SMOOTH",
+"50 52 OFFCURVE",
+"73 35 OFFCURVE",
+"102 35 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"436 -128 OFFCURVE",
+"459 -111 OFFCURVE",
+"459 -72 CURVE SMOOTH",
+"459 -33 OFFCURVE",
+"436 -16 OFFCURVE",
+"408 -16 CURVE SMOOTH",
+"379 -16 OFFCURVE",
+"356 -33 OFFCURVE",
+"356 -72 CURVE SMOOTH",
+"356 -111 OFFCURVE",
+"379 -128 OFFCURVE",
+"408 -128 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"547 16 LINE",
+"664 124 OFFCURVE",
+"741 212 OFFCURVE",
+"830 334 CURVE",
+"768 378 LINE",
+"730 324 OFFCURVE",
+"696 277 OFFCURVE",
+"659 234 CURVE SMOOTH",
+"614 182 OFFCURVE",
+"567 132 OFFCURVE",
+"520 84 CURVE",
+"516 84 LINE",
+"492 165 OFFCURVE",
+"472 224 OFFCURVE",
+"449 279 CURVE SMOOTH",
+"405 383 OFFCURVE",
+"351 497 OFFCURVE",
+"270 655 CURVE",
+"286 590 LINE",
+"325 632 OFFCURVE",
+"365 679 OFFCURVE",
+"404 730 CURVE SMOOTH",
+"432 766 OFFCURVE",
+"453 799 OFFCURVE",
+"480 846 CURVE",
+"484 846 LINE",
+"510 795 OFFCURVE",
+"537 741 OFFCURVE",
+"558 699 CURVE SMOOTH",
+"590 635 OFFCURVE",
+"619 569 OFFCURVE",
+"652 488 CURVE",
+"642 578 LINE",
+"557 455 OFFCURVE",
+"497 388 OFFCURVE",
+"402 290 CURVE",
+"458 243 LINE",
+"554 340 OFFCURVE",
+"620 417 OFFCURVE",
+"711 545 CURVE",
+"650 683 OFFCURVE",
+"592 801 OFFCURVE",
+"522 914 CURVE",
+"445 914 LINE",
+"371 803 OFFCURVE",
+"298 710 OFFCURVE",
+"209 612 CURVE",
+"336 364 OFFCURVE",
+"409 198 OFFCURVE",
+"468 26 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"552 753 LINE",
+"484 645 OFFCURVE",
+"411 560 OFFCURVE",
+"334 477 CURVE",
+"372 415 LINE",
+"464 511 OFFCURVE",
+"527 589 OFFCURVE",
+"600 696 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"600 283 OFFCURVE",
+"623 235 OFFCURVE",
+"643 186 CURVE",
+"660 158 LINE",
+"683 101 OFFCURVE",
+"703 43 OFFCURVE",
+"723 -25 CURVE",
+"794 -5 LINE",
+"768 81 OFFCURVE",
+"743 149 OFFCURVE",
+"714 216 CURVE",
+"698 239 LINE",
+"679 282 OFFCURVE",
+"657 325 OFFCURVE",
+"632 372 CURVE",
+"573 338 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 910;
+}
+);
+leftMetricsKey = u1B1D7;
+rightMetricsKey = u1B274;
+unicode = 1B2B2;
+},
+{
+glyphname = u1B2B3;
+lastChange = "2020-04-13 09:26:43 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"182 845 LINE",
+"159 705 OFFCURVE",
+"128 586 OFFCURVE",
+"80 453 CURVE",
+"193 373 OFFCURVE",
+"287 290 OFFCURVE",
+"359 209 CURVE",
+"410 262 LINE",
+"345 335 OFFCURVE",
+"246 415 OFFCURVE",
+"154 486 CURVE",
+"149 450 LINE",
+"200 587 OFFCURVE",
+"230 698 OFFCURVE",
+"255 833 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"375 939 LINE",
+"351 771 OFFCURVE",
+"329 658 OFFCURVE",
+"280 517 CURVE",
+"376 455 OFFCURVE",
+"448 397 OFFCURVE",
+"516 333 CURVE",
+"565 387 LINE",
+"481 463 OFFCURVE",
+"417 509 OFFCURVE",
+"346 554 CURVE",
+"345 513 LINE",
+"399 648 OFFCURVE",
+"424 761 OFFCURVE",
+"447 933 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"566 926 LINE",
+"545 793 OFFCURVE",
+"523 689 OFFCURVE",
+"485 593 CURVE",
+"554 547 OFFCURVE",
+"619 491 OFFCURVE",
+"680 430 CURVE",
+"728 485 LINE",
+"667 544 OFFCURVE",
+"608 591 OFFCURVE",
+"549 629 CURVE",
+"555 590 LINE",
+"593 686 OFFCURVE",
+"616 783 OFFCURVE",
+"639 914 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"741 329 LINE",
+"692 241 OFFCURVE",
+"647 168 OFFCURVE",
+"601 104 CURVE SMOOTH",
+"531 6 OFFCURVE",
+"463 -69 OFFCURVE",
+"394 -135 CURVE",
+"389 -134 LINE",
+"366 -51 OFFCURVE",
+"342 17 OFFCURVE",
+"301 104 CURVE SMOOTH",
+"293 121 OFFCURVE",
+"285 138 OFFCURVE",
+"276 155 CURVE",
+"210 121 LINE",
+"270 9 OFFCURVE",
+"299 -57 OFFCURVE",
+"335 -178 CURVE",
+"424 -198 LINE",
+"587 -38 OFFCURVE",
+"681 78 OFFCURVE",
+"806 293 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"479 91 OFFCURVE",
+"502 108 OFFCURVE",
+"502 147 CURVE SMOOTH",
+"502 186 OFFCURVE",
+"479 203 OFFCURVE",
+"451 203 CURVE SMOOTH",
+"422 203 OFFCURVE",
+"399 186 OFFCURVE",
+"399 147 CURVE SMOOTH",
+"399 108 OFFCURVE",
+"422 91 OFFCURVE",
+"451 91 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"176 -120 OFFCURVE",
+"199 -103 OFFCURVE",
+"199 -64 CURVE SMOOTH",
+"199 -25 OFFCURVE",
+"176 -8 OFFCURVE",
+"148 -8 CURVE SMOOTH",
+"119 -8 OFFCURVE",
+"96 -25 OFFCURVE",
+"96 -64 CURVE SMOOTH",
+"96 -103 OFFCURVE",
+"119 -120 OFFCURVE",
+"148 -120 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 886;
+}
+);
+rightMetricsKey = u1B193;
+unicode = 1B2B3;
+},
+{
+glyphname = u1B2B4;
+lastChange = "2020-04-13 09:26:40 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"725 427 LINE",
+"664 388 OFFCURVE",
+"602 353 OFFCURVE",
+"537 321 CURVE",
+"493 304 LINE",
+"424 272 OFFCURVE",
+"351 243 OFFCURVE",
+"272 215 CURVE",
+"295 149 LINE",
+"369 176 OFFCURVE",
+"438 203 OFFCURVE",
+"508 234 CURVE",
+"543 246 LINE",
+"618 282 OFFCURVE",
+"691 322 OFFCURVE",
+"763 368 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"439 9 OFFCURVE",
+"461 25 OFFCURVE",
+"461 62 CURVE SMOOTH",
+"461 99 OFFCURVE",
+"439 115 OFFCURVE",
+"412 115 CURVE SMOOTH",
+"384 115 OFFCURVE",
+"362 99 OFFCURVE",
+"362 62 CURVE SMOOTH",
+"362 25 OFFCURVE",
+"384 9 OFFCURVE",
+"412 9 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"741 124 OFFCURVE",
+"764 141 OFFCURVE",
+"764 180 CURVE SMOOTH",
+"764 219 OFFCURVE",
+"741 236 OFFCURVE",
+"713 236 CURVE SMOOTH",
+"684 236 OFFCURVE",
+"661 219 OFFCURVE",
+"661 180 CURVE SMOOTH",
+"661 141 OFFCURVE",
+"684 124 OFFCURVE",
+"713 124 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"582 809 LINE",
+"522 764 OFFCURVE",
+"460 721 OFFCURVE",
+"398 681 CURVE",
+"367 665 LINE",
+"294 621 OFFCURVE",
+"220 580 OFFCURVE",
+"143 542 CURVE",
+"172 476 LINE",
+"251 516 OFFCURVE",
+"324 555 OFFCURVE",
+"396 598 CURVE",
+"428 614 LINE",
+"493 654 OFFCURVE",
+"558 699 OFFCURVE",
+"627 753 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"657 624 LINE",
+"599 581 OFFCURVE",
+"537 541 OFFCURVE",
+"472 504 CURVE",
+"434 487 LINE",
+"364 449 OFFCURVE",
+"291 416 OFFCURVE",
+"216 386 CURVE",
+"243 321 LINE",
+"320 352 OFFCURVE",
+"391 384 OFFCURVE",
+"457 420 CURVE",
+"493 435 LINE",
+"564 475 OFFCURVE",
+"631 519 OFFCURVE",
+"700 568 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"194 640 OFFCURVE",
+"217 657 OFFCURVE",
+"217 696 CURVE SMOOTH",
+"217 735 OFFCURVE",
+"194 752 OFFCURVE",
+"166 752 CURVE SMOOTH",
+"137 752 OFFCURVE",
+"114 735 OFFCURVE",
+"114 696 CURVE SMOOTH",
+"114 657 OFFCURVE",
+"137 640 OFFCURVE",
+"166 640 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"487 815 OFFCURVE",
+"510 832 OFFCURVE",
+"510 871 CURVE SMOOTH",
+"510 910 OFFCURVE",
+"487 927 OFFCURVE",
+"459 927 CURVE SMOOTH",
+"430 927 OFFCURVE",
+"407 910 OFFCURVE",
+"407 871 CURVE SMOOTH",
+"407 832 OFFCURVE",
+"430 815 OFFCURVE",
+"459 815 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"614 -30 LINE",
+"555 398 OFFCURVE",
+"465 606 OFFCURVE",
+"287 900 CURVE",
+"228 861 LINE",
+"410 571 OFFCURVE",
+"493 358 OFFCURVE",
+"542 -39 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"118 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -103 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 884;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B1A8;
+unicode = 1B2B4;
+},
+{
+glyphname = u1B2B5;
+lastChange = "2020-04-13 09:26:37 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"623 18 LINE",
+"588 327 OFFCURVE",
+"542 523 OFFCURVE",
+"469 713 CURVE",
+"461 672 LINE",
+"485 699 OFFCURVE",
+"505 722 OFFCURVE",
+"522 741 CURVE SMOOTH",
+"553 776 OFFCURVE",
+"582 818 OFFCURVE",
+"609 864 CURVE",
+"613 864 LINE",
+"630 815 OFFCURVE",
+"649 762 OFFCURVE",
+"665 712 CURVE SMOOTH",
+"682 660 OFFCURVE",
+"698 606 OFFCURVE",
+"715 539 CURVE",
+"717 628 LINE",
+"651 544 OFFCURVE",
+"591 487 OFFCURVE",
+"531 421 CURVE",
+"558 363 LINE",
+"639 434 OFFCURVE",
+"702 498 OFFCURVE",
+"773 579 CURVE",
+"734 721 OFFCURVE",
+"708 803 OFFCURVE",
+"654 929 CURVE",
+"583 934 LINE",
+"530 853 OFFCURVE",
+"476 786 OFFCURVE",
+"400 705 CURVE",
+"481 483 OFFCURVE",
+"524 296 OFFCURVE",
+"551 9 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"657 789 LINE",
+"601 710 OFFCURVE",
+"544 643 OFFCURVE",
+"477 577 CURVE",
+"504 519 LINE",
+"593 608 OFFCURVE",
+"631 651 OFFCURVE",
+"689 739 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"283 -197 LINE",
+"260 70 OFFCURVE",
+"235 227 OFFCURVE",
+"179 431 CURVE",
+"169 386 LINE",
+"195 413 OFFCURVE",
+"221 440 OFFCURVE",
+"245 467 CURVE SMOOTH",
+"256 480 OFFCURVE",
+"277 505 OFFCURVE",
+"308 550 CURVE",
+"312 550 LINE",
+"326 505 OFFCURVE",
+"337 469 OFFCURVE",
+"347 424 CURVE SMOOTH",
+"361 361 OFFCURVE",
+"373 301 OFFCURVE",
+"385 225 CURVE",
+"398 306 LINE",
+"341 235 OFFCURVE",
+"283 179 OFFCURVE",
+"217 110 CURVE",
+"236 49 LINE",
+"315 118 OFFCURVE",
+"381 182 OFFCURVE",
+"448 254 CURVE",
+"423 401 OFFCURVE",
+"399 494 OFFCURVE",
+"355 629 CURVE",
+"293 634 LINE",
+"232 550 OFFCURVE",
+"180 490 OFFCURVE",
+"110 420 CURVE",
+"168 205 OFFCURVE",
+"196 50 OFFCURVE",
+"213 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"350 470 LINE",
+"293 392 OFFCURVE",
+"243 338 OFFCURVE",
+"166 268 CURVE",
+"193 213 LINE",
+"273 284 OFFCURVE",
+"303 318 OFFCURVE",
+"375 413 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 893;
+}
+);
+leftMetricsKey = u1B1BB;
+rightMetricsKey = u1B1BB;
+unicode = 1B2B5;
+},
+{
+glyphname = u1B2B6;
+lastChange = "2020-04-13 09:26:34 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"650 195 LINE",
+"643 259 OFFCURVE",
+"631 324 OFFCURVE",
+"615 393 CURVE SMOOTH",
+"590 498 OFFCURVE",
+"557 596 OFFCURVE",
+"515 706 CURVE",
+"456 660 LINE",
+"521 498 OFFCURVE",
+"563 360 OFFCURVE",
+"592 154 CURVE",
+"678 132 LINE",
+"747 198 OFFCURVE",
+"815 303 OFFCURVE",
+"890 455 CURVE",
+"826 483 LINE",
+"805 436 OFFCURVE",
+"787 396 OFFCURVE",
+"767 360 CURVE SMOOTH",
+"729 291 OFFCURVE",
+"695 244 OFFCURVE",
+"655 194 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"665 456 LINE",
+"694 403 OFFCURVE",
+"721 347 OFFCURVE",
+"744 289 CURVE",
+"758 266 LINE",
+"777 216 OFFCURVE",
+"793 164 OFFCURVE",
+"805 111 CURVE",
+"873 128 LINE",
+"854 197 OFFCURVE",
+"830 265 OFFCURVE",
+"804 326 CURVE",
+"784 361 LINE",
+"762 408 OFFCURVE",
+"741 452 OFFCURVE",
+"721 489 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"600 939 LINE",
+"511 771 OFFCURVE",
+"436 677 OFFCURVE",
+"336 577 CURVE",
+"384 526 LINE",
+"500 644 OFFCURVE",
+"571 735 OFFCURVE",
+"664 910 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"697 749 LINE",
+"650 673 OFFCURVE",
+"601 606 OFFCURVE",
+"549 547 CURVE",
+"529 532 LINE",
+"492 490 OFFCURVE",
+"453 452 OFFCURVE",
+"413 417 CURVE",
+"456 367 LINE",
+"488 395 OFFCURVE",
+"521 425 OFFCURVE",
+"552 457 CURVE",
+"581 479 LINE",
+"646 550 OFFCURVE",
+"707 630 OFFCURVE",
+"758 716 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"358 -136 LINE",
+"353 -68 OFFCURVE",
+"344 -17 OFFCURVE",
+"329 55 CURVE SMOOTH",
+"310 146 OFFCURVE",
+"284 234 OFFCURVE",
+"241 335 CURVE",
+"194 264 LINE",
+"244 140 OFFCURVE",
+"282 -7 OFFCURVE",
+"299 -182 CURVE",
+"388 -203 LINE",
+"484 -104 OFFCURVE",
+"547 -7 OFFCURVE",
+"601 103 CURVE",
+"541 130 LINE",
+"523 93 OFFCURVE",
+"505 60 OFFCURVE",
+"486 27 CURVE SMOOTH",
+"448 -39 OFFCURVE",
+"413 -88 OFFCURVE",
+"363 -137 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"389 99 LINE",
+"416 52 OFFCURVE",
+"439 7 OFFCURVE",
+"460 -41 CURVE",
+"476 -66 LINE",
+"492 -105 OFFCURVE",
+"507 -146 OFFCURVE",
+"522 -193 CURVE",
+"588 -169 LINE",
+"567 -106 OFFCURVE",
+"547 -53 OFFCURVE",
+"525 -6 CURVE",
+"506 23 LINE",
+"488 61 OFFCURVE",
+"469 96 OFFCURVE",
+"448 132 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"331 522 LINE",
+"242 383 OFFCURVE",
+"153 277 OFFCURVE",
+"60 191 CURVE",
+"106 141 LINE",
+"218 243 OFFCURVE",
+"300 343 OFFCURVE",
+"390 487 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"420 349 LINE",
+"382 291 OFFCURVE",
+"331 226 OFFCURVE",
+"280 164 CURVE",
+"260 151 LINE",
+"210 93 OFFCURVE",
+"159 40 OFFCURVE",
+"119 3 CURVE",
+"166 -48 LINE",
+"202 -15 OFFCURVE",
+"241 26 OFFCURVE",
+"282 70 CURVE",
+"305 86 LINE",
+"366 156 OFFCURVE",
+"427 235 OFFCURVE",
+"477 311 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 970;
+}
+);
+leftMetricsKey = u1B1C2;
+rightMetricsKey = u1B1C2;
+unicode = 1B2B6;
+},
+{
+glyphname = u1B2B7;
+lastChange = "2020-04-13 09:30:26 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"321 268 LINE",
+"288 237 OFFCURVE",
+"253 211 OFFCURVE",
+"219 187 CURVE",
+"192 179 LINE",
+"152 153 OFFCURVE",
+"111 132 OFFCURVE",
+"70 111 CURVE",
+"100 49 LINE",
+"144 69 OFFCURVE",
+"186 91 OFFCURVE",
+"226 117 CURVE",
+"250 123 LINE",
+"292 151 OFFCURVE",
+"331 182 OFFCURVE",
+"370 218 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"405 105 LINE",
+"366 72 OFFCURVE",
+"329 44 OFFCURVE",
+"289 19 CURVE",
+"262 12 LINE",
+"222 -11 OFFCURVE",
+"179 -33 OFFCURVE",
+"130 -56 CURVE",
+"159 -120 LINE",
+"206 -99 OFFCURVE",
+"247 -78 OFFCURVE",
+"286 -55 CURVE",
+"315 -47 LINE",
+"357 -20 OFFCURVE",
+"399 10 OFFCURVE",
+"447 48 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"377 -186 LINE",
+"328 0 OFFCURVE",
+"272 140 OFFCURVE",
+"170 314 CURVE",
+"113 277 LINE",
+"215 97 OFFCURVE",
+"264 -32 OFFCURVE",
+"309 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"577 -42 LINE",
+"691 79 OFFCURVE",
+"760 162 OFFCURVE",
+"844 290 CURVE",
+"780 331 LINE",
+"744 271 OFFCURVE",
+"711 223 OFFCURVE",
+"676 177 CURVE SMOOTH",
+"637 126 OFFCURVE",
+"596 77 OFFCURVE",
+"552 25 CURVE",
+"547 26 LINE",
+"520 123 OFFCURVE",
+"486 222 OFFCURVE",
+"452 308 CURVE SMOOTH",
+"408 418 OFFCURVE",
+"361 525 OFFCURVE",
+"287 670 CURVE",
+"302 604 LINE",
+"333 638 OFFCURVE",
+"363 671 OFFCURVE",
+"392 707 CURVE SMOOTH",
+"416 737 OFFCURVE",
+"451 788 OFFCURVE",
+"485 846 CURVE",
+"489 846 LINE",
+"518 788 OFFCURVE",
+"545 738 OFFCURVE",
+"569 689 CURVE SMOOTH",
+"599 628 OFFCURVE",
+"627 564 OFFCURVE",
+"658 488 CURVE",
+"648 579 LINE",
+"563 456 OFFCURVE",
+"503 389 OFFCURVE",
+"408 291 CURVE",
+"464 243 LINE",
+"560 340 OFFCURVE",
+"626 417 OFFCURVE",
+"717 545 CURVE",
+"656 683 OFFCURVE",
+"597 801 OFFCURVE",
+"527 914 CURVE",
+"451 914 LINE",
+"377 803 OFFCURVE",
+"314 725 OFFCURVE",
+"225 627 CURVE",
+"352 379 OFFCURVE",
+"412 215 OFFCURVE",
+"498 -32 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"558 754 LINE",
+"490 651 OFFCURVE",
+"417 564 OFFCURVE",
+"340 481 CURVE",
+"373 413 LINE",
+"465 509 OFFCURVE",
+"528 589 OFFCURVE",
+"601 691 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"613 239 OFFCURVE",
+"638 189 OFFCURVE",
+"660 139 CURVE",
+"678 112 LINE",
+"702 53 OFFCURVE",
+"723 -5 OFFCURVE",
+"743 -74 CURVE",
+"814 -55 LINE",
+"787 33 OFFCURVE",
+"762 102 OFFCURVE",
+"730 172 CURVE",
+"712 197 LINE",
+"692 240 OFFCURVE",
+"669 283 OFFCURVE",
+"641 332 CURVE",
+"582 297 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 924;
+}
+);
+leftMetricsKey = u1B1ED;
+rightMetricsKey = u1B274;
+unicode = 1B2B7;
+},
+{
+glyphname = u1B2B8;
+lastChange = "2020-04-13 09:25:05 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"599 692 OFFCURVE",
+"551 804 OFFCURVE",
+"496 919 CURVE",
+"421 929 LINE",
+"346 834 OFFCURVE",
+"282 765 OFFCURVE",
+"206 697 CURVE",
+"258 582 OFFCURVE",
+"307 468 OFFCURVE",
+"340 363 CURVE",
+"418 350 LINE",
+"498 415 OFFCURVE",
+"571 481 OFFCURVE",
+"644 565 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"574 595 LINE",
+"546 564 OFFCURVE",
+"520 537 OFFCURVE",
+"494 512 CURVE SMOOTH",
+"458 477 OFFCURVE",
+"428 447 OFFCURVE",
+"397 417 CURVE",
+"393 417 LINE",
+"377 474 OFFCURVE",
+"354 536 OFFCURVE",
+"335 582 CURVE SMOOTH",
+"316 627 OFFCURVE",
+"295 673 OFFCURVE",
+"271 721 CURVE",
+"274 662 LINE",
+"305 690 OFFCURVE",
+"335 720 OFFCURVE",
+"365 751 CURVE SMOOTH",
+"385 772 OFFCURVE",
+"413 808 OFFCURVE",
+"448 852 CURVE",
+"452 852 LINE",
+"470 804 OFFCURVE",
+"489 762 OFFCURVE",
+"511 710 CURVE SMOOTH",
+"535 653 OFFCURVE",
+"558 595 OFFCURVE",
+"578 541 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"505 766 LINE",
+"436 680 OFFCURVE",
+"378 621 OFFCURVE",
+"308 562 CURVE",
+"332 496 LINE",
+"419 570 OFFCURVE",
+"486 636 OFFCURVE",
+"554 720 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"286 236 LINE",
+"248 378 OFFCURVE",
+"209 475 OFFCURVE",
+"151 596 CURVE",
+"90 563 LINE",
+"146 449 OFFCURVE",
+"182 362 OFFCURVE",
+"219 217 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"691 327 OFFCURVE",
+"715 277 OFFCURVE",
+"740 218 CURVE SMOOTH",
+"753 187 OFFCURVE",
+"767 154 OFFCURVE",
+"781 116 CURVE",
+"847 144 LINE",
+"805 258 OFFCURVE",
+"764 340 OFFCURVE",
+"704 449 CURVE",
+"631 455 LINE",
+"518 335 OFFCURVE",
+"415 238 OFFCURVE",
+"269 125 CURVE",
+"332 6 OFFCURVE",
+"376 -95 OFFCURVE",
+"413 -203 CURVE",
+"482 -181 LINE",
+"440 -62 OFFCURVE",
+"403 24 OFFCURVE",
+"344 137 CURVE",
+"349 96 LINE",
+"417 147 OFFCURVE",
+"481 202 OFFCURVE",
+"544 261 CURVE SMOOTH",
+"579 294 OFFCURVE",
+"617 335 OFFCURVE",
+"656 387 CURVE",
+"660 387 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 143 OFFCURVE",
+"565 60 OFFCURVE",
+"605 -44 CURVE",
+"674 -16 LINE",
+"629 95 OFFCURVE",
+"590 180 OFFCURVE",
+"521 299 CURVE",
+"471 251 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 927;
+}
+);
+leftMetricsKey = u1B1F2;
+rightMetricsKey = u1B270;
+unicode = 1B2B8;
+},
+{
+glyphname = u1B2B9;
+lastChange = "2020-04-13 09:25:03 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"373 220 LINE",
+"330 191 OFFCURVE",
+"284 163 OFFCURVE",
+"238 137 CURVE",
+"212 128 LINE",
+"162 102 OFFCURVE",
+"111 77 OFFCURVE",
+"60 54 CURVE",
+"89 -11 LINE",
+"139 11 OFFCURVE",
+"189 35 OFFCURVE",
+"237 61 CURVE",
+"265 71 LINE",
+"317 99 OFFCURVE",
+"366 129 OFFCURVE",
+"412 160 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"344 -94 LINE",
+"312 18 OFFCURVE",
+"257 155 OFFCURVE",
+"202 286 CURVE",
+"133 256 LINE",
+"189 132 OFFCURVE",
+"244 -8 OFFCURVE",
+"281 -127 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"434 20 LINE",
+"347 -46 OFFCURVE",
+"240 -100 OFFCURVE",
+"150 -137 CURVE",
+"178 -203 LINE",
+"291 -157 OFFCURVE",
+"391 -102 OFFCURVE",
+"477 -38 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"709 570 LINE",
+"627 429 OFFCURVE",
+"564 345 OFFCURVE",
+"464 224 CURVE",
+"510 171 LINE",
+"603 278 OFFCURVE",
+"675 370 OFFCURVE",
+"751 490 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"226 779 LINE",
+"330 525 OFFCURVE",
+"416 280 OFFCURVE",
+"519 -43 CURVE",
+"602 -55 LINE",
+"685 35 OFFCURVE",
+"772 138 OFFCURVE",
+"854 260 CURVE",
+"800 457 OFFCURVE",
+"753 584 OFFCURVE",
+"673 799 CURVE",
+"622 719 LINE",
+"685 562 OFFCURVE",
+"737 410 OFFCURVE",
+"779 245 CURVE",
+"807 325 LINE",
+"774 272 OFFCURVE",
+"741 226 OFFCURVE",
+"708 183 CURVE SMOOTH",
+"664 125 OFFCURVE",
+"615 65 OFFCURVE",
+"577 16 CURVE",
+"572 17 LINE",
+"552 103 OFFCURVE",
+"524 180 OFFCURVE",
+"499 255 CURVE SMOOTH",
+"433 453 OFFCURVE",
+"371 619 OFFCURVE",
+"294 808 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"411 385 LINE",
+"516 514 OFFCURVE",
+"597 629 OFFCURVE",
+"754 904 CURVE",
+"686 939 LINE",
+"542 683 OFFCURVE",
+"471 578 OFFCURVE",
+"389 476 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"218 397 OFFCURVE",
+"241 414 OFFCURVE",
+"241 453 CURVE SMOOTH",
+"241 492 OFFCURVE",
+"218 509 OFFCURVE",
+"190 509 CURVE SMOOTH",
+"161 509 OFFCURVE",
+"138 492 OFFCURVE",
+"138 453 CURVE SMOOTH",
+"138 414 OFFCURVE",
+"161 397 OFFCURVE",
+"190 397 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"486 784 OFFCURVE",
+"509 801 OFFCURVE",
+"509 840 CURVE SMOOTH",
+"509 879 OFFCURVE",
+"486 896 OFFCURVE",
+"458 896 CURVE SMOOTH",
+"429 896 OFFCURVE",
+"406 879 OFFCURVE",
+"406 840 CURVE SMOOTH",
+"406 801 OFFCURVE",
+"429 784 OFFCURVE",
+"458 784 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 944;
+}
+);
+leftMetricsKey = u1B226;
+rightMetricsKey = u1B23E;
+unicode = 1B2B9;
+},
+{
+glyphname = u1B2BA;
+lastChange = "2020-04-13 09:24:48 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"774 537 LINE",
+"737 460 OFFCURVE",
+"697 391 OFFCURVE",
+"653 326 CURVE SMOOTH",
+"605 255 OFFCURVE",
+"569 206 OFFCURVE",
+"521 149 CURVE",
+"517 149 LINE",
+"491 219 OFFCURVE",
+"460 282 OFFCURVE",
+"423 352 CURVE SMOOTH",
+"415 367 OFFCURVE",
+"406 381 OFFCURVE",
+"396 397 CURVE",
+"333 359 LINE",
+"390 268 OFFCURVE",
+"425 203 OFFCURVE",
+"465 99 CURVE",
+"550 80 LINE",
+"663 202 OFFCURVE",
+"749 328 OFFCURVE",
+"839 503 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"581 362 OFFCURVE",
+"604 379 OFFCURVE",
+"604 418 CURVE SMOOTH",
+"604 457 OFFCURVE",
+"581 474 OFFCURVE",
+"553 474 CURVE SMOOTH",
+"524 474 OFFCURVE",
+"501 457 OFFCURVE",
+"501 418 CURVE SMOOTH",
+"501 379 OFFCURVE",
+"524 362 OFFCURVE",
+"553 362 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"346 126 OFFCURVE",
+"368 142 OFFCURVE",
+"368 179 CURVE SMOOTH",
+"368 216 OFFCURVE",
+"346 232 OFFCURVE",
+"319 232 CURVE SMOOTH",
+"291 232 OFFCURVE",
+"269 216 OFFCURVE",
+"269 179 CURVE SMOOTH",
+"269 142 OFFCURVE",
+"291 126 OFFCURVE",
+"319 126 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"621 939 LINE",
+"573 843 OFFCURVE",
+"528 763 OFFCURVE",
+"480 689 CURVE SMOOTH",
+"439 625 OFFCURVE",
+"398 569 OFFCURVE",
+"359 514 CURVE",
+"355 514 LINE",
+"335 578 OFFCURVE",
+"301 638 OFFCURVE",
+"270 688 CURVE SMOOTH",
+"257 709 OFFCURVE",
+"243 730 OFFCURVE",
+"226 753 CURVE",
+"166 711 LINE",
+"227 622 OFFCURVE",
+"270 550 OFFCURVE",
+"305 461 CURVE",
+"390 450 LINE",
+"506 592 OFFCURVE",
+"589 712 OFFCURVE",
+"689 909 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"397 723 OFFCURVE",
+"420 740 OFFCURVE",
+"420 779 CURVE SMOOTH",
+"420 818 OFFCURVE",
+"397 835 OFFCURVE",
+"369 835 CURVE SMOOTH",
+"340 835 OFFCURVE",
+"317 818 OFFCURVE",
+"317 779 CURVE SMOOTH",
+"317 740 OFFCURVE",
+"340 723 OFFCURVE",
+"369 723 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"173 463 OFFCURVE",
+"196 480 OFFCURVE",
+"196 519 CURVE SMOOTH",
+"196 558 OFFCURVE",
+"173 575 OFFCURVE",
+"145 575 CURVE SMOOTH",
+"116 575 OFFCURVE",
+"93 558 OFFCURVE",
+"93 519 CURVE SMOOTH",
+"93 480 OFFCURVE",
+"116 463 OFFCURVE",
+"145 463 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"118 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -103 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 919;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B193;
+unicode = 1B2BA;
+},
+{
+glyphname = u1B2BB;
+lastChange = "2020-04-13 09:24:45 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"747 454 OFFCURVE",
+"719 589 OFFCURVE",
+"690 693 CURVE",
+"606 719 LINE",
+"566 691 OFFCURVE",
+"525 665 OFFCURVE",
+"481 641 CURVE",
+"443 624 LINE",
+"384 594 OFFCURVE",
+"321 566 OFFCURVE",
+"253 536 CURVE",
+"288 380 OFFCURVE",
+"305 265 OFFCURVE",
+"323 145 CURVE",
+"389 115 LINE",
+"436 135 OFFCURVE",
+"482 155 OFFCURVE",
+"528 176 CURVE",
+"562 189 LINE",
+"633 222 OFFCURVE",
+"701 258 OFFCURVE",
+"766 298 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"603 34 LINE",
+"597 100 OFFCURVE",
+"591 165 OFFCURVE",
+"582 231 CURVE",
+"572 278 LINE",
+"556 384 OFFCURVE",
+"535 491 OFFCURVE",
+"506 604 CURVE",
+"502 636 LINE",
+"486 695 OFFCURVE",
+"469 755 OFFCURVE",
+"449 818 CURVE",
+"383 778 LINE",
+"403 713 OFFCURVE",
+"421 652 OFFCURVE",
+"437 593 CURVE",
+"450 555 LINE",
+"477 447 OFFCURVE",
+"496 344 OFFCURVE",
+"510 236 CURVE",
+"513 195 LINE",
+"520 136 OFFCURVE",
+"525 75 OFFCURVE",
+"530 10 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"703 342 LINE",
+"657 317 OFFCURVE",
+"607 291 OFFCURVE",
+"556 266 CURVE",
+"515 249 LINE",
+"464 224 OFFCURVE",
+"429 208 OFFCURVE",
+"390 188 CURVE",
+"385 189 LINE",
+"379 246 OFFCURVE",
+"373 296 OFFCURVE",
+"361 363 CURVE SMOOTH",
+"351 420 OFFCURVE",
+"340 478 OFFCURVE",
+"330 529 CURVE",
+"308 482 LINE",
+"361 504 OFFCURVE",
+"414 529 OFFCURVE",
+"465 555 CURVE",
+"503 572 LINE",
+"551 597 OFFCURVE",
+"577 615 OFFCURVE",
+"619 644 CURVE",
+"624 643 LINE",
+"641 589 OFFCURVE",
+"653 535 OFFCURVE",
+"664 481 CURVE SMOOTH",
+"676 423 OFFCURVE",
+"685 361 OFFCURVE",
+"693 290 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"663 531 LINE",
+"615 502 OFFCURVE",
+"569 477 OFFCURVE",
+"524 455 CURVE",
+"485 439 LINE",
+"435 414 OFFCURVE",
+"385 392 OFFCURVE",
+"334 371 CURVE",
+"340 300 LINE",
+"392 321 OFFCURVE",
+"447 345 OFFCURVE",
+"502 371 CURVE",
+"538 385 LINE",
+"591 412 OFFCURVE",
+"643 440 OFFCURVE",
+"693 470 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"592 939 LINE",
+"466 850 OFFCURVE",
+"331 775 OFFCURVE",
+"190 715 CURVE",
+"217 648 LINE",
+"362 711 OFFCURVE",
+"505 788 OFFCURVE",
+"639 884 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"754 150 LINE",
+"634 89 OFFCURVE",
+"517 43 OFFCURVE",
+"374 -5 CURVE",
+"396 -71 LINE",
+"533 -26 OFFCURVE",
+"656 19 OFFCURVE",
+"786 86 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 126 LINE",
+"206 45 LINE",
+"238 -17 OFFCURVE",
+"259 -64 OFFCURVE",
+"297 -165 CURVE",
+"368 -138 LINE",
+"322 -20 OFFCURVE",
+"277 60 OFFCURVE",
+"203 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"162 226 LINE",
+"145 60 OFFCURVE",
+"118 -53 OFFCURVE",
+"70 -183 CURVE",
+"142 -203 LINE",
+"177 -103 OFFCURVE",
+"191 -28 OFFCURVE",
+"201 44 CURVE",
+"220 49 LINE",
+"226 82 OFFCURVE",
+"232 186 OFFCURVE",
+"235 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 886;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B244;
+unicode = 1B2BB;
+},
+{
+glyphname = u1B2BC;
+lastChange = "2020-04-13 09:24:38 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"793 672 LINE",
+"759 645 OFFCURVE",
+"725 620 OFFCURVE",
+"690 597 CURVE",
+"664 587 LINE",
+"619 560 OFFCURVE",
+"570 534 OFFCURVE",
+"513 508 CURVE",
+"546 445 LINE",
+"597 470 OFFCURVE",
+"642 492 OFFCURVE",
+"685 517 CURVE",
+"713 527 LINE",
+"753 551 OFFCURVE",
+"792 579 OFFCURVE",
+"835 615 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"605 740 LINE",
+"647 605 OFFCURVE",
+"673 485 OFFCURVE",
+"688 347 CURVE",
+"756 353 LINE",
+"742 501 OFFCURVE",
+"720 606 OFFCURVE",
+"672 759 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"208 864 LINE",
+"170 709 OFFCURVE",
+"134 614 OFFCURVE",
+"73 492 CURVE",
+"137 461 LINE",
+"198 580 OFFCURVE",
+"237 681 OFFCURVE",
+"278 850 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"190 85 OFFCURVE",
+"213 102 OFFCURVE",
+"213 141 CURVE SMOOTH",
+"213 180 OFFCURVE",
+"190 197 OFFCURVE",
+"162 197 CURVE SMOOTH",
+"133 197 OFFCURVE",
+"110 180 OFFCURVE",
+"110 141 CURVE SMOOTH",
+"110 102 OFFCURVE",
+"133 85 OFFCURVE",
+"162 85 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"353 -63 OFFCURVE",
+"376 -46 OFFCURVE",
+"376 -7 CURVE SMOOTH",
+"376 32 OFFCURVE",
+"353 49 OFFCURVE",
+"325 49 CURVE SMOOTH",
+"296 49 OFFCURVE",
+"273 32 OFFCURVE",
+"273 -7 CURVE SMOOTH",
+"273 -46 OFFCURVE",
+"296 -63 OFFCURVE",
+"325 -63 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"527 -203 OFFCURVE",
+"550 -186 OFFCURVE",
+"550 -147 CURVE SMOOTH",
+"550 -108 OFFCURVE",
+"527 -91 OFFCURVE",
+"499 -91 CURVE SMOOTH",
+"470 -91 OFFCURVE",
+"447 -108 OFFCURVE",
+"447 -147 CURVE SMOOTH",
+"447 -186 OFFCURVE",
+"470 -203 OFFCURVE",
+"499 -203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"407 920 LINE",
+"331 686 OFFCURVE",
+"268 522 OFFCURVE",
+"189 370 CURVE",
+"204 298 LINE",
+"309 227 OFFCURVE",
+"437 124 OFFCURVE",
+"555 10 CURVE",
+"631 44 LINE",
+"606 366 OFFCURVE",
+"562 628 OFFCURVE",
+"495 924 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"449 848 LINE",
+"461 745 OFFCURVE",
+"478 652 OFFCURVE",
+"493 560 CURVE SMOOTH",
+"506 482 OFFCURVE",
+"518 406 OFFCURVE",
+"528 327 CURVE SMOOTH",
+"537 259 OFFCURVE",
+"545 167 OFFCURVE",
+"562 90 CURVE",
+"557 89 LINE",
+"504 150 OFFCURVE",
+"459 198 OFFCURVE",
+"406 241 CURVE SMOOTH",
+"360 279 OFFCURVE",
+"312 315 OFFCURVE",
+"251 359 CURVE",
+"250 319 LINE",
+"288 396 OFFCURVE",
+"319 464 OFFCURVE",
+"348 538 CURVE SMOOTH",
+"382 624 OFFCURVE",
+"416 725 OFFCURVE",
+"445 848 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"30 727 LINE",
+"76 697 OFFCURVE",
+"118 666 OFFCURVE",
+"155 637 CURVE",
+"185 620 LINE",
+"234 580 OFFCURVE",
+"275 543 OFFCURVE",
+"306 510 CURVE",
+"345 565 LINE",
+"307 605 OFFCURVE",
+"263 645 OFFCURVE",
+"213 686 CURVE",
+"185 702 LINE",
+"151 728 OFFCURVE",
+"113 755 OFFCURVE",
+"72 783 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 885;
+}
+);
+leftMetricsKey = u1B26B;
+rightMetricsKey = u1B2A1;
+unicode = 1B2BC;
+},
+{
+glyphname = u1B2BD;
+lastChange = "2020-04-13 09:24:05 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"341 497 LINE",
+"238 364 OFFCURVE",
+"146 282 OFFCURVE",
+"50 202 CURVE",
+"94 148 LINE",
+"192 228 OFFCURVE",
+"296 323 OFFCURVE",
+"395 452 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"338 352 OFFCURVE",
+"360 318 OFFCURVE",
+"360 272 CURVE SMOOTH",
+"360 220 OFFCURVE",
+"330 168 OFFCURVE",
+"113 -1 CURVE",
+"157 -55 LINE",
+"402 136 OFFCURVE",
+"430 198 OFFCURVE",
+"430 272 CURVE SMOOTH",
+"430 326 OFFCURVE",
+"406 376 OFFCURVE",
+"335 450 CURVE",
+"290 394 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"294 75 LINE",
+"346 -26 OFFCURVE",
+"360 -89 OFFCURVE",
+"371 -203 CURVE",
+"445 -194 LINE",
+"430 -68 OFFCURVE",
+"407 12 OFFCURVE",
+"346 128 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"271 -174 OFFCURVE",
+"293 -158 OFFCURVE",
+"293 -121 CURVE SMOOTH",
+"293 -84 OFFCURVE",
+"271 -68 OFFCURVE",
+"244 -68 CURVE SMOOTH",
+"216 -68 OFFCURVE",
+"194 -84 OFFCURVE",
+"194 -121 CURVE SMOOTH",
+"194 -158 OFFCURVE",
+"216 -174 OFFCURVE",
+"244 -174 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"525 7 OFFCURVE",
+"548 24 OFFCURVE",
+"548 63 CURVE SMOOTH",
+"548 102 OFFCURVE",
+"525 119 OFFCURVE",
+"497 119 CURVE SMOOTH",
+"468 119 OFFCURVE",
+"445 102 OFFCURVE",
+"445 63 CURVE SMOOTH",
+"445 24 OFFCURVE",
+"468 7 OFFCURVE",
+"497 7 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"714 730 LINE",
+"633 605 OFFCURVE",
+"571 524 OFFCURVE",
+"472 414 CURVE",
+"522 359 LINE",
+"611 458 OFFCURVE",
+"685 550 OFFCURVE",
+"758 656 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"583 935 LINE",
+"519 832 OFFCURVE",
+"439 720 OFFCURVE",
+"356 625 CURVE",
+"439 452 OFFCURVE",
+"499 317 OFFCURVE",
+"554 175 CURVE",
+"646 165 LINE",
+"717 239 OFFCURVE",
+"795 329 OFFCURVE",
+"886 451 CURVE",
+"825 617 OFFCURVE",
+"757 777 OFFCURVE",
+"679 929 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"626 868 LINE",
+"660 799 OFFCURVE",
+"682 756 OFFCURVE",
+"714 682 CURVE SMOOTH",
+"753 592 OFFCURVE",
+"791 496 OFFCURVE",
+"825 396 CURVE",
+"834 506 LINE",
+"801 460 OFFCURVE",
+"770 420 OFFCURVE",
+"740 383 CURVE SMOOTH",
+"692 324 OFFCURVE",
+"652 280 OFFCURVE",
+"610 228 CURVE",
+"606 228 LINE",
+"582 302 OFFCURVE",
+"556 367 OFFCURVE",
+"524 439 CURVE SMOOTH",
+"491 513 OFFCURVE",
+"455 588 OFFCURVE",
+"418 663 CURVE",
+"424 586 LINE",
+"464 638 OFFCURVE",
+"500 684 OFFCURVE",
+"532 728 CURVE SMOOTH",
+"571 781 OFFCURVE",
+"590 809 OFFCURVE",
+"622 868 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 976;
+}
+);
+rightMetricsKey = u1B1C8;
+unicode = 1B2BD;
+},
+{
+glyphname = u1B2BE;
+lastChange = "2020-04-13 09:29:21 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"130 273 OFFCURVE",
+"153 290 OFFCURVE",
+"153 329 CURVE SMOOTH",
+"153 368 OFFCURVE",
+"130 385 OFFCURVE",
+"102 385 CURVE SMOOTH",
+"73 385 OFFCURVE",
+"50 368 OFFCURVE",
+"50 329 CURVE SMOOTH",
+"50 290 OFFCURVE",
+"73 273 OFFCURVE",
+"102 273 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"242 75 OFFCURVE",
+"265 92 OFFCURVE",
+"265 131 CURVE SMOOTH",
+"265 170 OFFCURVE",
+"242 187 OFFCURVE",
+"214 187 CURVE SMOOTH",
+"185 187 OFFCURVE",
+"162 170 OFFCURVE",
+"162 131 CURVE SMOOTH",
+"162 92 OFFCURVE",
+"185 75 OFFCURVE",
+"214 75 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"279 -158 OFFCURVE",
+"302 -141 OFFCURVE",
+"302 -102 CURVE SMOOTH",
+"302 -63 OFFCURVE",
+"279 -46 OFFCURVE",
+"251 -46 CURVE SMOOTH",
+"222 -46 OFFCURVE",
+"199 -63 OFFCURVE",
+"199 -102 CURVE SMOOTH",
+"199 -141 OFFCURVE",
+"222 -158 OFFCURVE",
+"251 -158 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"354 146 OFFCURVE",
+"337 93 OFFCURVE",
+"337 32 CURVE SMOOTH",
+"337 -105 OFFCURVE",
+"424 -203 OFFCURVE",
+"612 -203 CURVE",
+"615 -131 LINE",
+"466 -131 OFFCURVE",
+"411 -69 OFFCURVE",
+"411 37 CURVE SMOOTH",
+"411 98 OFFCURVE",
+"427 135 OFFCURVE",
+"472 174 CURVE",
+"451 274 LINE",
+"317 274 OFFCURVE",
+"274 336 OFFCURVE",
+"274 436 CURVE SMOOTH",
+"274 505 OFFCURVE",
+"295 548 OFFCURVE",
+"359 593 CURVE",
+"316 648 LINE",
+"236 593 OFFCURVE",
+"200 519 OFFCURVE",
+"200 433 CURVE SMOOTH",
+"200 361 OFFCURVE",
+"222 302 OFFCURVE",
+"258 263 CURVE SMOOTH",
+"288 231 OFFCURVE",
+"328 212 OFFCURVE",
+"390 207 CURVE",
+"391 203 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"921 286 OFFCURVE",
+"944 303 OFFCURVE",
+"944 342 CURVE SMOOTH",
+"944 381 OFFCURVE",
+"921 398 OFFCURVE",
+"893 398 CURVE SMOOTH",
+"864 398 OFFCURVE",
+"841 381 OFFCURVE",
+"841 342 CURVE SMOOTH",
+"841 303 OFFCURVE",
+"864 286 OFFCURVE",
+"893 286 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"608 162 OFFCURVE",
+"631 179 OFFCURVE",
+"631 218 CURVE SMOOTH",
+"631 257 OFFCURVE",
+"608 274 OFFCURVE",
+"580 274 CURVE SMOOTH",
+"551 274 OFFCURVE",
+"528 257 OFFCURVE",
+"528 218 CURVE SMOOTH",
+"528 179 OFFCURVE",
+"551 162 OFFCURVE",
+"580 162 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"816 939 LINE",
+"668 819 OFFCURVE",
+"526 736 OFFCURVE",
+"362 651 CURVE",
+"396 588 LINE",
+"560 672 OFFCURVE",
+"701 755 OFFCURVE",
+"863 887 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"776 763 OFFCURVE",
+"791 711 OFFCURVE",
+"791 667 CURVE SMOOTH",
+"791 581 OFFCURVE",
+"727 531 OFFCURVE",
+"435 395 CURVE",
+"469 329 LINE",
+"790 481 OFFCURVE",
+"867 554 OFFCURVE",
+"867 667 CURVE SMOOTH",
+"867 738 OFFCURVE",
+"845 804 OFFCURVE",
+"768 893 CURVE",
+"729 822 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"802 29 LINE",
+"793 183 OFFCURVE",
+"774 301 OFFCURVE",
+"731 477 CURVE",
+"671 434 LINE",
+"705 270 OFFCURVE",
+"717 175 OFFCURVE",
+"726 23 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 1064;
+}
+);
+leftMetricsKey = u1B1D7;
+rightMetricsKey = u1B1B3;
+unicode = 1B2BE;
+},
+{
+glyphname = u1B2BF;
+lastChange = "2020-04-13 09:30:12 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"523 265 LINE",
+"482 435 OFFCURVE",
+"437 591 OFFCURVE",
+"359 773 CURVE",
+"304 713 LINE",
+"371 547 OFFCURVE",
+"423 382 OFFCURVE",
+"456 225 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"600 737 LINE",
+"537 687 OFFCURVE",
+"474 639 OFFCURVE",
+"408 594 CURVE",
+"380 580 LINE",
+"310 533 OFFCURVE",
+"237 486 OFFCURVE",
+"157 440 CURVE",
+"192 376 LINE",
+"268 420 OFFCURVE",
+"339 465 OFFCURVE",
+"408 512 CURVE",
+"429 521 LINE",
+"503 572 OFFCURVE",
+"574 625 OFFCURVE",
+"647 682 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"519 939 LINE",
+"363 814 OFFCURVE",
+"225 721 OFFCURVE",
+"70 635 CURVE",
+"106 572 LINE",
+"258 657 OFFCURVE",
+"405 751 OFFCURVE",
+"567 884 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"625 448 OFFCURVE",
+"647 464 OFFCURVE",
+"647 501 CURVE SMOOTH",
+"647 539 OFFCURVE",
+"625 555 OFFCURVE",
+"598 555 CURVE SMOOTH",
+"571 555 OFFCURVE",
+"549 539 OFFCURVE",
+"549 501 CURVE SMOOTH",
+"549 464 OFFCURVE",
+"571 448 OFFCURVE",
+"598 448 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"332 266 OFFCURVE",
+"354 282 OFFCURVE",
+"354 320 CURVE SMOOTH",
+"354 357 OFFCURVE",
+"332 373 OFFCURVE",
+"306 373 CURVE SMOOTH",
+"278 373 OFFCURVE",
+"256 357 OFFCURVE",
+"256 320 CURVE SMOOTH",
+"256 282 OFFCURVE",
+"278 266 OFFCURVE",
+"306 266 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"297 103 LINE",
+"445 23 OFFCURVE",
+"563 -48 OFFCURVE",
+"699 -141 CURVE",
+"740 -82 LINE",
+"688 -45 OFFCURVE",
+"641 -19 OFFCURVE",
+"549 37 CURVE",
+"535 37 LINE",
+"484 75 OFFCURVE",
+"437 109 OFFCURVE",
+"359 152 CURVE",
+"348 118 LINE",
+"465 194 OFFCURVE",
+"525 240 OFFCURVE",
+"575 288 CURVE",
+"614 313 LINE",
+"631 326 OFFCURVE",
+"648 340 OFFCURVE",
+"665 355 CURVE",
+"617 410 LINE",
+"505 309 OFFCURVE",
+"411 242 OFFCURVE",
+"297 174 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"555 288 LINE",
+"579 288 LINE",
+"588 255 OFFCURVE",
+"592 220 OFFCURVE",
+"592 193 CURVE SMOOTH",
+"592 146 OFFCURVE",
+"577 90 OFFCURVE",
+"539 37 CURVE",
+"530 37 LINE",
+"468 -34 OFFCURVE",
+"391 -82 OFFCURVE",
+"302 -143 CURVE",
+"342 -203 LINE",
+"608 -26 OFFCURVE",
+"666 85 OFFCURVE",
+"666 193 CURVE SMOOTH",
+"666 240 OFFCURVE",
+"654 288 OFFCURVE",
+"611 352 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"178 207 LINE",
+"173 72 OFFCURVE",
+"161 -21 OFFCURVE",
+"120 -126 CURVE",
+"184 -154 LINE",
+"226 -48 OFFCURVE",
+"242 60 OFFCURVE",
+"249 202 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"50 37 LINE",
+"98 27 OFFCURVE",
+"141 16 OFFCURVE",
+"182 3 CURVE",
+"203 1 LINE",
+"242 -11 OFFCURVE",
+"279 -25 OFFCURVE",
+"315 -42 CURVE",
+"347 20 LINE",
+"305 40 OFFCURVE",
+"261 57 OFFCURVE",
+"216 72 CURVE",
+"192 74 LINE",
+"152 86 OFFCURVE",
+"111 96 OFFCURVE",
+"68 105 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 850;
+}
+);
+leftMetricsKey = u1B1AC;
+rightMetricsKey = u1B276;
+unicode = 1B2BF;
+},
+{
+glyphname = u1B2C0;
+lastChange = "2020-04-13 09:30:36 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"335 -203 OFFCURVE",
+"358 -186 OFFCURVE",
+"358 -147 CURVE SMOOTH",
+"358 -108 OFFCURVE",
+"335 -91 OFFCURVE",
+"307 -91 CURVE SMOOTH",
+"278 -91 OFFCURVE",
+"255 -108 OFFCURVE",
+"255 -147 CURVE SMOOTH",
+"255 -186 OFFCURVE",
+"278 -203 OFFCURVE",
+"307 -203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"251 41 OFFCURVE",
+"274 58 OFFCURVE",
+"274 97 CURVE SMOOTH",
+"274 136 OFFCURVE",
+"251 153 OFFCURVE",
+"223 153 CURVE SMOOTH",
+"194 153 OFFCURVE",
+"171 136 OFFCURVE",
+"171 97 CURVE SMOOTH",
+"171 58 OFFCURVE",
+"194 41 OFFCURVE",
+"223 41 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"150 278 OFFCURVE",
+"173 295 OFFCURVE",
+"173 334 CURVE SMOOTH",
+"173 373 OFFCURVE",
+"150 390 OFFCURVE",
+"122 390 CURVE SMOOTH",
+"93 390 OFFCURVE",
+"70 373 OFFCURVE",
+"70 334 CURVE SMOOTH",
+"70 295 OFFCURVE",
+"93 278 OFFCURVE",
+"122 278 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"537 -42 LINE",
+"651 79 OFFCURVE",
+"720 162 OFFCURVE",
+"804 290 CURVE",
+"740 331 LINE",
+"704 271 OFFCURVE",
+"671 223 OFFCURVE",
+"636 177 CURVE SMOOTH",
+"597 126 OFFCURVE",
+"556 77 OFFCURVE",
+"512 25 CURVE",
+"507 26 LINE",
+"480 123 OFFCURVE",
+"446 222 OFFCURVE",
+"412 308 CURVE SMOOTH",
+"368 418 OFFCURVE",
+"321 525 OFFCURVE",
+"247 670 CURVE",
+"262 604 LINE",
+"293 638 OFFCURVE",
+"323 671 OFFCURVE",
+"352 707 CURVE SMOOTH",
+"376 737 OFFCURVE",
+"411 788 OFFCURVE",
+"445 846 CURVE",
+"449 846 LINE",
+"478 788 OFFCURVE",
+"505 738 OFFCURVE",
+"529 689 CURVE SMOOTH",
+"559 628 OFFCURVE",
+"587 564 OFFCURVE",
+"618 488 CURVE",
+"608 579 LINE",
+"523 456 OFFCURVE",
+"463 389 OFFCURVE",
+"368 291 CURVE",
+"424 243 LINE",
+"520 340 OFFCURVE",
+"586 417 OFFCURVE",
+"677 545 CURVE",
+"616 683 OFFCURVE",
+"557 801 OFFCURVE",
+"487 914 CURVE",
+"411 914 LINE",
+"337 803 OFFCURVE",
+"274 725 OFFCURVE",
+"185 627 CURVE",
+"312 379 OFFCURVE",
+"372 215 OFFCURVE",
+"458 -32 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"518 754 LINE",
+"450 651 OFFCURVE",
+"377 564 OFFCURVE",
+"300 481 CURVE",
+"333 413 LINE",
+"425 509 OFFCURVE",
+"488 589 OFFCURVE",
+"561 691 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"573 239 OFFCURVE",
+"598 189 OFFCURVE",
+"620 139 CURVE",
+"638 112 LINE",
+"662 53 OFFCURVE",
+"683 -5 OFFCURVE",
+"703 -74 CURVE",
+"774 -55 LINE",
+"747 33 OFFCURVE",
+"722 102 OFFCURVE",
+"690 172 CURVE",
+"672 197 LINE",
+"652 240 OFFCURVE",
+"629 283 OFFCURVE",
+"601 332 CURVE",
+"542 297 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 884;
+}
+);
+leftMetricsKey = u1B29F;
+rightMetricsKey = u1B274;
+unicode = 1B2C0;
+},
+{
+glyphname = u1B2C1;
+lastChange = "2020-04-13 09:30:38 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"552 934 LINE",
+"504 853 OFFCURVE",
+"453 778 OFFCURVE",
+"388 696 CURVE",
+"432 579 OFFCURVE",
+"459 485 OFFCURVE",
+"484 367 CURVE",
+"552 349 LINE",
+"609 404 OFFCURVE",
+"646 446 OFFCURVE",
+"716 554 CURVE",
+"681 603 LINE",
+"665 580 OFFCURVE",
+"650 560 OFFCURVE",
+"635 540 CURVE SMOOTH",
+"598 490 OFFCURVE",
+"578 466 OFFCURVE",
+"541 421 CURVE",
+"536 422 LINE",
+"523 484 OFFCURVE",
+"506 550 OFFCURVE",
+"482 628 CURVE SMOOTH",
+"472 660 OFFCURVE",
+"460 697 OFFCURVE",
+"445 739 CURVE",
+"452 672 LINE",
+"473 698 OFFCURVE",
+"492 723 OFFCURVE",
+"511 749 CURVE SMOOTH",
+"534 781 OFFCURVE",
+"552 806 OFFCURVE",
+"585 866 CURVE",
+"589 866 LINE",
+"610 806 OFFCURVE",
+"625 766 OFFCURVE",
+"643 699 CURVE SMOOTH",
+"675 579 OFFCURVE",
+"695 454 OFFCURVE",
+"695 288 CURVE SMOOTH",
+"695 194 OFFCURVE",
+"692 102 OFFCURVE",
+"682 9 CURVE",
+"752 0 LINE",
+"761 104 OFFCURVE",
+"765 181 OFFCURVE",
+"765 288 CURVE SMOOTH",
+"765 527 OFFCURVE",
+"720 742 OFFCURVE",
+"637 929 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"635 782 LINE",
+"575 692 OFFCURVE",
+"535 638 OFFCURVE",
+"469 564 CURVE",
+"500 511 LINE",
+"570 586 OFFCURVE",
+"629 662 OFFCURVE",
+"674 727 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"283 -197 LINE",
+"260 70 OFFCURVE",
+"235 227 OFFCURVE",
+"179 431 CURVE",
+"169 386 LINE",
+"195 413 OFFCURVE",
+"221 440 OFFCURVE",
+"245 467 CURVE SMOOTH",
+"256 480 OFFCURVE",
+"277 505 OFFCURVE",
+"308 550 CURVE",
+"312 550 LINE",
+"326 505 OFFCURVE",
+"337 469 OFFCURVE",
+"347 424 CURVE SMOOTH",
+"361 361 OFFCURVE",
+"373 301 OFFCURVE",
+"385 225 CURVE",
+"398 306 LINE",
+"341 235 OFFCURVE",
+"283 179 OFFCURVE",
+"217 110 CURVE",
+"236 49 LINE",
+"315 118 OFFCURVE",
+"381 182 OFFCURVE",
+"448 254 CURVE",
+"423 401 OFFCURVE",
+"399 494 OFFCURVE",
+"355 629 CURVE",
+"293 634 LINE",
+"232 550 OFFCURVE",
+"180 490 OFFCURVE",
+"110 420 CURVE",
+"168 205 OFFCURVE",
+"196 50 OFFCURVE",
+"213 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"350 470 LINE",
+"293 392 OFFCURVE",
+"243 338 OFFCURVE",
+"166 268 CURVE",
+"193 213 LINE",
+"273 284 OFFCURVE",
+"303 318 OFFCURVE",
+"375 413 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 905;
+}
+);
+leftMetricsKey = u1B1BB;
+rightMetricsKey = u1B1AB;
+unicode = 1B2C1;
+},
+{
+glyphname = u1B2C2;
+lastChange = "2020-04-13 09:30:49 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"109 280 LINE",
+"156 155 OFFCURVE",
+"180 64 OFFCURVE",
+"199 -64 CURVE",
+"268 -52 LINE",
+"250 73 OFFCURVE",
+"221 181 OFFCURVE",
+"175 305 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"581 384 OFFCURVE",
+"604 401 OFFCURVE",
+"604 440 CURVE SMOOTH",
+"604 479 OFFCURVE",
+"581 496 OFFCURVE",
+"553 496 CURVE SMOOTH",
+"524 496 OFFCURVE",
+"501 479 OFFCURVE",
+"501 440 CURVE SMOOTH",
+"501 401 OFFCURVE",
+"524 384 OFFCURVE",
+"553 384 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"387 227 OFFCURVE",
+"410 244 OFFCURVE",
+"410 283 CURVE SMOOTH",
+"410 322 OFFCURVE",
+"387 339 OFFCURVE",
+"359 339 CURVE SMOOTH",
+"330 339 OFFCURVE",
+"307 322 OFFCURVE",
+"307 283 CURVE SMOOTH",
+"307 244 OFFCURVE",
+"330 227 OFFCURVE",
+"359 227 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"680 234 OFFCURVE",
+"700 179 OFFCURVE",
+"713 129 CURVE SMOOTH",
+"722 95 OFFCURVE",
+"731 60 OFFCURVE",
+"741 20 CURVE",
+"813 35 LINE",
+"785 155 OFFCURVE",
+"758 246 OFFCURVE",
+"714 353 CURVE",
+"637 361 LINE",
+"538 272 OFFCURVE",
+"450 205 OFFCURVE",
+"323 121 CURVE",
+"354 -1 OFFCURVE",
+"369 -85 OFFCURVE",
+"383 -203 CURVE",
+"456 -194 LINE",
+"441 -76 OFFCURVE",
+"426 11 OFFCURVE",
+"392 135 CURVE",
+"392 80 LINE",
+"451 117 OFFCURVE",
+"497 149 OFFCURVE",
+"543 185 CURVE SMOOTH",
+"592 223 OFFCURVE",
+"616 242 OFFCURVE",
+"660 289 CURVE",
+"664 289 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"532 86 OFFCURVE",
+"550 19 OFFCURVE",
+"571 -98 CURVE",
+"641 -86 LINE",
+"618 36 OFFCURVE",
+"594 125 OFFCURVE",
+"550 239 CURVE",
+"493 187 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"516 939 LINE",
+"436 855 OFFCURVE",
+"368 788 OFFCURVE",
+"297 728 CURVE",
+"277 716 LINE",
+"222 669 OFFCURVE",
+"165 625 OFFCURVE",
+"100 578 CURVE",
+"140 518 LINE",
+"200 561 OFFCURVE",
+"253 602 OFFCURVE",
+"306 646 CURVE",
+"325 657 LINE",
+"403 722 OFFCURVE",
+"480 795 OFFCURVE",
+"571 892 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 677 LINE",
+"421 573 OFFCURVE",
+"318 490 OFFCURVE",
+"193 397 CURVE",
+"234 338 LINE",
+"370 440 OFFCURVE",
+"461 512 OFFCURVE",
+"581 626 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"181 856 LINE",
+"270 682 OFFCURVE",
+"321 560 OFFCURVE",
+"357 445 CURVE",
+"419 491 LINE",
+"380 610 OFFCURVE",
+"343 709 OFFCURVE",
+"248 890 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 893;
+}
+);
+leftMetricsKey = u1B224;
+rightMetricsKey = u1B270;
+unicode = 1B2C2;
+},
+{
+glyphname = u1B2C3;
+lastChange = "2020-04-13 09:31:01 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"528 460 OFFCURVE",
+"550 476 OFFCURVE",
+"550 514 CURVE SMOOTH",
+"550 551 OFFCURVE",
+"528 567 OFFCURVE",
+"501 567 CURVE SMOOTH",
+"473 567 OFFCURVE",
+"451 551 OFFCURVE",
+"451 514 CURVE SMOOTH",
+"451 476 OFFCURVE",
+"473 460 OFFCURVE",
+"501 460 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"334 351 OFFCURVE",
+"356 367 OFFCURVE",
+"356 404 CURVE SMOOTH",
+"356 442 OFFCURVE",
+"334 458 OFFCURVE",
+"307 458 CURVE SMOOTH",
+"279 458 OFFCURVE",
+"257 442 OFFCURVE",
+"257 404 CURVE SMOOTH",
+"257 367 OFFCURVE",
+"279 351 OFFCURVE",
+"307 351 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"500 939 LINE",
+"419 881 OFFCURVE",
+"349 836 OFFCURVE",
+"280 794 CURVE",
+"257 785 LINE",
+"195 749 OFFCURVE",
+"132 715 OFFCURVE",
+"60 679 CURVE",
+"92 615 LINE",
+"162 651 OFFCURVE",
+"224 683 OFFCURVE",
+"286 720 CURVE",
+"312 730 LINE",
+"383 772 OFFCURVE",
+"457 821 OFFCURVE",
+"545 883 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"519 724 LINE",
+"402 647 OFFCURVE",
+"264 566 OFFCURVE",
+"144 506 CURVE",
+"176 443 LINE",
+"308 510 OFFCURVE",
+"427 581 OFFCURVE",
+"559 666 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"173 900 LINE",
+"249 751 OFFCURVE",
+"292 660 OFFCURVE",
+"328 545 CURVE",
+"389 589 LINE",
+"350 708 OFFCURVE",
+"312 792 OFFCURVE",
+"239 932 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"577 -166 LINE",
+"494 6 OFFCURVE",
+"436 136 OFFCURVE",
+"354 280 CURVE",
+"339 229 LINE",
+"379 250 OFFCURVE",
+"419 272 OFFCURVE",
+"459 295 CURVE SMOOTH",
+"512 326 OFFCURVE",
+"537 342 OFFCURVE",
+"589 375 CURVE",
+"593 374 LINE",
+"615 326 OFFCURVE",
+"641 277 OFFCURVE",
+"664 229 CURVE SMOOTH",
+"691 173 OFFCURVE",
+"717 116 OFFCURVE",
+"739 74 CURVE",
+"740 130 LINE",
+"665 80 OFFCURVE",
+"597 38 OFFCURVE",
+"490 -21 CURVE",
+"450 -42 LINE",
+"398 -71 OFFCURVE",
+"337 -103 OFFCURVE",
+"264 -141 CURVE",
+"297 -202 LINE",
+"369 -166 OFFCURVE",
+"430 -133 OFFCURVE",
+"485 -103 CURVE",
+"520 -85 LINE",
+"644 -16 OFFCURVE",
+"725 36 OFFCURVE",
+"807 93 CURVE",
+"754 216 OFFCURVE",
+"700 327 OFFCURVE",
+"644 429 CURVE",
+"568 446 LINE",
+"482 385 OFFCURVE",
+"386 333 OFFCURVE",
+"271 271 CURVE",
+"383 84 OFFCURVE",
+"444 -54 OFFCURVE",
+"513 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"651 275 LINE",
+"566 217 OFFCURVE",
+"503 180 OFFCURVE",
+"405 129 CURVE",
+"444 74 LINE",
+"530 118 OFFCURVE",
+"613 170 OFFCURVE",
+"686 217 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 897;
+}
+);
+leftMetricsKey = u1B214;
+rightMetricsKey = u1B1BC;
+unicode = 1B2C3;
+},
+{
+glyphname = u1B2C4;
+lastChange = "2020-04-13 09:31:03 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"451 52 OFFCURVE",
+"442 -46 OFFCURVE",
+"421 -193 CURVE",
+"493 -203 LINE",
+"512 -44 OFFCURVE",
+"517 98 OFFCURVE",
+"513 227 CURVE",
+"539 275 LINE",
+"456 254 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"651 416 LINE",
+"610 388 OFFCURVE",
+"571 363 OFFCURVE",
+"532 339 CURVE SMOOTH",
+"474 303 OFFCURVE",
+"430 281 OFFCURVE",
+"391 258 CURVE",
+"386 259 LINE",
+"388 323 OFFCURVE",
+"384 386 OFFCURVE",
+"378 436 CURVE SMOOTH",
+"371 497 OFFCURVE",
+"362 558 OFFCURVE",
+"353 613 CURVE",
+"318 570 LINE",
+"416 625 OFFCURVE",
+"518 695 OFFCURVE",
+"628 785 CURVE",
+"581 843 LINE",
+"463 745 OFFCURVE",
+"382 687 OFFCURVE",
+"278 627 CURVE",
+"298 487 OFFCURVE",
+"315 339 OFFCURVE",
+"321 212 CURVE",
+"386 183 LINE",
+"484 223 OFFCURVE",
+"580 283 OFFCURVE",
+"690 353 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"368 385 LINE",
+"481 441 OFFCURVE",
+"562 489 OFFCURVE",
+"648 559 CURVE",
+"604 618 LINE",
+"511 544 OFFCURVE",
+"442 500 OFFCURVE",
+"362 459 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"497 227 LINE",
+"517 227 LINE",
+"569 149 OFFCURVE",
+"611 88 OFFCURVE",
+"649 16 CURVE",
+"710 50 LINE",
+"657 142 OFFCURVE",
+"617 198 OFFCURVE",
+"530 291 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"210 834 LINE",
+"244 834 LINE",
+"276 767 OFFCURVE",
+"306 718 OFFCURVE",
+"344 628 CURVE",
+"410 656 LINE",
+"367 754 OFFCURVE",
+"319 819 OFFCURVE",
+"252 899 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"203 939 LINE",
+"167 784 OFFCURVE",
+"134 695 OFFCURVE",
+"80 589 CURVE",
+"143 557 LINE",
+"187 642 OFFCURVE",
+"220 732 OFFCURVE",
+"240 834 CURVE",
+"258 867 LINE",
+"263 886 OFFCURVE",
+"267 906 OFFCURVE",
+"272 926 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"182 159 LINE",
+"210 159 LINE",
+"234 105 OFFCURVE",
+"256 56 OFFCURVE",
+"287 -30 CURVE",
+"353 -4 LINE",
+"317 84 OFFCURVE",
+"280 153 OFFCURVE",
+"226 233 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"166 292 LINE",
+"143 147 OFFCURVE",
+"125 65 OFFCURVE",
+"80 -69 CURVE",
+"147 -90 LINE",
+"177 0 OFFCURVE",
+"192 71 OFFCURVE",
+"206 159 CURVE",
+"223 205 LINE",
+"227 229 OFFCURVE",
+"231 255 OFFCURVE",
+"234 282 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 820;
+}
+);
+leftMetricsKey = u1B21E;
+unicode = 1B2C4;
+},
+{
+glyphname = u1B2C5;
+lastChange = "2020-04-13 09:31:06 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"463 456 OFFCURVE",
+"486 473 OFFCURVE",
+"486 512 CURVE SMOOTH",
+"486 551 OFFCURVE",
+"463 568 OFFCURVE",
+"435 568 CURVE SMOOTH",
+"406 568 OFFCURVE",
+"383 551 OFFCURVE",
+"383 512 CURVE SMOOTH",
+"383 473 OFFCURVE",
+"406 456 OFFCURVE",
+"435 456 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"584 590 OFFCURVE",
+"607 607 OFFCURVE",
+"607 646 CURVE SMOOTH",
+"607 685 OFFCURVE",
+"584 702 OFFCURVE",
+"556 702 CURVE SMOOTH",
+"527 702 OFFCURVE",
+"504 685 OFFCURVE",
+"504 646 CURVE SMOOTH",
+"504 607 OFFCURVE",
+"527 590 OFFCURVE",
+"556 590 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"612 165 OFFCURVE",
+"635 182 OFFCURVE",
+"635 221 CURVE SMOOTH",
+"635 260 OFFCURVE",
+"612 277 OFFCURVE",
+"584 277 CURVE SMOOTH",
+"555 277 OFFCURVE",
+"532 260 OFFCURVE",
+"532 221 CURVE SMOOTH",
+"532 182 OFFCURVE",
+"555 165 OFFCURVE",
+"584 165 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"491 30 OFFCURVE",
+"514 47 OFFCURVE",
+"514 86 CURVE SMOOTH",
+"514 125 OFFCURVE",
+"491 142 OFFCURVE",
+"463 142 CURVE SMOOTH",
+"434 142 OFFCURVE",
+"411 125 OFFCURVE",
+"411 86 CURVE SMOOTH",
+"411 47 OFFCURVE",
+"434 30 OFFCURVE",
+"463 30 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"90 369 LINE",
+"153 249 OFFCURVE",
+"211 104 OFFCURVE",
+"261 -50 CURVE",
+"327 -26 LINE",
+"277 129 OFFCURVE",
+"218 276 OFFCURVE",
+"152 402 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"379 638 OFFCURVE",
+"456 734 OFFCURVE",
+"568 900 CURVE",
+"507 939 LINE",
+"405 789 OFFCURVE",
+"318 680 OFFCURVE",
+"190 546 CURVE",
+"255 427 OFFCURVE",
+"300 330 OFFCURVE",
+"343 230 CURVE",
+"423 222 LINE",
+"444 241 OFFCURVE",
+"468 268 OFFCURVE",
+"486 288 CURVE SMOOTH",
+"538 347 OFFCURVE",
+"567 384 OFFCURVE",
+"617 451 CURVE",
+"621 451 LINE",
+"647 394 OFFCURVE",
+"673 338 OFFCURVE",
+"701 277 CURVE SMOOTH",
+"719 237 OFFCURVE",
+"737 196 OFFCURVE",
+"755 153 CURVE",
+"748 210 LINE",
+"638 79 OFFCURVE",
+"552 -12 OFFCURVE",
+"401 -150 CURVE",
+"452 -203 LINE",
+"603 -68 OFFCURVE",
+"699 39 OFFCURVE",
+"819 189 CURVE",
+"771 310 OFFCURVE",
+"719 413 OFFCURVE",
+"668 511 CURVE",
+"588 516 LINE",
+"563 482 OFFCURVE",
+"541 455 OFFCURVE",
+"523 432 CURVE SMOOTH",
+"476 371 OFFCURVE",
+"437 331 OFFCURVE",
+"396 282 CURVE",
+"392 282 LINE",
+"371 339 OFFCURVE",
+"347 401 OFFCURVE",
+"320 456 CURVE SMOOTH",
+"301 495 OFFCURVE",
+"280 535 OFFCURVE",
+"255 580 CURVE",
+"259 516 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 919;
+}
+);
+leftMetricsKey = u1B1F2;
+rightMetricsKey = u1B1BA;
+unicode = 1B2C5;
+},
+{
+glyphname = u1B2C6;
+lastChange = "2020-04-13 09:31:19 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"377 119 LINE",
+"523 31 OFFCURVE",
+"624 -46 OFFCURVE",
+"746 -139 CURVE",
+"788 -83 LINE",
+"739 -44 OFFCURVE",
+"695 -18 OFFCURVE",
+"605 46 CURVE",
+"593 46 LINE",
+"555 78 OFFCURVE",
+"509 117 OFFCURVE",
+"436 163 CURVE",
+"435 135 LINE",
+"504 177 OFFCURVE",
+"574 229 OFFCURVE",
+"626 278 CURVE",
+"671 305 LINE",
+"687 319 OFFCURVE",
+"704 333 OFFCURVE",
+"721 347 CURVE",
+"674 401 LINE",
+"562 300 OFFCURVE",
+"481 242 OFFCURVE",
+"377 178 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"600 278 LINE",
+"630 278 LINE",
+"640 247 OFFCURVE",
+"643 217 OFFCURVE",
+"643 193 CURVE SMOOTH",
+"643 150 OFFCURVE",
+"630 94 OFFCURVE",
+"597 46 CURVE",
+"588 46 LINE",
+"531 -25 OFFCURVE",
+"452 -79 OFFCURVE",
+"354 -145 CURVE",
+"393 -203 LINE",
+"492 -137 OFFCURVE",
+"562 -75 OFFCURVE",
+"611 -25 CURVE",
+"640 2 LINE",
+"699 73 OFFCURVE",
+"717 134 OFFCURVE",
+"717 193 CURVE SMOOTH",
+"717 240 OFFCURVE",
+"705 288 OFFCURVE",
+"662 352 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 -15 OFFCURVE",
+"109 -63 OFFCURVE",
+"177 -103 CURVE",
+"248 -94 LINE",
+"316 -15 OFFCURVE",
+"334 50 OFFCURVE",
+"334 111 CURVE SMOOTH",
+"334 171 OFFCURVE",
+"300 212 OFFCURVE",
+"232 250 CURVE",
+"158 240 LINE",
+"100 158 OFFCURVE",
+"80 91 OFFCURVE",
+"80 42 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 196 LINE",
+"244 164 OFFCURVE",
+"259 129 OFFCURVE",
+"259 100 CURVE SMOOTH",
+"259 57 OFFCURVE",
+"249 12 OFFCURVE",
+"209 -52 CURVE",
+"204 -53 LINE",
+"169 -18 OFFCURVE",
+"154 13 OFFCURVE",
+"154 46 CURVE SMOOTH",
+"154 88 OFFCURVE",
+"167 132 OFFCURVE",
+"199 195 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"582 260 LINE",
+"558 376 OFFCURVE",
+"540 451 OFFCURVE",
+"494 577 CURVE",
+"434 522 LINE",
+"472 418 OFFCURVE",
+"497 334 OFFCURVE",
+"514 225 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"578 939 LINE",
+"422 807 OFFCURVE",
+"295 724 OFFCURVE",
+"150 645 CURVE",
+"187 580 LINE",
+"329 658 OFFCURVE",
+"466 746 OFFCURVE",
+"628 886 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"684 435 OFFCURVE",
+"706 451 OFFCURVE",
+"706 488 CURVE SMOOTH",
+"706 526 OFFCURVE",
+"684 542 OFFCURVE",
+"657 542 CURVE SMOOTH",
+"630 542 OFFCURVE",
+"608 526 OFFCURVE",
+"608 488 CURVE SMOOTH",
+"608 451 OFFCURVE",
+"630 435 OFFCURVE",
+"657 435 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"401 253 OFFCURVE",
+"423 269 OFFCURVE",
+"423 307 CURVE SMOOTH",
+"423 344 OFFCURVE",
+"401 360 OFFCURVE",
+"375 360 CURVE SMOOTH",
+"347 360 OFFCURVE",
+"325 344 OFFCURVE",
+"325 307 CURVE SMOOTH",
+"325 269 OFFCURVE",
+"347 253 OFFCURVE",
+"375 253 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"565 774 OFFCURVE",
+"575 744 OFFCURVE",
+"575 711 CURVE SMOOTH",
+"575 655 OFFCURVE",
+"524 595 OFFCURVE",
+"219 434 CURVE",
+"255 369 LINE",
+"584 540 OFFCURVE",
+"651 623 OFFCURVE",
+"651 710 CURVE SMOOTH",
+"651 762 OFFCURVE",
+"637 796 OFFCURVE",
+"578 862 CURVE",
+"527 818 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 898;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B17C;
+unicode = 1B2C6;
+},
+{
+glyphname = u1B2C7;
+lastChange = "2020-04-13 09:31:28 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"483 540 OFFCURVE",
+"506 557 OFFCURVE",
+"506 596 CURVE SMOOTH",
+"506 635 OFFCURVE",
+"483 652 OFFCURVE",
+"455 652 CURVE SMOOTH",
+"426 652 OFFCURVE",
+"403 635 OFFCURVE",
+"403 596 CURVE SMOOTH",
+"403 557 OFFCURVE",
+"426 540 OFFCURVE",
+"455 540 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"319 271 OFFCURVE",
+"342 288 OFFCURVE",
+"342 327 CURVE SMOOTH",
+"342 366 OFFCURVE",
+"319 383 OFFCURVE",
+"291 383 CURVE SMOOTH",
+"262 383 OFFCURVE",
+"239 366 OFFCURVE",
+"239 327 CURVE SMOOTH",
+"239 288 OFFCURVE",
+"262 271 OFFCURVE",
+"291 271 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"559 61 OFFCURVE",
+"582 78 OFFCURVE",
+"582 117 CURVE SMOOTH",
+"582 156 OFFCURVE",
+"559 173 OFFCURVE",
+"531 173 CURVE SMOOTH",
+"502 173 OFFCURVE",
+"479 156 OFFCURVE",
+"479 117 CURVE SMOOTH",
+"479 78 OFFCURVE",
+"502 61 OFFCURVE",
+"531 61 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"750 328 OFFCURVE",
+"773 345 OFFCURVE",
+"773 384 CURVE SMOOTH",
+"773 423 OFFCURVE",
+"750 440 OFFCURVE",
+"722 440 CURVE SMOOTH",
+"693 440 OFFCURVE",
+"670 423 OFFCURVE",
+"670 384 CURVE SMOOTH",
+"670 345 OFFCURVE",
+"693 328 OFFCURVE",
+"722 328 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"604 640 LINE",
+"559 541 OFFCURVE",
+"508 445 OFFCURVE",
+"447 331 CURVE SMOOTH",
+"409 260 OFFCURVE",
+"369 196 OFFCURVE",
+"337 144 CURVE",
+"332 143 LINE",
+"288 185 OFFCURVE",
+"238 226 OFFCURVE",
+"177 272 CURVE SMOOTH",
+"156 288 OFFCURVE",
+"134 304 OFFCURVE",
+"112 319 CURVE",
+"70 258 LINE",
+"145 208 OFFCURVE",
+"236 133 OFFCURVE",
+"307 74 CURVE",
+"387 96 LINE",
+"448 196 OFFCURVE",
+"507 294 OFFCURVE",
+"572 412 CURVE SMOOTH",
+"607 474 OFFCURVE",
+"629 522 OFFCURVE",
+"656 584 CURVE",
+"661 585 LINE",
+"721 543 OFFCURVE",
+"767 509 OFFCURVE",
+"818 467 CURVE SMOOTH",
+"835 453 OFFCURVE",
+"852 439 OFFCURVE",
+"868 426 CURVE",
+"916 482 LINE",
+"849 540 OFFCURVE",
+"767 601 OFFCURVE",
+"685 658 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"407 393 OFFCURVE",
+"589 262 OFFCURVE",
+"708 154 CURVE",
+"714 195 LINE",
+"634 53 OFFCURVE",
+"586 -23 OFFCURVE",
+"482 -159 CURVE",
+"538 -203 LINE",
+"651 -56 OFFCURVE",
+"704 23 OFFCURVE",
+"789 180 CURVE",
+"630 318 OFFCURVE",
+"440 451 OFFCURVE",
+"279 558 CURVE",
+"273 528 LINE",
+"346 646 OFFCURVE",
+"404 755 OFFCURVE",
+"473 913 CURVE",
+"403 939 LINE",
+"338 788 OFFCURVE",
+"286 689 OFFCURVE",
+"190 529 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 986;
+}
+);
+leftMetricsKey = u1B204;
+rightMetricsKey = u1B204;
+unicode = 1B2C7;
+},
+{
+glyphname = u1B2C8;
+lastChange = "2020-04-13 09:31:51 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"130 69 OFFCURVE",
+"153 86 OFFCURVE",
+"153 125 CURVE SMOOTH",
+"153 164 OFFCURVE",
+"130 181 OFFCURVE",
+"102 181 CURVE SMOOTH",
+"73 181 OFFCURVE",
+"50 164 OFFCURVE",
+"50 125 CURVE SMOOTH",
+"50 86 OFFCURVE",
+"73 69 OFFCURVE",
+"102 69 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 296 LINE",
+"192 250 OFFCURVE",
+"222 196 OFFCURVE",
+"222 139 CURVE SMOOTH",
+"222 67 OFFCURVE",
+"195 20 OFFCURVE",
+"121 -38 CURVE",
+"160 -86 LINE",
+"244 -19 OFFCURVE",
+"292 37 OFFCURVE",
+"292 140 CURVE SMOOTH",
+"292 217 OFFCURVE",
+"256 278 OFFCURVE",
+"186 340 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"719 540 OFFCURVE",
+"691 478 OFFCURVE",
+"691 391 CURVE SMOOTH",
+"691 276 OFFCURVE",
+"740 223 OFFCURVE",
+"840 168 CURVE",
+"871 222 LINE",
+"788 272 OFFCURVE",
+"761 321 OFFCURVE",
+"761 391 CURVE SMOOTH",
+"761 461 OFFCURVE",
+"784 513 OFFCURVE",
+"855 572 CURVE",
+"809 616 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"916 356 OFFCURVE",
+"939 373 OFFCURVE",
+"939 412 CURVE SMOOTH",
+"939 451 OFFCURVE",
+"916 468 OFFCURVE",
+"888 468 CURVE SMOOTH",
+"859 468 OFFCURVE",
+"836 451 OFFCURVE",
+"836 412 CURVE SMOOTH",
+"836 373 OFFCURVE",
+"859 356 OFFCURVE",
+"888 356 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"508 327 LINE",
+"467 497 OFFCURVE",
+"440 591 OFFCURVE",
+"362 773 CURVE",
+"308 713 LINE",
+"375 547 OFFCURVE",
+"409 444 OFFCURVE",
+"442 287 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 721 LINE",
+"544 668 OFFCURVE",
+"480 623 OFFCURVE",
+"412 579 CURVE",
+"388 569 LINE",
+"323 528 OFFCURVE",
+"255 488 OFFCURVE",
+"178 443 CURVE",
+"214 380 LINE",
+"285 421 OFFCURVE",
+"350 460 OFFCURVE",
+"413 499 CURVE",
+"432 506 LINE",
+"508 555 OFFCURVE",
+"581 606 OFFCURVE",
+"659 667 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"534 939 LINE",
+"378 814 OFFCURVE",
+"241 731 OFFCURVE",
+"86 645 CURVE",
+"120 583 LINE",
+"272 668 OFFCURVE",
+"418 752 OFFCURVE",
+"580 885 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"333 191 LINE",
+"482 77 OFFCURVE",
+"571 0 OFFCURVE",
+"697 -116 CURVE",
+"747 -64 LINE",
+"699 -21 OFFCURVE",
+"655 19 OFFCURVE",
+"575 86 CURVE",
+"565 86 LINE",
+"523 133 OFFCURVE",
+"472 175 OFFCURVE",
+"393 241 CURVE",
+"382 210 LINE",
+"460 263 OFFCURVE",
+"508 300 OFFCURVE",
+"560 350 CURVE",
+"600 376 LINE",
+"617 390 OFFCURVE",
+"633 405 OFFCURVE",
+"650 421 CURVE",
+"600 472 LINE",
+"495 371 OFFCURVE",
+"438 330 OFFCURVE",
+"333 262 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"535 350 LINE",
+"564 350 LINE",
+"583 309 OFFCURVE",
+"595 267 OFFCURVE",
+"595 225 CURVE SMOOTH",
+"595 173 OFFCURVE",
+"590 133 OFFCURVE",
+"569 86 CURVE",
+"559 86 LINE",
+"477 0 OFFCURVE",
+"393 -67 OFFCURVE",
+"277 -145 CURVE",
+"316 -203 LINE",
+"443 -118 OFFCURVE",
+"525 -50 OFFCURVE",
+"581 14 CURVE",
+"604 38 LINE",
+"650 100 OFFCURVE",
+"669 159 OFFCURVE",
+"669 225 CURVE SMOOTH",
+"669 271 OFFCURVE",
+"655 334 OFFCURVE",
+"598 418 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 1019;
+}
+);
+leftMetricsKey = u1B1D7;
+rightMetricsKey = u1B177;
+unicode = 1B2C8;
+},
+{
+glyphname = u1B2C9;
+lastChange = "2020-04-13 09:32:14 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"839 192 LINE",
+"776 411 OFFCURVE",
+"700 581 OFFCURVE",
+"598 752 CURVE",
+"546 700 LINE",
+"648 541 OFFCURVE",
+"719 358 OFFCURVE",
+"767 173 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"685 939 LINE",
+"593 804 OFFCURVE",
+"491 699 OFFCURVE",
+"360 598 CURVE",
+"402 543 LINE",
+"543 650 OFFCURVE",
+"645 754 OFFCURVE",
+"747 902 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"808 763 LINE",
+"765 707 OFFCURVE",
+"716 652 OFFCURVE",
+"663 598 CURVE",
+"638 579 LINE",
+"580 523 OFFCURVE",
+"518 467 OFFCURVE",
+"450 416 CURVE",
+"493 358 LINE",
+"562 413 OFFCURVE",
+"621 463 OFFCURVE",
+"674 514 CURVE",
+"703 535 LINE",
+"760 590 OFFCURVE",
+"812 650 OFFCURVE",
+"868 721 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"885 447 OFFCURVE",
+"908 464 OFFCURVE",
+"908 503 CURVE SMOOTH",
+"908 542 OFFCURVE",
+"885 559 OFFCURVE",
+"857 559 CURVE SMOOTH",
+"828 559 OFFCURVE",
+"805 542 OFFCURVE",
+"805 503 CURVE SMOOTH",
+"805 464 OFFCURVE",
+"828 447 OFFCURVE",
+"857 447 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"636 234 OFFCURVE",
+"659 251 OFFCURVE",
+"659 290 CURVE SMOOTH",
+"659 329 OFFCURVE",
+"636 346 OFFCURVE",
+"608 346 CURVE SMOOTH",
+"579 346 OFFCURVE",
+"556 329 OFFCURVE",
+"556 290 CURVE SMOOTH",
+"556 251 OFFCURVE",
+"579 234 OFFCURVE",
+"608 234 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"504 -183 LINE",
+"458 -6 OFFCURVE",
+"380 183 OFFCURVE",
+"285 339 CURVE",
+"233 282 LINE",
+"326 135 OFFCURVE",
+"388 -18 OFFCURVE",
+"433 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"368 483 LINE",
+"273 372 OFFCURVE",
+"185 289 OFFCURVE",
+"60 202 CURVE",
+"99 139 LINE",
+"225 231 OFFCURVE",
+"343 332 OFFCURVE",
+"427 440 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"468 303 LINE",
+"425 254 OFFCURVE",
+"385 213 OFFCURVE",
+"345 176 CURVE",
+"327 167 LINE",
+"270 116 OFFCURVE",
+"211 74 OFFCURVE",
+"143 30 CURVE",
+"181 -31 LINE",
+"247 12 OFFCURVE",
+"305 54 OFFCURVE",
+"360 101 CURVE",
+"387 118 LINE",
+"433 159 OFFCURVE",
+"477 204 OFFCURVE",
+"525 258 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"572 11 OFFCURVE",
+"595 28 OFFCURVE",
+"595 67 CURVE SMOOTH",
+"595 106 OFFCURVE",
+"572 123 OFFCURVE",
+"544 123 CURVE SMOOTH",
+"515 123 OFFCURVE",
+"492 106 OFFCURVE",
+"492 67 CURVE SMOOTH",
+"492 28 OFFCURVE",
+"515 11 OFFCURVE",
+"544 11 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"318 -179 OFFCURVE",
+"341 -162 OFFCURVE",
+"341 -123 CURVE SMOOTH",
+"341 -84 OFFCURVE",
+"318 -67 OFFCURVE",
+"290 -67 CURVE SMOOTH",
+"261 -67 OFFCURVE",
+"238 -84 OFFCURVE",
+"238 -123 CURVE SMOOTH",
+"238 -162 OFFCURVE",
+"261 -179 OFFCURVE",
+"290 -179 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 1028;
+}
+);
+leftMetricsKey = u1B189;
+rightMetricsKey = u1B1A8;
+unicode = 1B2C9;
+},
+{
+glyphname = u1B2CA;
+lastChange = "2020-04-11 17:39:42 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"207 681 OFFCURVE",
+"230 698 OFFCURVE",
+"230 737 CURVE SMOOTH",
+"230 776 OFFCURVE",
+"207 793 OFFCURVE",
+"179 793 CURVE SMOOTH",
+"150 793 OFFCURVE",
+"127 776 OFFCURVE",
+"127 737 CURVE SMOOTH",
+"127 698 OFFCURVE",
+"150 681 OFFCURVE",
+"179 681 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"191 -86 OFFCURVE",
+"214 -69 OFFCURVE",
+"214 -30 CURVE SMOOTH",
+"214 9 OFFCURVE",
+"191 26 OFFCURVE",
+"163 26 CURVE SMOOTH",
+"134 26 OFFCURVE",
+"111 9 OFFCURVE",
+"111 -30 CURVE SMOOTH",
+"111 -69 OFFCURVE",
+"134 -86 OFFCURVE",
+"163 -86 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"735 705 OFFCURVE",
+"758 722 OFFCURVE",
+"758 761 CURVE SMOOTH",
+"758 800 OFFCURVE",
+"735 817 OFFCURVE",
+"707 817 CURVE SMOOTH",
+"678 817 OFFCURVE",
+"655 800 OFFCURVE",
+"655 761 CURVE SMOOTH",
+"655 722 OFFCURVE",
+"678 705 OFFCURVE",
+"707 705 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"720 -94 OFFCURVE",
+"743 -77 OFFCURVE",
+"743 -38 CURVE SMOOTH",
+"743 1 OFFCURVE",
+"720 18 OFFCURVE",
+"692 18 CURVE SMOOTH",
+"663 18 OFFCURVE",
+"640 1 OFFCURVE",
+"640 -38 CURVE SMOOTH",
+"640 -77 OFFCURVE",
+"663 -94 OFFCURVE",
+"692 -94 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"260 574 LINE",
+"313 496 OFFCURVE",
+"362 419 OFFCURVE",
+"407 340 CURVE",
+"434 296 LINE",
+"474 225 OFFCURVE",
+"511 152 OFFCURVE",
+"549 74 CURVE",
+"598 138 LINE",
+"562 215 OFFCURVE",
+"522 292 OFFCURVE",
+"478 369 CURVE",
+"448 417 LINE",
+"407 488 OFFCURVE",
+"361 559 OFFCURVE",
+"311 632 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"558 648 LINE",
+"468 462 OFFCURVE",
+"381 316 OFFCURVE",
+"265 158 CURVE",
+"310 98 LINE",
+"431 261 OFFCURVE",
+"512 396 OFFCURVE",
+"607 584 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"391 872 LINE",
+"297 670 OFFCURVE",
+"189 483 OFFCURVE",
+"90 340 CURVE",
+"212 160 OFFCURVE",
+"295 7 OFFCURVE",
+"361 -143 CURVE",
+"454 -150 LINE",
+"571 12 OFFCURVE",
+"682 176 OFFCURVE",
+"770 366 CURVE",
+"685 546 OFFCURVE",
+"604 690 OFFCURVE",
+"481 880 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"442 806 LINE",
+"496 709 OFFCURVE",
+"536 650 OFFCURVE",
+"579 573 CURVE SMOOTH",
+"627 487 OFFCURVE",
+"671 399 OFFCURVE",
+"716 298 CURVE",
+"721 433 LINE",
+"669 326 OFFCURVE",
+"617 232 OFFCURVE",
+"565 148 CURVE SMOOTH",
+"513 65 OFFCURVE",
+"458 -20 OFFCURVE",
+"415 -87 CURVE",
+"411 -87 LINE",
+"381 -5 OFFCURVE",
+"341 76 OFFCURVE",
+"295 157 CURVE SMOOTH",
+"253 230 OFFCURVE",
+"206 305 OFFCURVE",
+"153 383 CURVE",
+"146 285 LINE",
+"208 378 OFFCURVE",
+"263 467 OFFCURVE",
+"315 557 CURVE SMOOTH",
+"362 639 OFFCURVE",
+"395 706 OFFCURVE",
+"437 805 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 860;
+}
+);
+leftMetricsKey = u1B20E;
+rightMetricsKey = u1B20E;
+unicode = 1B2CA;
+},
+{
+glyphname = u1B2CB;
+lastChange = "2020-04-13 09:32:19 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"475 -203 OFFCURVE",
+"498 -186 OFFCURVE",
+"498 -147 CURVE SMOOTH",
+"498 -108 OFFCURVE",
+"475 -91 OFFCURVE",
+"447 -91 CURVE SMOOTH",
+"418 -91 OFFCURVE",
+"395 -108 OFFCURVE",
+"395 -147 CURVE SMOOTH",
+"395 -186 OFFCURVE",
+"418 -203 OFFCURVE",
+"447 -203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"658 -97 OFFCURVE",
+"681 -80 OFFCURVE",
+"681 -41 CURVE SMOOTH",
+"681 -2 OFFCURVE",
+"658 15 OFFCURVE",
+"630 15 CURVE SMOOTH",
+"601 15 OFFCURVE",
+"578 -2 OFFCURVE",
+"578 -41 CURVE SMOOTH",
+"578 -80 OFFCURVE",
+"601 -97 OFFCURVE",
+"630 -97 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"817 24 OFFCURVE",
+"840 41 OFFCURVE",
+"840 80 CURVE SMOOTH",
+"840 119 OFFCURVE",
+"817 136 OFFCURVE",
+"789 136 CURVE SMOOTH",
+"760 136 OFFCURVE",
+"737 119 OFFCURVE",
+"737 80 CURVE SMOOTH",
+"737 41 OFFCURVE",
+"760 24 OFFCURVE",
+"789 24 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"735 335 OFFCURVE",
+"706 445 OFFCURVE",
+"677 536 CURVE",
+"598 556 LINE",
+"501 457 OFFCURVE",
+"421 390 OFFCURVE",
+"312 311 CURVE",
+"348 198 OFFCURVE",
+"371 106 OFFCURVE",
+"392 4 CURVE",
+"462 -18 LINE",
+"557 41 OFFCURVE",
+"659 123 OFFCURVE",
+"756 215 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"687 253 LINE",
+"655 222 OFFCURVE",
+"621 192 OFFCURVE",
+"584 161 CURVE SMOOTH",
+"535 120 OFFCURVE",
+"504 95 OFFCURVE",
+"456 57 CURVE",
+"451 58 LINE",
+"440 120 OFFCURVE",
+"427 178 OFFCURVE",
+"419 210 CURVE SMOOTH",
+"408 252 OFFCURVE",
+"396 293 OFFCURVE",
+"382 335 CURVE",
+"380 270 LINE",
+"427 305 OFFCURVE",
+"469 340 OFFCURVE",
+"509 374 CURVE SMOOTH",
+"542 402 OFFCURVE",
+"576 438 OFFCURVE",
+"618 478 CURVE",
+"623 477 LINE",
+"634 424 OFFCURVE",
+"648 371 OFFCURVE",
+"658 327 CURVE SMOOTH",
+"668 281 OFFCURVE",
+"678 234 OFFCURVE",
+"686 186 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"704 939 LINE",
+"637 837 OFFCURVE",
+"573 753 OFFCURVE",
+"502 679 CURVE SMOOTH",
+"446 620 OFFCURVE",
+"397 568 OFFCURVE",
+"346 523 CURVE",
+"342 523 LINE",
+"316 592 OFFCURVE",
+"299 640 OFFCURVE",
+"265 712 CURVE SMOOTH",
+"252 740 OFFCURVE",
+"237 768 OFFCURVE",
+"221 799 CURVE",
+"155 765 LINE",
+"215 653 OFFCURVE",
+"241 583 OFFCURVE",
+"284 473 CURVE",
+"372 458 LINE",
+"517 585 OFFCURVE",
+"640 713 OFFCURVE",
+"768 901 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"443 732 OFFCURVE",
+"466 749 OFFCURVE",
+"466 788 CURVE SMOOTH",
+"466 827 OFFCURVE",
+"443 844 OFFCURVE",
+"415 844 CURVE SMOOTH",
+"386 844 OFFCURVE",
+"363 827 OFFCURVE",
+"363 788 CURVE SMOOTH",
+"363 749 OFFCURVE",
+"386 732 OFFCURVE",
+"415 732 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 466 OFFCURVE",
+"163 483 OFFCURVE",
+"163 522 CURVE SMOOTH",
+"163 561 OFFCURVE",
+"140 578 OFFCURVE",
+"112 578 CURVE SMOOTH",
+"83 578 OFFCURVE",
+"60 561 OFFCURVE",
+"60 522 CURVE SMOOTH",
+"60 483 OFFCURVE",
+"83 466 OFFCURVE",
+"112 466 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 920;
+}
+);
+leftMetricsKey = u1B256;
+rightMetricsKey = u1B177;
+unicode = 1B2CB;
+},
+{
+glyphname = u1B2CC;
+lastChange = "2020-04-13 09:32:36 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"508 -162 LINE",
+"602 -62 OFFCURVE",
+"687 45 OFFCURVE",
+"763 176 CURVE",
+"702 209 LINE",
+"676 162 OFFCURVE",
+"647 117 OFFCURVE",
+"618 75 CURVE SMOOTH",
+"574 11 OFFCURVE",
+"533 -41 OFFCURVE",
+"487 -92 CURVE",
+"482 -91 LINE",
+"459 -20 OFFCURVE",
+"434 50 OFFCURVE",
+"403 125 CURVE SMOOTH",
+"359 230 OFFCURVE",
+"310 334 OFFCURVE",
+"264 425 CURVE",
+"276 362 LINE",
+"304 393 OFFCURVE",
+"329 422 OFFCURVE",
+"355 455 CURVE SMOOTH",
+"386 495 OFFCURVE",
+"400 518 OFFCURVE",
+"428 565 CURVE",
+"432 565 LINE",
+"452 527 OFFCURVE",
+"473 491 OFFCURVE",
+"492 456 CURVE SMOOTH",
+"520 404 OFFCURVE",
+"547 347 OFFCURVE",
+"573 283 CURVE",
+"563 373 LINE",
+"488 266 OFFCURVE",
+"429 200 OFFCURVE",
+"359 129 CURVE",
+"400 72 LINE",
+"473 144 OFFCURVE",
+"547 231 OFFCURVE",
+"629 334 CURVE",
+"583 439 OFFCURVE",
+"527 541 OFFCURVE",
+"469 627 CURVE",
+"389 627 LINE",
+"327 531 OFFCURVE",
+"281 472 OFFCURVE",
+"206 391 CURVE",
+"288 214 OFFCURVE",
+"375 17 OFFCURVE",
+"429 -139 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"487 518 LINE",
+"426 414 OFFCURVE",
+"377 355 OFFCURVE",
+"311 279 CURVE",
+"344 222 LINE",
+"421 312 OFFCURVE",
+"479 383 OFFCURVE",
+"530 464 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"556 101 OFFCURVE",
+"578 59 OFFCURVE",
+"597 19 CURVE",
+"615 -11 LINE",
+"637 -62 OFFCURVE",
+"656 -109 OFFCURVE",
+"675 -163 CURVE",
+"742 -141 LINE",
+"716 -69 OFFCURVE",
+"695 -15 OFFCURVE",
+"665 47 CURVE",
+"645 79 LINE",
+"628 111 OFFCURVE",
+"609 146 OFFCURVE",
+"587 186 CURVE",
+"529 151 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"188 41 OFFCURVE",
+"230 -73 OFFCURVE",
+"259 -203 CURVE",
+"329 -187 LINE",
+"294 -39 OFFCURVE",
+"253 71 OFFCURVE",
+"181 209 CURVE",
+"118 174 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"382 941 LINE",
+"293 754 OFFCURVE",
+"202 633 OFFCURVE",
+"80 509 CURVE",
+"131 456 LINE",
+"253 582 OFFCURVE",
+"357 711 OFFCURVE",
+"451 915 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"375 818 LINE",
+"486 720 OFFCURVE",
+"585 610 OFFCURVE",
+"671 488 CURVE",
+"729 533 LINE",
+"638 658 OFFCURVE",
+"546 762 OFFCURVE",
+"412 881 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 853;
+}
+);
+leftMetricsKey = u1B185;
+rightMetricsKey = u1B185;
+unicode = 1B2CC;
+},
+{
+glyphname = u1B2CD;
+lastChange = "2020-04-13 09:32:53 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"555 159 OFFCURVE",
+"578 176 OFFCURVE",
+"578 215 CURVE SMOOTH",
+"578 254 OFFCURVE",
+"555 271 OFFCURVE",
+"527 271 CURVE SMOOTH",
+"498 271 OFFCURVE",
+"475 254 OFFCURVE",
+"475 215 CURVE SMOOTH",
+"475 176 OFFCURVE",
+"498 159 OFFCURVE",
+"527 159 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"664 3 OFFCURVE",
+"687 20 OFFCURVE",
+"687 59 CURVE SMOOTH",
+"687 98 OFFCURVE",
+"664 115 OFFCURVE",
+"636 115 CURVE SMOOTH",
+"607 115 OFFCURVE",
+"584 98 OFFCURVE",
+"584 59 CURVE SMOOTH",
+"584 20 OFFCURVE",
+"607 3 OFFCURVE",
+"636 3 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"540 -147 OFFCURVE",
+"563 -130 OFFCURVE",
+"563 -91 CURVE SMOOTH",
+"563 -52 OFFCURVE",
+"540 -35 OFFCURVE",
+"512 -35 CURVE SMOOTH",
+"483 -35 OFFCURVE",
+"460 -52 OFFCURVE",
+"460 -91 CURVE SMOOTH",
+"460 -130 OFFCURVE",
+"483 -147 OFFCURVE",
+"512 -147 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"448 12 OFFCURVE",
+"471 29 OFFCURVE",
+"471 68 CURVE SMOOTH",
+"471 107 OFFCURVE",
+"448 124 OFFCURVE",
+"420 124 CURVE SMOOTH",
+"391 124 OFFCURVE",
+"368 107 OFFCURVE",
+"368 68 CURVE SMOOTH",
+"368 29 OFFCURVE",
+"391 12 OFFCURVE",
+"420 12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"502 939 LINE",
+"372 781 OFFCURVE",
+"279 685 OFFCURVE",
+"111 549 CURVE",
+"156 496 LINE",
+"311 622 OFFCURVE",
+"419 727 OFFCURVE",
+"558 897 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"343 728 LINE",
+"515 490 OFFCURVE",
+"621 314 OFFCURVE",
+"727 116 CURVE",
+"788 152 LINE",
+"683 354 OFFCURVE",
+"565 543 OFFCURVE",
+"402 763 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"580 770 LINE",
+"544 728 OFFCURVE",
+"510 691 OFFCURVE",
+"477 656 CURVE",
+"444 627 LINE",
+"357 540 OFFCURVE",
+"272 470 OFFCURVE",
+"173 389 CURVE",
+"218 334 LINE",
+"318 414 OFFCURVE",
+"400 484 OFFCURVE",
+"482 566 CURVE",
+"512 591 LINE",
+"551 632 OFFCURVE",
+"591 675 OFFCURVE",
+"634 725 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"660 620 LINE",
+"626 579 OFFCURVE",
+"593 543 OFFCURVE",
+"561 509 CURVE",
+"531 484 LINE",
+"441 394 OFFCURVE",
+"355 322 OFFCURVE",
+"253 239 CURVE",
+"298 187 LINE",
+"401 270 OFFCURVE",
+"484 341 OFFCURVE",
+"569 426 CURVE",
+"601 454 LINE",
+"637 492 OFFCURVE",
+"675 532 OFFCURVE",
+"714 578 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 -95 OFFCURVE",
+"109 -143 OFFCURVE",
+"177 -183 CURVE",
+"248 -174 LINE",
+"316 -95 OFFCURVE",
+"334 -30 OFFCURVE",
+"334 31 CURVE SMOOTH",
+"334 91 OFFCURVE",
+"300 132 OFFCURVE",
+"232 170 CURVE",
+"158 160 LINE",
+"100 78 OFFCURVE",
+"80 11 OFFCURVE",
+"80 -38 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 116 LINE",
+"244 84 OFFCURVE",
+"259 49 OFFCURVE",
+"259 20 CURVE SMOOTH",
+"259 -23 OFFCURVE",
+"249 -68 OFFCURVE",
+"209 -132 CURVE",
+"204 -133 LINE",
+"169 -98 OFFCURVE",
+"154 -67 OFFCURVE",
+"154 -34 CURVE SMOOTH",
+"154 8 OFFCURVE",
+"167 52 OFFCURVE",
+"199 115 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 868;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B252;
+unicode = 1B2CD;
+},
+{
+glyphname = u1B2CE;
+lastChange = "2020-04-13 09:33:12 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"548 939 LINE",
+"383 835 OFFCURVE",
+"251 767 OFFCURVE",
+"131 715 CURVE",
+"158 648 LINE",
+"293 709 OFFCURVE",
+"432 779 OFFCURVE",
+"587 879 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"570 759 LINE",
+"514 722 OFFCURVE",
+"460 691 OFFCURVE",
+"409 664 CURVE",
+"388 657 LINE",
+"319 621 OFFCURVE",
+"256 592 OFFCURVE",
+"196 566 CURVE",
+"220 507 LINE",
+"276 532 OFFCURVE",
+"336 558 OFFCURVE",
+"405 594 CURVE",
+"434 605 LINE",
+"486 632 OFFCURVE",
+"542 665 OFFCURVE",
+"605 705 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"617 606 LINE",
+"499 536 OFFCURVE",
+"379 474 OFFCURVE",
+"246 416 CURVE",
+"274 352 LINE",
+"408 409 OFFCURVE",
+"541 480 OFFCURVE",
+"654 547 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"328 759 LINE",
+"372 643 OFFCURVE",
+"397 556 OFFCURVE",
+"420 466 CURVE",
+"484 499 LINE",
+"461 587 OFFCURVE",
+"429 689 OFFCURVE",
+"382 814 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"358 196 LINE",
+"478 87 OFFCURVE",
+"555 9 OFFCURVE",
+"662 -120 CURVE",
+"720 -73 LINE",
+"674 -21 OFFCURVE",
+"638 16 OFFCURVE",
+"567 91 CURVE",
+"556 91 LINE",
+"522 136 OFFCURVE",
+"480 185 OFFCURVE",
+"405 252 CURVE",
+"402 214 LINE",
+"498 279 OFFCURVE",
+"551 316 OFFCURVE",
+"588 354 CURVE",
+"634 380 LINE",
+"652 396 OFFCURVE",
+"671 412 OFFCURVE",
+"689 429 CURVE",
+"639 480 LINE",
+"530 382 OFFCURVE",
+"450 327 OFFCURVE",
+"358 267 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"560 354 LINE",
+"592 354 LINE",
+"605 322 OFFCURVE",
+"614 290 OFFCURVE",
+"614 255 CURVE SMOOTH",
+"614 201 OFFCURVE",
+"592 141 OFFCURVE",
+"560 91 CURVE",
+"550 91 LINE",
+"484 6 OFFCURVE",
+"398 -60 OFFCURVE",
+"285 -143 CURVE",
+"331 -203 LINE",
+"442 -118 OFFCURVE",
+"520 -45 OFFCURVE",
+"575 15 CURVE",
+"597 34 LINE",
+"665 114 OFFCURVE",
+"686 182 OFFCURVE",
+"686 258 CURVE SMOOTH",
+"686 306 OFFCURVE",
+"672 357 OFFCURVE",
+"632 417 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"788 35 OFFCURVE",
+"811 52 OFFCURVE",
+"811 91 CURVE SMOOTH",
+"811 130 OFFCURVE",
+"788 147 OFFCURVE",
+"760 147 CURVE SMOOTH",
+"731 147 OFFCURVE",
+"708 130 OFFCURVE",
+"708 91 CURVE SMOOTH",
+"708 52 OFFCURVE",
+"731 35 OFFCURVE",
+"760 35 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"224 309 LINE",
+"209 135 OFFCURVE",
+"188 42 OFFCURVE",
+"139 -63 CURVE",
+"202 -90 LINE",
+"255 26 OFFCURVE",
+"279 122 OFFCURVE",
+"294 306 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"130 115 OFFCURVE",
+"153 132 OFFCURVE",
+"153 171 CURVE SMOOTH",
+"153 210 OFFCURVE",
+"130 227 OFFCURVE",
+"102 227 CURVE SMOOTH",
+"73 227 OFFCURVE",
+"50 210 OFFCURVE",
+"50 171 CURVE SMOOTH",
+"50 132 OFFCURVE",
+"73 115 OFFCURVE",
+"102 115 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"386 6 OFFCURVE",
+"408 22 OFFCURVE",
+"408 59 CURVE SMOOTH",
+"408 96 OFFCURVE",
+"386 112 OFFCURVE",
+"359 112 CURVE SMOOTH",
+"331 112 OFFCURVE",
+"309 96 OFFCURVE",
+"309 59 CURVE SMOOTH",
+"309 22 OFFCURVE",
+"331 6 OFFCURVE",
+"359 6 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 891;
+}
+);
+leftMetricsKey = u1B1D7;
+unicode = 1B2CE;
+},
+{
+glyphname = u1B2CF;
+lastChange = "2020-04-13 09:36:48 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"773 238 OFFCURVE",
+"733 398 OFFCURVE",
+"691 514 CURVE",
+"607 528 LINE",
+"543 441 OFFCURVE",
+"471 371 OFFCURVE",
+"384 295 CURVE",
+"436 140 OFFCURVE",
+"470 6 OFFCURVE",
+"494 -118 CURVE",
+"572 -140 LINE",
+"655 -69 OFFCURVE",
+"729 2 OFFCURVE",
+"804 90 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"735 121 LINE",
+"712 94 OFFCURVE",
+"689 69 OFFCURVE",
+"665 45 CURVE SMOOTH",
+"621 1 OFFCURVE",
+"589 -33 OFFCURVE",
+"558 -66 CURVE",
+"554 -66 LINE",
+"544 -2 OFFCURVE",
+"529 71 OFFCURVE",
+"508 145 CURVE SMOOTH",
+"492 200 OFFCURVE",
+"474 257 OFFCURVE",
+"453 319 CURVE",
+"455 263 LINE",
+"483 288 OFFCURVE",
+"511 314 OFFCURVE",
+"537 340 CURVE SMOOTH",
+"576 379 OFFCURVE",
+"599 404 OFFCURVE",
+"634 449 CURVE",
+"639 448 LINE",
+"651 395 OFFCURVE",
+"668 342 OFFCURVE",
+"685 277 CURVE SMOOTH",
+"704 205 OFFCURVE",
+"720 130 OFFCURVE",
+"733 59 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"687 339 LINE",
+"620 261 OFFCURVE",
+"550 189 OFFCURVE",
+"477 123 CURVE",
+"501 49 LINE",
+"588 126 OFFCURVE",
+"654 193 OFFCURVE",
+"732 276 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"704 939 LINE",
+"643 834 OFFCURVE",
+"582 745 OFFCURVE",
+"517 666 CURVE SMOOTH",
+"457 593 OFFCURVE",
+"397 531 OFFCURVE",
+"341 469 CURVE",
+"337 469 LINE",
+"315 555 OFFCURVE",
+"291 607 OFFCURVE",
+"251 691 CURVE SMOOTH",
+"242 710 OFFCURVE",
+"232 729 OFFCURVE",
+"221 749 CURVE",
+"155 715 LINE",
+"215 603 OFFCURVE",
+"242 533 OFFCURVE",
+"286 422 CURVE",
+"370 406 LINE",
+"527 551 OFFCURVE",
+"642 694 OFFCURVE",
+"769 902 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"433 717 OFFCURVE",
+"456 734 OFFCURVE",
+"456 773 CURVE SMOOTH",
+"456 812 OFFCURVE",
+"433 829 OFFCURVE",
+"405 829 CURVE SMOOTH",
+"376 829 OFFCURVE",
+"353 812 OFFCURVE",
+"353 773 CURVE SMOOTH",
+"353 734 OFFCURVE",
+"376 717 OFFCURVE",
+"405 717 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"140 416 OFFCURVE",
+"163 433 OFFCURVE",
+"163 472 CURVE SMOOTH",
+"163 511 OFFCURVE",
+"140 528 OFFCURVE",
+"112 528 CURVE SMOOTH",
+"83 528 OFFCURVE",
+"60 511 OFFCURVE",
+"60 472 CURVE SMOOTH",
+"60 433 OFFCURVE",
+"83 416 OFFCURVE",
+"112 416 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"240 126 LINE",
+"257 45 LINE",
+"289 -17 OFFCURVE",
+"310 -64 OFFCURVE",
+"348 -165 CURVE",
+"419 -138 LINE",
+"373 -20 OFFCURVE",
+"328 60 OFFCURVE",
+"254 161 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"213 226 LINE",
+"196 60 OFFCURVE",
+"169 -53 OFFCURVE",
+"121 -183 CURVE",
+"193 -203 LINE",
+"228 -103 OFFCURVE",
+"242 -28 OFFCURVE",
+"252 44 CURVE",
+"271 49 LINE",
+"277 82 OFFCURVE",
+"283 186 OFFCURVE",
+"286 218 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 894;
+}
+);
+leftMetricsKey = u1B256;
+rightMetricsKey = u1B2A4;
+unicode = 1B2CF;
+},
+{
+glyphname = u1B2D0;
+lastChange = "2020-04-13 09:36:45 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"315 27 LINE",
+"276 116 OFFCURVE",
+"247 163 OFFCURVE",
+"199 231 CURVE",
+"178 151 LINE",
+"195 151 LINE",
+"212 104 OFFCURVE",
+"231 61 OFFCURVE",
+"253 1 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"150 261 LINE",
+"141 155 OFFCURVE",
+"123 88 OFFCURVE",
+"80 -21 CURVE",
+"140 -42 LINE",
+"167 24 OFFCURVE",
+"184 86 OFFCURVE",
+"191 151 CURVE",
+"206 192 LINE",
+"209 213 OFFCURVE",
+"212 235 OFFCURVE",
+"214 258 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"814 -9 LINE",
+"791 61 OFFCURVE",
+"761 134 OFFCURVE",
+"707 215 CURVE",
+"674 135 LINE",
+"697 135 LINE",
+"720 74 OFFCURVE",
+"733 32 OFFCURVE",
+"749 -28 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"661 254 LINE",
+"645 156 OFFCURVE",
+"621 84 OFFCURVE",
+"575 -7 CURVE",
+"635 -35 LINE",
+"661 14 OFFCURVE",
+"675 63 OFFCURVE",
+"693 135 CURVE",
+"715 184 LINE",
+"720 207 OFFCURVE",
+"722 219 OFFCURVE",
+"726 245 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"419 524 LINE",
+"448 481 OFFCURVE",
+"468 450 OFFCURVE",
+"501 403 CURVE SMOOTH",
+"536 353 OFFCURVE",
+"569 301 OFFCURVE",
+"601 246 CURVE",
+"601 340 LINE",
+"547 264 OFFCURVE",
+"493 192 OFFCURVE",
+"428 112 CURVE",
+"398 77 LINE",
+"339 3 OFFCURVE",
+"274 -72 OFFCURVE",
+"201 -155 CURVE",
+"256 -203 LINE",
+"324 -125 OFFCURVE",
+"385 -53 OFFCURVE",
+"441 16 CURVE",
+"462 40 LINE",
+"544 141 OFFCURVE",
+"605 219 OFFCURVE",
+"660 296 CURVE",
+"601 391 OFFCURVE",
+"524 500 OFFCURVE",
+"456 587 CURVE",
+"376 587 LINE",
+"319 501 OFFCURVE",
+"265 438 OFFCURVE",
+"185 347 CURVE",
+"319 164 OFFCURVE",
+"412 31 OFFCURVE",
+"547 -177 CURVE",
+"610 -138 LINE",
+"489 50 OFFCURVE",
+"368 224 OFFCURVE",
+"256 377 CURVE",
+"269 334 LINE",
+"288 355 OFFCURVE",
+"306 376 OFFCURVE",
+"323 396 CURVE SMOOTH",
+"360 440 OFFCURVE",
+"382 472 OFFCURVE",
+"415 524 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"483 446 LINE",
+"426 366 OFFCURVE",
+"380 311 OFFCURVE",
+"316 245 CURVE",
+"363 193 LINE",
+"435 268 OFFCURVE",
+"482 325 OFFCURVE",
+"536 400 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"382 941 LINE",
+"298 760 OFFCURVE",
+"201 633 OFFCURVE",
+"80 509 CURVE",
+"133 457 LINE",
+"254 583 OFFCURVE",
+"361 716 OFFCURVE",
+"450 914 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"374 819 LINE",
+"485 721 OFFCURVE",
+"584 611 OFFCURVE",
+"670 489 CURVE",
+"729 533 LINE",
+"638 658 OFFCURVE",
+"546 762 OFFCURVE",
+"412 881 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 894;
+}
+);
+leftMetricsKey = u1B295;
+rightMetricsKey = u1B295;
+unicode = 1B2D0;
+},
+{
+glyphname = u1B2D1;
+lastChange = "2020-04-13 09:36:40 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"774 360 LINE",
+"720 329 OFFCURVE",
+"663 298 OFFCURVE",
+"606 270 CURVE",
+"576 262 LINE",
+"512 232 OFFCURVE",
+"447 205 OFFCURVE",
+"383 183 CURVE",
+"406 117 LINE",
+"467 138 OFFCURVE",
+"528 163 OFFCURVE",
+"591 192 CURVE",
+"615 197 LINE",
+"680 228 OFFCURVE",
+"746 263 OFFCURVE",
+"812 301 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"841 156 LINE",
+"718 86 OFFCURVE",
+"573 25 OFFCURVE",
+"431 -21 CURVE",
+"452 -87 LINE",
+"608 -36 OFFCURVE",
+"736 15 OFFCURVE",
+"878 93 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"647 744 LINE",
+"600 713 OFFCURVE",
+"551 683 OFFCURVE",
+"499 654 CURVE",
+"467 639 LINE",
+"411 608 OFFCURVE",
+"352 577 OFFCURVE",
+"287 548 CURVE",
+"306 479 LINE",
+"372 510 OFFCURVE",
+"432 540 OFFCURVE",
+"490 571 CURVE",
+"522 586 LINE",
+"581 619 OFFCURVE",
+"639 654 OFFCURVE",
+"701 696 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"674 24 LINE",
+"644 178 OFFCURVE",
+"618 313 OFFCURVE",
+"585 440 CURVE",
+"571 478 LINE",
+"539 597 OFFCURVE",
+"506 709 OFFCURVE",
+"463 821 CURVE",
+"407 774 LINE",
+"445 666 OFFCURVE",
+"479 552 OFFCURVE",
+"510 434 CURVE",
+"517 406 LINE",
+"548 281 OFFCURVE",
+"576 151 OFFCURVE",
+"598 16 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"591 939 LINE",
+"463 851 OFFCURVE",
+"343 784 OFFCURVE",
+"204 716 CURVE",
+"249 564 OFFCURVE",
+"272 482 OFFCURVE",
+"304 332 CURVE",
+"376 305 LINE",
+"433 330 OFFCURVE",
+"486 355 OFFCURVE",
+"537 380 CURVE",
+"572 395 LINE",
+"639 430 OFFCURVE",
+"704 467 OFFCURVE",
+"775 510 CURVE",
+"739 678 OFFCURVE",
+"712 776 OFFCURVE",
+"665 924 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"608 857 LINE",
+"625 803 OFFCURVE",
+"640 748 OFFCURVE",
+"656 690 CURVE SMOOTH",
+"671 636 OFFCURVE",
+"683 583 OFFCURVE",
+"696 523 CURVE",
+"736 573 LINE",
+"675 536 OFFCURVE",
+"610 498 OFFCURVE",
+"548 465 CURVE",
+"514 451 LINE",
+"455 420 OFFCURVE",
+"411 400 OFFCURVE",
+"373 379 CURVE",
+"368 380 LINE",
+"357 442 OFFCURVE",
+"345 492 OFFCURVE",
+"329 549 CURVE SMOOTH",
+"314 603 OFFCURVE",
+"298 658 OFFCURVE",
+"277 725 CURVE",
+"251 657 LINE",
+"310 685 OFFCURVE",
+"378 721 OFFCURVE",
+"446 760 CURVE SMOOTH",
+"508 795 OFFCURVE",
+"549 822 OFFCURVE",
+"603 858 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"377 -186 LINE",
+"328 0 OFFCURVE",
+"272 140 OFFCURVE",
+"170 314 CURVE",
+"113 277 LINE",
+"215 97 OFFCURVE",
+"264 -32 OFFCURVE",
+"309 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"318 269 LINE",
+"283 237 OFFCURVE",
+"248 209 OFFCURVE",
+"212 185 CURVE",
+"190 177 LINE",
+"150 152 OFFCURVE",
+"110 131 OFFCURVE",
+"70 111 CURVE",
+"100 49 LINE",
+"143 69 OFFCURVE",
+"184 90 OFFCURVE",
+"224 115 CURVE",
+"249 125 LINE",
+"290 152 OFFCURVE",
+"330 183 OFFCURVE",
+"367 219 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"402 106 LINE",
+"363 73 OFFCURVE",
+"324 44 OFFCURVE",
+"283 19 CURVE",
+"262 12 LINE",
+"222 -12 OFFCURVE",
+"179 -33 OFFCURVE",
+"130 -56 CURVE",
+"159 -120 LINE",
+"206 -98 OFFCURVE",
+"247 -78 OFFCURVE",
+"286 -55 CURVE",
+"311 -46 LINE",
+"354 -20 OFFCURVE",
+"396 11 OFFCURVE",
+"444 49 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 978;
+}
+);
+leftMetricsKey = u1B1ED;
+rightMetricsKey = u1B244;
+unicode = 1B2D1;
+},
+{
+glyphname = u1B2D2;
+lastChange = "2020-04-13 09:36:17 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"335 648 LINE",
+"376 678 OFFCURVE",
+"416 709 OFFCURVE",
+"454 741 CURVE SMOOTH",
+"494 774 OFFCURVE",
+"529 805 OFFCURVE",
+"574 853 CURVE",
+"579 852 LINE",
+"592 804 OFFCURVE",
+"610 747 OFFCURVE",
+"622 700 CURVE SMOOTH",
+"638 640 OFFCURVE",
+"652 575 OFFCURVE",
+"667 496 CURVE",
+"679 573 LINE",
+"580 482 OFFCURVE",
+"497 420 OFFCURVE",
+"390 348 CURVE",
+"432 289 LINE",
+"547 366 OFFCURVE",
+"640 439 OFFCURVE",
+"738 526 CURVE",
+"707 676 OFFCURVE",
+"678 785 OFFCURVE",
+"633 920 CURVE",
+"556 934 LINE",
+"473 848 OFFCURVE",
+"391 778 OFFCURVE",
+"307 718 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"623 756 LINE",
+"534 667 OFFCURVE",
+"447 597 OFFCURVE",
+"354 534 CURVE",
+"400 483 LINE",
+"498 549 OFFCURVE",
+"580 616 OFFCURVE",
+"655 686 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"148 532 OFFCURVE",
+"173 432 OFFCURVE",
+"182 313 CURVE",
+"253 317 LINE",
+"238 465 OFFCURVE",
+"215 551 OFFCURVE",
+"166 673 CURVE",
+"100 646 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"259 100 OFFCURVE",
+"282 117 OFFCURVE",
+"282 156 CURVE SMOOTH",
+"282 195 OFFCURVE",
+"259 212 OFFCURVE",
+"231 212 CURVE SMOOTH",
+"202 212 OFFCURVE",
+"179 195 OFFCURVE",
+"179 156 CURVE SMOOTH",
+"179 117 OFFCURVE",
+"202 100 OFFCURVE",
+"231 100 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"248 -103 OFFCURVE",
+"271 -86 OFFCURVE",
+"271 -47 CURVE SMOOTH",
+"271 -8 OFFCURVE",
+"248 9 OFFCURVE",
+"220 9 CURVE SMOOTH",
+"191 9 OFFCURVE",
+"168 -8 OFFCURVE",
+"168 -47 CURVE SMOOTH",
+"168 -86 OFFCURVE",
+"191 -103 OFFCURVE",
+"220 -103 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"652 214 OFFCURVE",
+"674 230 OFFCURVE",
+"674 267 CURVE SMOOTH",
+"674 305 OFFCURVE",
+"652 321 OFFCURVE",
+"625 321 CURVE SMOOTH",
+"597 321 OFFCURVE",
+"575 305 OFFCURVE",
+"575 267 CURVE SMOOTH",
+"575 230 OFFCURVE",
+"597 214 OFFCURVE",
+"625 214 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"662 21 OFFCURVE",
+"684 37 OFFCURVE",
+"684 74 CURVE SMOOTH",
+"684 111 OFFCURVE",
+"662 128 OFFCURVE",
+"635 128 CURVE SMOOTH",
+"608 128 OFFCURVE",
+"586 111 OFFCURVE",
+"586 74 CURVE SMOOTH",
+"586 37 OFFCURVE",
+"608 21 OFFCURVE",
+"635 21 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"642 -166 OFFCURVE",
+"664 -150 OFFCURVE",
+"664 -113 CURVE SMOOTH",
+"664 -75 OFFCURVE",
+"642 -59 OFFCURVE",
+"615 -59 CURVE SMOOTH",
+"588 -59 OFFCURVE",
+"566 -75 OFFCURVE",
+"566 -113 CURVE SMOOTH",
+"566 -150 OFFCURVE",
+"588 -166 OFFCURVE",
+"615 -166 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"214 910 LINE",
+"355 595 OFFCURVE",
+"381 281 OFFCURVE",
+"381 68 CURVE SMOOTH",
+"381 -57 OFFCURVE",
+"375 -115 OFFCURVE",
+"365 -193 CURVE",
+"440 -203 LINE",
+"450 -124 OFFCURVE",
+"455 -57 OFFCURVE",
+"455 68 CURVE SMOOTH",
+"455 327 OFFCURVE",
+"408 635 OFFCURVE",
+"281 939 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 808;
+}
+);
+leftMetricsKey = u1B224;
+unicode = 1B2D2;
+},
+{
+glyphname = u1B2D3;
+lastChange = "2020-04-13 09:36:15 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"803 230 OFFCURVE",
+"757 350 OFFCURVE",
+"701 468 CURVE",
+"622 484 LINE",
+"540 414 OFFCURVE",
+"469 363 OFFCURVE",
+"361 294 CURVE",
+"427 147 OFFCURVE",
+"462 55 OFFCURVE",
+"496 -50 CURVE",
+"584 -70 LINE",
+"662 -22 OFFCURVE",
+"753 39 OFFCURVE",
+"836 110 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"775 155 LINE",
+"743 127 OFFCURVE",
+"710 101 OFFCURVE",
+"675 76 CURVE SMOOTH",
+"630 44 OFFCURVE",
+"601 25 OFFCURVE",
+"561 -3 CURVE",
+"556 -2 LINE",
+"539 55 OFFCURVE",
+"520 102 OFFCURVE",
+"495 165 CURVE SMOOTH",
+"477 210 OFFCURVE",
+"455 260 OFFCURVE",
+"429 318 CURVE",
+"429 254 LINE",
+"465 276 OFFCURVE",
+"498 298 OFFCURVE",
+"530 320 CURVE SMOOTH",
+"578 353 OFFCURVE",
+"598 369 OFFCURVE",
+"644 409 CURVE",
+"649 408 LINE",
+"671 358 OFFCURVE",
+"690 312 OFFCURVE",
+"710 260 CURVE SMOOTH",
+"732 204 OFFCURVE",
+"751 150 OFFCURVE",
+"770 92 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"699 321 LINE",
+"629 261 OFFCURVE",
+"554 206 OFFCURVE",
+"466 151 CURVE",
+"490 83 LINE",
+"589 145 OFFCURVE",
+"669 204 OFFCURVE",
+"744 265 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"613 696 LINE",
+"503 588 OFFCURVE",
+"390 500 OFFCURVE",
+"264 420 CURVE",
+"305 361 LINE",
+"442 450 OFFCURVE",
+"544 528 OFFCURVE",
+"665 646 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"230 882 LINE",
+"321 730 OFFCURVE",
+"397 586 OFFCURVE",
+"442 464 CURVE",
+"500 516 LINE",
+"452 631 OFFCURVE",
+"390 762 OFFCURVE",
+"293 920 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"561 939 LINE",
+"492 861 OFFCURVE",
+"431 800 OFFCURVE",
+"367 746 CURVE",
+"342 730 LINE",
+"288 685 OFFCURVE",
+"231 643 OFFCURVE",
+"164 598 CURVE",
+"207 539 LINE",
+"270 583 OFFCURVE",
+"327 624 OFFCURVE",
+"380 668 CURVE",
+"401 681 LINE",
+"475 743 OFFCURVE",
+"544 810 OFFCURVE",
+"618 893 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"377 -186 LINE",
+"328 0 OFFCURVE",
+"272 140 OFFCURVE",
+"170 314 CURVE",
+"113 277 LINE",
+"215 97 OFFCURVE",
+"264 -32 OFFCURVE",
+"309 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"318 269 LINE",
+"283 237 OFFCURVE",
+"248 209 OFFCURVE",
+"212 185 CURVE",
+"190 177 LINE",
+"150 152 OFFCURVE",
+"110 131 OFFCURVE",
+"70 111 CURVE",
+"100 49 LINE",
+"143 69 OFFCURVE",
+"184 90 OFFCURVE",
+"224 115 CURVE",
+"249 125 LINE",
+"290 152 OFFCURVE",
+"330 183 OFFCURVE",
+"367 219 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"402 106 LINE",
+"363 73 OFFCURVE",
+"324 44 OFFCURVE",
+"283 19 CURVE",
+"262 12 LINE",
+"222 -12 OFFCURVE",
+"179 -33 OFFCURVE",
+"130 -56 CURVE",
+"159 -120 LINE",
+"206 -98 OFFCURVE",
+"247 -78 OFFCURVE",
+"286 -55 CURVE",
+"311 -46 LINE",
+"354 -20 OFFCURVE",
+"396 11 OFFCURVE",
+"444 49 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 926;
+}
+);
+leftMetricsKey = u1B1ED;
+rightMetricsKey = u1B1BC;
+unicode = 1B2D3;
+},
+{
+glyphname = u1B2D4;
+lastChange = "2020-04-13 09:35:58 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"318 269 LINE",
+"283 237 OFFCURVE",
+"248 209 OFFCURVE",
+"212 185 CURVE",
+"190 177 LINE",
+"150 152 OFFCURVE",
+"110 131 OFFCURVE",
+"70 111 CURVE",
+"100 49 LINE",
+"143 69 OFFCURVE",
+"184 90 OFFCURVE",
+"224 115 CURVE",
+"249 125 LINE",
+"290 152 OFFCURVE",
+"330 183 OFFCURVE",
+"367 219 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"402 106 LINE",
+"363 73 OFFCURVE",
+"324 44 OFFCURVE",
+"283 19 CURVE",
+"262 12 LINE",
+"222 -12 OFFCURVE",
+"179 -33 OFFCURVE",
+"130 -56 CURVE",
+"159 -120 LINE",
+"206 -98 OFFCURVE",
+"247 -78 OFFCURVE",
+"286 -55 CURVE",
+"311 -46 LINE",
+"354 -20 OFFCURVE",
+"396 11 OFFCURVE",
+"444 49 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"377 -186 LINE",
+"328 0 OFFCURVE",
+"272 140 OFFCURVE",
+"170 314 CURVE",
+"113 277 LINE",
+"215 97 OFFCURVE",
+"264 -32 OFFCURVE",
+"309 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"625 159 OFFCURVE",
+"648 176 OFFCURVE",
+"648 215 CURVE SMOOTH",
+"648 254 OFFCURVE",
+"625 271 OFFCURVE",
+"597 271 CURVE SMOOTH",
+"568 271 OFFCURVE",
+"545 254 OFFCURVE",
+"545 215 CURVE SMOOTH",
+"545 176 OFFCURVE",
+"568 159 OFFCURVE",
+"597 159 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"734 3 OFFCURVE",
+"757 20 OFFCURVE",
+"757 59 CURVE SMOOTH",
+"757 98 OFFCURVE",
+"734 115 OFFCURVE",
+"706 115 CURVE SMOOTH",
+"677 115 OFFCURVE",
+"654 98 OFFCURVE",
+"654 59 CURVE SMOOTH",
+"654 20 OFFCURVE",
+"677 3 OFFCURVE",
+"706 3 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"610 -147 OFFCURVE",
+"633 -130 OFFCURVE",
+"633 -91 CURVE SMOOTH",
+"633 -52 OFFCURVE",
+"610 -35 OFFCURVE",
+"582 -35 CURVE SMOOTH",
+"553 -35 OFFCURVE",
+"530 -52 OFFCURVE",
+"530 -91 CURVE SMOOTH",
+"530 -130 OFFCURVE",
+"553 -147 OFFCURVE",
+"582 -147 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"539 12 OFFCURVE",
+"562 29 OFFCURVE",
+"562 68 CURVE SMOOTH",
+"562 107 OFFCURVE",
+"539 124 OFFCURVE",
+"511 124 CURVE SMOOTH",
+"482 124 OFFCURVE",
+"459 107 OFFCURVE",
+"459 68 CURVE SMOOTH",
+"459 29 OFFCURVE",
+"482 12 OFFCURVE",
+"511 12 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"572 939 LINE",
+"442 781 OFFCURVE",
+"349 685 OFFCURVE",
+"181 549 CURVE",
+"226 496 LINE",
+"381 622 OFFCURVE",
+"489 727 OFFCURVE",
+"628 897 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"413 728 LINE",
+"585 490 OFFCURVE",
+"691 314 OFFCURVE",
+"797 116 CURVE",
+"858 152 LINE",
+"753 354 OFFCURVE",
+"635 543 OFFCURVE",
+"472 763 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"650 770 LINE",
+"612 725 OFFCURVE",
+"575 684 OFFCURVE",
+"540 648 CURVE",
+"517 629 LINE",
+"430 542 OFFCURVE",
+"350 474 OFFCURVE",
+"263 402 CURVE",
+"308 347 LINE",
+"394 418 OFFCURVE",
+"470 483 OFFCURVE",
+"550 563 CURVE",
+"582 590 LINE",
+"620 631 OFFCURVE",
+"661 675 OFFCURVE",
+"704 725 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"730 620 LINE",
+"694 578 OFFCURVE",
+"660 540 OFFCURVE",
+"628 506 CURVE",
+"602 485 LINE",
+"516 397 OFFCURVE",
+"440 333 OFFCURVE",
+"371 274 CURVE",
+"416 222 LINE",
+"487 281 OFFCURVE",
+"559 344 OFFCURVE",
+"639 426 CURVE",
+"671 454 LINE",
+"707 491 OFFCURVE",
+"744 532 OFFCURVE",
+"784 578 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 938;
+}
+);
+leftMetricsKey = u1B1ED;
+rightMetricsKey = u1B252;
+unicode = 1B2D4;
+},
+{
+glyphname = u1B2D5;
+lastChange = "2020-04-13 09:35:21 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"238 184 LINE",
+"274 219 OFFCURVE",
+"297 268 OFFCURVE",
+"297 311 CURVE SMOOTH",
+"297 465 OFFCURVE",
+"201 544 OFFCURVE",
+"60 543 CURVE",
+"61 475 LINE",
+"179 475 OFFCURVE",
+"228 419 OFFCURVE",
+"228 308 CURVE SMOOTH",
+"228 262 OFFCURVE",
+"207 224 OFFCURVE",
+"169 196 CURVE",
+"194 126 LINE",
+"323 126 OFFCURVE",
+"367 75 OFFCURVE",
+"367 -16 CURVE SMOOTH",
+"367 -89 OFFCURVE",
+"339 -119 OFFCURVE",
+"287 -148 CURVE",
+"320 -203 LINE",
+"403 -155 OFFCURVE",
+"438 -92 OFFCURVE",
+"438 -17 CURVE SMOOTH",
+"438 62 OFFCURVE",
+"404 125 OFFCURVE",
+"347 158 CURVE SMOOTH",
+"316 176 OFFCURVE",
+"280 181 OFFCURVE",
+"239 179 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"264 -62 OFFCURVE",
+"285 -47 OFFCURVE",
+"285 -12 CURVE SMOOTH",
+"285 23 OFFCURVE",
+"264 38 OFFCURVE",
+"238 38 CURVE SMOOTH",
+"211 38 OFFCURVE",
+"190 23 OFFCURVE",
+"190 -12 CURVE SMOOTH",
+"190 -47 OFFCURVE",
+"211 -62 OFFCURVE",
+"238 -62 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"124 281 OFFCURVE",
+"145 296 OFFCURVE",
+"145 331 CURVE SMOOTH",
+"145 366 OFFCURVE",
+"124 381 OFFCURVE",
+"98 381 CURVE SMOOTH",
+"71 381 OFFCURVE",
+"50 366 OFFCURVE",
+"50 331 CURVE SMOOTH",
+"50 296 OFFCURVE",
+"71 281 OFFCURVE",
+"98 281 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"565 16 LINE",
+"682 124 OFFCURVE",
+"759 212 OFFCURVE",
+"848 334 CURVE",
+"787 377 LINE",
+"749 323 OFFCURVE",
+"715 276 OFFCURVE",
+"678 233 CURVE SMOOTH",
+"633 181 OFFCURVE",
+"588 132 OFFCURVE",
+"540 84 CURVE",
+"536 84 LINE",
+"515 152 OFFCURVE",
+"495 214 OFFCURVE",
+"472 269 CURVE SMOOTH",
+"428 373 OFFCURVE",
+"374 487 OFFCURVE",
+"293 645 CURVE",
+"304 592 LINE",
+"343 634 OFFCURVE",
+"383 681 OFFCURVE",
+"422 732 CURVE SMOOTH",
+"450 768 OFFCURVE",
+"471 800 OFFCURVE",
+"498 847 CURVE",
+"502 847 LINE",
+"526 796 OFFCURVE",
+"551 751 OFFCURVE",
+"572 709 CURVE SMOOTH",
+"604 645 OFFCURVE",
+"632 579 OFFCURVE",
+"666 498 CURVE",
+"660 576 LINE",
+"575 453 OFFCURVE",
+"515 386 OFFCURVE",
+"420 288 CURVE",
+"476 243 LINE",
+"572 340 OFFCURVE",
+"638 417 OFFCURVE",
+"729 545 CURVE",
+"668 683 OFFCURVE",
+"610 801 OFFCURVE",
+"540 914 CURVE",
+"463 914 LINE",
+"389 803 OFFCURVE",
+"316 710 OFFCURVE",
+"227 612 CURVE",
+"354 364 OFFCURVE",
+"427 198 OFFCURVE",
+"486 26 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"570 755 LINE",
+"502 647 OFFCURVE",
+"429 562 OFFCURVE",
+"352 479 CURVE",
+"385 411 LINE",
+"477 507 OFFCURVE",
+"540 585 OFFCURVE",
+"613 692 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"617 286 OFFCURVE",
+"639 239 OFFCURVE",
+"659 194 CURVE",
+"680 154 LINE",
+"702 99 OFFCURVE",
+"722 43 OFFCURVE",
+"741 -23 CURVE",
+"812 -5 LINE",
+"786 79 OFFCURVE",
+"762 146 OFFCURVE",
+"734 212 CURVE",
+"714 244 LINE",
+"695 285 OFFCURVE",
+"674 327 OFFCURVE",
+"650 372 CURVE",
+"591 338 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 928;
+}
+);
+leftMetricsKey = u1B25A;
+rightMetricsKey = u1B274;
+unicode = 1B2D5;
+},
+{
+glyphname = u1B2D6;
+lastChange = "2020-04-13 09:35:09 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"711 328 OFFCURVE",
+"686 427 OFFCURVE",
+"655 519 CURVE",
+"587 542 LINE",
+"470 476 OFFCURVE",
+"362 432 OFFCURVE",
+"225 375 CURVE",
+"259 260 OFFCURVE",
+"279 176 OFFCURVE",
+"298 70 CURVE",
+"368 42 LINE",
+"478 81 OFFCURVE",
+"612 133 OFFCURVE",
+"732 197 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"663 237 LINE",
+"608 210 OFFCURVE",
+"552 186 OFFCURVE",
+"494 163 CURVE SMOOTH",
+"449 145 OFFCURVE",
+"403 124 OFFCURVE",
+"367 110 CURVE",
+"362 111 LINE",
+"357 163 OFFCURVE",
+"343 217 OFFCURVE",
+"334 251 CURVE SMOOTH",
+"323 294 OFFCURVE",
+"311 341 OFFCURVE",
+"297 389 CURVE",
+"293 329 LINE",
+"348 350 OFFCURVE",
+"407 375 OFFCURVE",
+"469 403 CURVE SMOOTH",
+"519 426 OFFCURVE",
+"547 442 OFFCURVE",
+"594 470 CURVE",
+"599 469 LINE",
+"608 426 OFFCURVE",
+"622 374 OFFCURVE",
+"631 336 CURVE SMOOTH",
+"644 281 OFFCURVE",
+"655 224 OFFCURVE",
+"663 191 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"636 390 LINE",
+"530 333 OFFCURVE",
+"409 287 OFFCURVE",
+"299 246 CURVE",
+"323 183 LINE",
+"437 228 OFFCURVE",
+"565 280 OFFCURVE",
+"681 338 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"789 -78 LINE",
+"765 -18 OFFCURVE",
+"729 51 OFFCURVE",
+"680 115 CURVE",
+"623 76 LINE",
+"670 17 OFFCURVE",
+"703 -49 OFFCURVE",
+"722 -103 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"396 -203 LINE",
+"413 -139 OFFCURVE",
+"418 -78 OFFCURVE",
+"418 8 CURVE",
+"347 9 LINE",
+"347 -66 OFFCURVE",
+"343 -120 OFFCURVE",
+"326 -189 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"346 551 LINE",
+"319 652 OFFCURVE",
+"291 730 OFFCURVE",
+"234 852 CURVE",
+"170 823 LINE",
+"230 695 OFFCURVE",
+"258 626 OFFCURVE",
+"283 531 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"612 939 LINE",
+"553 901 OFFCURVE",
+"497 869 OFFCURVE",
+"444 840 CURVE",
+"422 831 LINE",
+"367 800 OFFCURVE",
+"313 773 OFFCURVE",
+"260 747 CURVE",
+"235 739 LINE",
+"178 713 OFFCURVE",
+"121 688 OFFCURVE",
+"60 663 CURVE",
+"85 598 LINE",
+"146 624 OFFCURVE",
+"205 650 OFFCURVE",
+"262 677 CURVE",
+"287 685 LINE",
+"341 710 OFFCURVE",
+"394 737 OFFCURVE",
+"449 767 CURVE",
+"468 773 LINE",
+"526 806 OFFCURVE",
+"587 841 OFFCURVE",
+"652 882 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"543 623 LINE",
+"519 719 OFFCURVE",
+"490 799 OFFCURVE",
+"429 934 CURVE",
+"364 905 LINE",
+"420 780 OFFCURVE",
+"455 691 OFFCURVE",
+"477 604 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"717 783 LINE",
+"520 666 OFFCURVE",
+"312 571 OFFCURVE",
+"94 484 CURVE",
+"119 418 LINE",
+"315 494 OFFCURVE",
+"528 593 OFFCURVE",
+"753 722 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 889;
+}
+);
+unicode = 1B2D6;
+},
+{
+glyphname = u1B2D7;
+lastChange = "2020-04-13 09:34:43 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"136 70 OFFCURVE",
+"159 87 OFFCURVE",
+"159 126 CURVE SMOOTH",
+"159 165 OFFCURVE",
+"136 182 OFFCURVE",
+"108 182 CURVE SMOOTH",
+"79 182 OFFCURVE",
+"56 165 OFFCURVE",
+"56 126 CURVE SMOOTH",
+"56 87 OFFCURVE",
+"79 70 OFFCURVE",
+"108 70 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"50 373 LINE",
+"152 313 OFFCURVE",
+"206 239 OFFCURVE",
+"256 136 CURVE",
+"320 165 LINE",
+"263 285 OFFCURVE",
+"196 364 OFFCURVE",
+"89 431 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"301 399 OFFCURVE",
+"324 416 OFFCURVE",
+"324 455 CURVE SMOOTH",
+"324 494 OFFCURVE",
+"301 511 OFFCURVE",
+"273 511 CURVE SMOOTH",
+"244 511 OFFCURVE",
+"221 494 OFFCURVE",
+"221 455 CURVE SMOOTH",
+"221 416 OFFCURVE",
+"244 399 OFFCURVE",
+"273 399 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"686 137 OFFCURVE",
+"642 220 OFFCURVE",
+"579 316 CURVE",
+"505 321 LINE",
+"439 227 OFFCURVE",
+"384 160 OFFCURVE",
+"306 83 CURVE",
+"369 -23 OFFCURVE",
+"413 -102 OFFCURVE",
+"451 -191 CURVE",
+"525 -203 LINE",
+"593 -140 OFFCURVE",
+"661 -61 OFFCURVE",
+"731 31 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"675 73 LINE",
+"649 35 OFFCURVE",
+"624 1 OFFCURVE",
+"599 -29 CURVE SMOOTH",
+"560 -75 OFFCURVE",
+"533 -106 OFFCURVE",
+"503 -139 CURVE",
+"499 -139 LINE",
+"480 -88 OFFCURVE",
+"450 -27 OFFCURVE",
+"430 9 CURVE SMOOTH",
+"413 40 OFFCURVE",
+"394 72 OFFCURVE",
+"373 107 CURVE",
+"367 52 LINE",
+"395 80 OFFCURVE",
+"422 108 OFFCURVE",
+"448 138 CURVE SMOOTH",
+"475 169 OFFCURVE",
+"505 210 OFFCURVE",
+"535 256 CURVE",
+"539 256 LINE",
+"568 204 OFFCURVE",
+"592 161 OFFCURVE",
+"614 117 CURVE SMOOTH",
+"633 79 OFFCURVE",
+"651 42 OFFCURVE",
+"667 2 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"594 196 LINE",
+"544 121 OFFCURVE",
+"481 52 OFFCURVE",
+"416 -12 CURVE",
+"441 -74 LINE",
+"523 7 OFFCURVE",
+"585 79 OFFCURVE",
+"643 155 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"287 594 LINE",
+"450 489 OFFCURVE",
+"584 388 OFFCURVE",
+"735 257 CURVE",
+"782 314 LINE",
+"706 380 OFFCURVE",
+"629 443 OFFCURVE",
+"511 534 CURVE",
+"494 534 LINE",
+"452 569 OFFCURVE",
+"416 592 OFFCURVE",
+"326 655 CURVE",
+"329 610 LINE",
+"408 696 OFFCURVE",
+"452 756 OFFCURVE",
+"493 826 CURVE",
+"516 844 LINE",
+"528 862 OFFCURVE",
+"541 882 OFFCURVE",
+"555 903 CURVE",
+"493 939 LINE",
+"421 830 OFFCURVE",
+"361 753 OFFCURVE",
+"287 670 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"383 281 LINE",
+"443 345 OFFCURVE",
+"485 400 OFFCURVE",
+"521 449 CURVE",
+"547 477 LINE",
+"599 555 OFFCURVE",
+"622 618 OFFCURVE",
+"622 679 CURVE SMOOTH",
+"622 749 OFFCURVE",
+"602 802 OFFCURVE",
+"514 890 CURVE",
+"464 826 LINE",
+"497 826 LINE",
+"531 770 OFFCURVE",
+"546 724 OFFCURVE",
+"546 679 CURVE SMOOTH",
+"546 630 OFFCURVE",
+"538 594 OFFCURVE",
+"498 534 CURVE",
+"489 534 LINE",
+"445 465 OFFCURVE",
+"394 400 OFFCURVE",
+"329 331 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 862;
+}
+);
+leftMetricsKey = u1B1D7;
+rightMetricsKey = u1B251;
+unicode = 1B2D7;
+},
+{
+glyphname = u1B2D8;
+lastChange = "2020-04-13 09:34:34 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"80 -95 OFFCURVE",
+"109 -143 OFFCURVE",
+"177 -183 CURVE",
+"248 -174 LINE",
+"316 -95 OFFCURVE",
+"334 -30 OFFCURVE",
+"334 31 CURVE SMOOTH",
+"334 91 OFFCURVE",
+"300 132 OFFCURVE",
+"232 170 CURVE",
+"158 160 LINE",
+"100 78 OFFCURVE",
+"80 11 OFFCURVE",
+"80 -38 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 116 LINE",
+"244 84 OFFCURVE",
+"259 49 OFFCURVE",
+"259 20 CURVE SMOOTH",
+"259 -23 OFFCURVE",
+"249 -68 OFFCURVE",
+"209 -132 CURVE",
+"204 -133 LINE",
+"169 -98 OFFCURVE",
+"154 -67 OFFCURVE",
+"154 -34 CURVE SMOOTH",
+"154 8 OFFCURVE",
+"167 52 OFFCURVE",
+"199 115 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"785 189 OFFCURVE",
+"739 347 OFFCURVE",
+"696 466 CURVE",
+"618 479 LINE",
+"542 393 OFFCURVE",
+"453 314 OFFCURVE",
+"334 222 CURVE",
+"387 75 OFFCURVE",
+"417 -34 OFFCURVE",
+"450 -166 CURVE",
+"528 -183 LINE",
+"629 -115 OFFCURVE",
+"727 -40 OFFCURVE",
+"812 47 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"746 87 LINE",
+"711 51 OFFCURVE",
+"676 19 OFFCURVE",
+"638 -11 CURVE SMOOTH",
+"591 -48 OFFCURVE",
+"558 -78 OFFCURVE",
+"512 -115 CURVE",
+"507 -114 LINE",
+"495 -44 OFFCURVE",
+"478 23 OFFCURVE",
+"459 83 CURVE SMOOTH",
+"443 134 OFFCURVE",
+"425 188 OFFCURVE",
+"404 246 CURVE",
+"402 184 LINE",
+"440 212 OFFCURVE",
+"479 243 OFFCURVE",
+"516 275 CURVE SMOOTH",
+"560 313 OFFCURVE",
+"596 354 OFFCURVE",
+"640 410 CURVE",
+"645 409 LINE",
+"662 342 OFFCURVE",
+"679 284 OFFCURVE",
+"696 220 CURVE SMOOTH",
+"714 154 OFFCURVE",
+"730 86 OFFCURVE",
+"743 18 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"691 290 LINE",
+"608 201 OFFCURVE",
+"532 142 OFFCURVE",
+"431 67 CURVE",
+"458 0 LINE",
+"564 75 OFFCURVE",
+"647 139 OFFCURVE",
+"739 235 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"545 332 LINE",
+"485 509 OFFCURVE",
+"413 674 OFFCURVE",
+"300 886 CURVE",
+"233 851 LINE",
+"343 646 OFFCURVE",
+"419 478 OFFCURVE",
+"482 289 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"552 939 LINE",
+"494 866 OFFCURVE",
+"427 794 OFFCURVE",
+"354 723 CURVE",
+"332 708 LINE",
+"261 640 OFFCURVE",
+"186 574 OFFCURVE",
+"110 513 CURVE",
+"156 455 LINE",
+"224 509 OFFCURVE",
+"297 572 OFFCURVE",
+"369 640 CURVE",
+"394 658 LINE",
+"472 734 OFFCURVE",
+"548 814 OFFCURVE",
+"612 895 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"322 322 OFFCURVE",
+"345 339 OFFCURVE",
+"345 378 CURVE SMOOTH",
+"345 417 OFFCURVE",
+"322 434 OFFCURVE",
+"294 434 CURVE SMOOTH",
+"265 434 OFFCURVE",
+"242 417 OFFCURVE",
+"242 378 CURVE SMOOTH",
+"242 339 OFFCURVE",
+"265 322 OFFCURVE",
+"294 322 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"620 566 OFFCURVE",
+"643 583 OFFCURVE",
+"643 622 CURVE SMOOTH",
+"643 661 OFFCURVE",
+"620 678 OFFCURVE",
+"592 678 CURVE SMOOTH",
+"563 678 OFFCURVE",
+"540 661 OFFCURVE",
+"540 622 CURVE SMOOTH",
+"540 583 OFFCURVE",
+"563 566 OFFCURVE",
+"592 566 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 902;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B296;
+unicode = 1B2D8;
+},
+{
+glyphname = u1B2D9;
+lastChange = "2020-04-13 09:34:22 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"541 7 OFFCURVE",
+"564 24 OFFCURVE",
+"564 63 CURVE SMOOTH",
+"564 102 OFFCURVE",
+"541 119 OFFCURVE",
+"513 119 CURVE SMOOTH",
+"484 119 OFFCURVE",
+"461 102 OFFCURVE",
+"461 63 CURVE SMOOTH",
+"461 24 OFFCURVE",
+"484 7 OFFCURVE",
+"513 7 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"805 700 LINE",
+"745 664 OFFCURVE",
+"705 645 OFFCURVE",
+"649 617 CURVE",
+"618 603 LINE",
+"559 574 OFFCURVE",
+"508 551 OFFCURVE",
+"438 522 CURVE",
+"449 448 LINE",
+"516 477 OFFCURVE",
+"573 503 OFFCURVE",
+"638 535 CURVE",
+"670 549 LINE",
+"737 581 OFFCURVE",
+"787 607 OFFCURVE",
+"852 646 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"767 -44 LINE",
+"754 126 OFFCURVE",
+"740 264 OFFCURVE",
+"719 389 CURVE",
+"709 432 LINE",
+"687 550 OFFCURVE",
+"660 658 OFFCURVE",
+"625 769 CURVE",
+"614 810 LINE",
+"600 852 OFFCURVE",
+"585 895 OFFCURVE",
+"569 939 CURVE",
+"504 916 LINE",
+"521 869 OFFCURVE",
+"536 818 OFFCURVE",
+"550 774 CURVE",
+"564 733 LINE",
+"600 617 OFFCURVE",
+"626 511 OFFCURVE",
+"646 398 CURVE",
+"652 357 LINE",
+"671 236 OFFCURVE",
+"683 108 OFFCURVE",
+"692 -48 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"735 890 LINE",
+"683 859 OFFCURVE",
+"650 841 OFFCURVE",
+"600 815 CURVE",
+"561 796 LINE",
+"497 764 OFFCURVE",
+"442 738 OFFCURVE",
+"371 706 CURVE",
+"409 559 OFFCURVE",
+"436 441 OFFCURVE",
+"459 306 CURVE",
+"535 280 LINE",
+"581 295 OFFCURVE",
+"622 314 OFFCURVE",
+"674 338 CURVE",
+"715 354 LINE",
+"786 387 OFFCURVE",
+"841 412 OFFCURVE",
+"908 449 CURVE",
+"881 604 OFFCURVE",
+"850 729 OFFCURVE",
+"808 871 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"749 816 LINE",
+"764 763 OFFCURVE",
+"775 716 OFFCURVE",
+"789 661 CURVE SMOOTH",
+"806 592 OFFCURVE",
+"819 527 OFFCURVE",
+"830 464 CURVE",
+"870 511 LINE",
+"802 473 OFFCURVE",
+"752 451 OFFCURVE",
+"689 421 CURVE",
+"661 410 LINE",
+"612 387 OFFCURVE",
+"571 368 OFFCURVE",
+"531 348 CURVE",
+"526 349 LINE",
+"516 414 OFFCURVE",
+"502 480 OFFCURVE",
+"491 527 CURVE SMOOTH",
+"478 585 OFFCURVE",
+"463 646 OFFCURVE",
+"445 711 CURVE",
+"414 649 LINE",
+"479 675 OFFCURVE",
+"529 699 OFFCURVE",
+"590 730 CURVE",
+"617 742 LINE",
+"672 770 OFFCURVE",
+"698 786 OFFCURVE",
+"744 817 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"271 -174 OFFCURVE",
+"293 -158 OFFCURVE",
+"293 -121 CURVE SMOOTH",
+"293 -84 OFFCURVE",
+"271 -68 OFFCURVE",
+"244 -68 CURVE SMOOTH",
+"216 -68 OFFCURVE",
+"194 -84 OFFCURVE",
+"194 -121 CURVE SMOOTH",
+"194 -158 OFFCURVE",
+"216 -174 OFFCURVE",
+"244 -174 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"341 497 LINE",
+"238 364 OFFCURVE",
+"146 282 OFFCURVE",
+"50 202 CURVE",
+"94 148 LINE",
+"192 228 OFFCURVE",
+"296 323 OFFCURVE",
+"395 452 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"338 352 OFFCURVE",
+"360 318 OFFCURVE",
+"360 272 CURVE SMOOTH",
+"360 220 OFFCURVE",
+"330 168 OFFCURVE",
+"113 -1 CURVE",
+"157 -55 LINE",
+"402 136 OFFCURVE",
+"430 198 OFFCURVE",
+"430 272 CURVE SMOOTH",
+"430 326 OFFCURVE",
+"406 376 OFFCURVE",
+"335 450 CURVE",
+"290 394 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"294 75 LINE",
+"346 -26 OFFCURVE",
+"360 -89 OFFCURVE",
+"371 -203 CURVE",
+"445 -194 LINE",
+"430 -68 OFFCURVE",
+"407 12 OFFCURVE",
+"346 128 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 998;
+}
+);
+leftMetricsKey = u1B2BD;
+rightMetricsKey = u1B20C;
+unicode = 1B2D9;
+},
+{
+glyphname = u1B2DA;
+lastChange = "2020-04-13 09:34:19 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"314 -173 OFFCURVE",
+"336 -157 OFFCURVE",
+"336 -120 CURVE SMOOTH",
+"336 -83 OFFCURVE",
+"314 -67 OFFCURVE",
+"287 -67 CURVE SMOOTH",
+"259 -67 OFFCURVE",
+"237 -83 OFFCURVE",
+"237 -120 CURVE SMOOTH",
+"237 -157 OFFCURVE",
+"259 -173 OFFCURVE",
+"287 -173 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"655 -117 OFFCURVE",
+"678 -100 OFFCURVE",
+"678 -61 CURVE SMOOTH",
+"678 -22 OFFCURVE",
+"655 -5 OFFCURVE",
+"627 -5 CURVE SMOOTH",
+"598 -5 OFFCURVE",
+"575 -22 OFFCURVE",
+"575 -61 CURVE SMOOTH",
+"575 -100 OFFCURVE",
+"598 -117 OFFCURVE",
+"627 -117 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"647 249 OFFCURVE",
+"669 265 OFFCURVE",
+"669 302 CURVE SMOOTH",
+"669 339 OFFCURVE",
+"647 355 OFFCURVE",
+"620 355 CURVE SMOOTH",
+"592 355 OFFCURVE",
+"570 339 OFFCURVE",
+"570 302 CURVE SMOOTH",
+"570 265 OFFCURVE",
+"592 249 OFFCURVE",
+"620 249 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"302 121 OFFCURVE",
+"324 137 OFFCURVE",
+"324 174 CURVE SMOOTH",
+"324 211 OFFCURVE",
+"302 227 OFFCURVE",
+"275 227 CURVE SMOOTH",
+"247 227 OFFCURVE",
+"225 211 OFFCURVE",
+"225 174 CURVE SMOOTH",
+"225 137 OFFCURVE",
+"247 121 OFFCURVE",
+"275 121 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"701 194 LINE",
+"629 167 OFFCURVE",
+"554 141 OFFCURVE",
+"477 116 CURVE",
+"434 105 LINE",
+"350 79 OFFCURVE",
+"265 55 OFFCURVE",
+"182 34 CURVE",
+"199 -33 LINE",
+"282 -12 OFFCURVE",
+"361 9 OFFCURVE",
+"437 32 CURVE",
+"472 40 LINE",
+"558 67 OFFCURVE",
+"641 95 OFFCURVE",
+"726 127 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"584 729 LINE",
+"524 696 OFFCURVE",
+"465 665 OFFCURVE",
+"406 637 CURVE",
+"372 625 LINE",
+"307 595 OFFCURVE",
+"240 566 OFFCURVE",
+"168 538 CURVE",
+"188 471 LINE",
+"260 501 OFFCURVE",
+"326 530 OFFCURVE",
+"391 559 CURVE",
+"427 572 LINE",
+"493 604 OFFCURVE",
+"558 636 OFFCURVE",
+"624 673 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"329 766 LINE",
+"357 661 OFFCURVE",
+"380 538 OFFCURVE",
+"395 412 CURVE",
+"399 364 LINE",
+"409 263 OFFCURVE",
+"413 161 OFFCURVE",
+"413 68 CURVE SMOOTH",
+"413 -28 OFFCURVE",
+"410 -107 OFFCURVE",
+"399 -193 CURVE",
+"474 -203 LINE",
+"486 -104 OFFCURVE",
+"489 -28 OFFCURVE",
+"489 75 CURVE SMOOTH",
+"489 170 OFFCURVE",
+"484 281 OFFCURVE",
+"472 391 CURVE",
+"460 441 LINE",
+"445 566 OFFCURVE",
+"420 689 OFFCURVE",
+"385 820 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 939 LINE",
+"390 858 OFFCURVE",
+"254 790 OFFCURVE",
+"100 725 CURVE",
+"132 578 OFFCURVE",
+"156 444 OFFCURVE",
+"176 305 CURVE",
+"254 281 LINE",
+"306 300 OFFCURVE",
+"363 324 OFFCURVE",
+"420 349 CURVE",
+"458 362 LINE",
+"536 398 OFFCURVE",
+"615 437 OFFCURVE",
+"698 479 CURVE",
+"674 626 OFFCURVE",
+"644 771 OFFCURVE",
+"604 924 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"544 862 LINE",
+"559 802 OFFCURVE",
+"570 751 OFFCURVE",
+"583 691 CURVE SMOOTH",
+"598 622 OFFCURVE",
+"609 557 OFFCURVE",
+"618 493 CURVE",
+"656 544 LINE",
+"584 505 OFFCURVE",
+"515 470 OFFCURVE",
+"446 438 CURVE",
+"404 423 LINE",
+"344 397 OFFCURVE",
+"294 374 OFFCURVE",
+"245 350 CURVE",
+"240 351 LINE",
+"235 405 OFFCURVE",
+"226 459 OFFCURVE",
+"214 529 CURVE SMOOTH",
+"202 597 OFFCURVE",
+"188 668 OFFCURVE",
+"172 734 CURVE",
+"150 665 LINE",
+"222 696 OFFCURVE",
+"297 731 OFFCURVE",
+"369 767 CURVE SMOOTH",
+"437 801 OFFCURVE",
+"483 829 OFFCURVE",
+"539 863 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 826;
+}
+);
+leftMetricsKey = u1B205;
+rightMetricsKey = u1B244;
+unicode = 1B2DA;
+},
+{
+glyphname = u1B2DB;
+lastChange = "2020-04-13 09:34:16 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"424 -140 LINE",
+"386 -56 OFFCURVE",
+"337 9 OFFCURVE",
+"270 78 CURVE",
+"244 0 LINE",
+"267 0 LINE",
+"299 -51 OFFCURVE",
+"327 -95 OFFCURVE",
+"358 -168 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"214 125 LINE",
+"205 4 OFFCURVE",
+"183 -83 OFFCURVE",
+"151 -185 CURVE",
+"218 -203 LINE",
+"240 -133 OFFCURVE",
+"257 -64 OFFCURVE",
+"263 0 CURVE",
+"273 43 LINE",
+"276 66 OFFCURVE",
+"279 93 OFFCURVE",
+"281 119 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"374 171 LINE",
+"315 256 OFFCURVE",
+"272 304 OFFCURVE",
+"199 371 CURVE",
+"175 301 LINE",
+"196 301 LINE",
+"235 251 OFFCURVE",
+"272 207 OFFCURVE",
+"317 134 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"145 420 LINE",
+"134 296 OFFCURVE",
+"115 223 OFFCURVE",
+"70 110 CURVE",
+"135 87 LINE",
+"163 162 OFFCURVE",
+"181 228 OFFCURVE",
+"192 301 CURVE",
+"203 344 LINE",
+"206 366 OFFCURVE",
+"209 388 OFFCURVE",
+"212 414 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"158 477 OFFCURVE",
+"181 494 OFFCURVE",
+"181 533 CURVE SMOOTH",
+"181 572 OFFCURVE",
+"158 589 OFFCURVE",
+"130 589 CURVE SMOOTH",
+"101 589 OFFCURVE",
+"78 572 OFFCURVE",
+"78 533 CURVE SMOOTH",
+"78 494 OFFCURVE",
+"101 477 OFFCURVE",
+"130 477 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"459 784 OFFCURVE",
+"482 801 OFFCURVE",
+"482 840 CURVE SMOOTH",
+"482 879 OFFCURVE",
+"459 896 OFFCURVE",
+"431 896 CURVE SMOOTH",
+"402 896 OFFCURVE",
+"379 879 OFFCURVE",
+"379 840 CURVE SMOOTH",
+"379 801 OFFCURVE",
+"402 784 OFFCURVE",
+"431 784 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"681 570 LINE",
+"599 429 OFFCURVE",
+"536 345 OFFCURVE",
+"436 224 CURVE",
+"482 171 LINE",
+"575 278 OFFCURVE",
+"647 370 OFFCURVE",
+"723 490 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"198 779 LINE",
+"302 525 OFFCURVE",
+"388 280 OFFCURVE",
+"491 -43 CURVE",
+"574 -55 LINE",
+"657 35 OFFCURVE",
+"744 138 OFFCURVE",
+"826 260 CURVE",
+"772 457 OFFCURVE",
+"725 584 OFFCURVE",
+"645 799 CURVE",
+"594 719 LINE",
+"657 562 OFFCURVE",
+"709 410 OFFCURVE",
+"751 245 CURVE",
+"779 325 LINE",
+"746 272 OFFCURVE",
+"713 226 OFFCURVE",
+"680 183 CURVE SMOOTH",
+"636 125 OFFCURVE",
+"587 65 OFFCURVE",
+"549 16 CURVE",
+"544 17 LINE",
+"524 103 OFFCURVE",
+"496 180 OFFCURVE",
+"471 255 CURVE SMOOTH",
+"405 453 OFFCURVE",
+"343 619 OFFCURVE",
+"266 808 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"383 385 LINE",
+"488 514 OFFCURVE",
+"569 629 OFFCURVE",
+"726 904 CURVE",
+"658 939 LINE",
+"514 683 OFFCURVE",
+"443 578 OFFCURVE",
+"361 476 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 916;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B23E;
+unicode = 1B2DB;
+},
+{
+glyphname = u1B2DC;
+lastChange = "2020-04-13 09:34:14 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"479 340 OFFCURVE",
+"384 275 OFFCURVE",
+"271 212 CURVE",
+"282 32 OFFCURVE",
+"274 -70 OFFCURVE",
+"244 -187 CURVE",
+"315 -203 LINE",
+"345 -65 OFFCURVE",
+"354 14 OFFCURVE",
+"343 203 CURVE",
+"311 152 LINE",
+"363 181 OFFCURVE",
+"418 215 OFFCURVE",
+"473 252 CURVE SMOOTH",
+"516 281 OFFCURVE",
+"551 312 OFFCURVE",
+"599 355 CURVE",
+"603 355 LINE",
+"637 325 OFFCURVE",
+"647 298 OFFCURVE",
+"647 249 CURVE SMOOTH",
+"647 201 OFFCURVE",
+"623 170 OFFCURVE",
+"579 150 CURVE",
+"574 74 LINE",
+"623 51 OFFCURVE",
+"643 19 OFFCURVE",
+"643 -28 CURVE SMOOTH",
+"643 -91 OFFCURVE",
+"608 -122 OFFCURVE",
+"533 -139 CURVE",
+"550 -203 LINE",
+"663 -176 OFFCURVE",
+"715 -122 OFFCURVE",
+"715 -30 CURVE SMOOTH",
+"715 29 OFFCURVE",
+"689 71 OFFCURVE",
+"626 106 CURVE",
+"626 110 LINE",
+"682 138 OFFCURVE",
+"719 184 OFFCURVE",
+"719 250 CURVE SMOOTH",
+"719 312 OFFCURVE",
+"699 353 OFFCURVE",
+"641 413 CURVE",
+"568 417 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"499 73 OFFCURVE",
+"522 90 OFFCURVE",
+"522 129 CURVE SMOOTH",
+"522 168 OFFCURVE",
+"499 185 OFFCURVE",
+"471 185 CURVE SMOOTH",
+"442 185 OFFCURVE",
+"419 168 OFFCURVE",
+"419 129 CURVE SMOOTH",
+"419 90 OFFCURVE",
+"442 73 OFFCURVE",
+"471 73 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"497 -104 OFFCURVE",
+"520 -87 OFFCURVE",
+"520 -48 CURVE SMOOTH",
+"520 -9 OFFCURVE",
+"497 8 OFFCURVE",
+"469 8 CURVE SMOOTH",
+"440 8 OFFCURVE",
+"417 -9 OFFCURVE",
+"417 -48 CURVE SMOOTH",
+"417 -87 OFFCURVE",
+"440 -104 OFFCURVE",
+"469 -104 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"491 281 LINE",
+"441 454 OFFCURVE",
+"393 602 OFFCURVE",
+"319 784 CURVE",
+"268 724 LINE",
+"335 558 OFFCURVE",
+"383 394 OFFCURVE",
+"426 241 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"453 939 LINE",
+"314 799 OFFCURVE",
+"216 717 OFFCURVE",
+"60 620 CURVE",
+"98 559 LINE",
+"250 656 OFFCURVE",
+"353 733 OFFCURVE",
+"506 892 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"544 763 LINE",
+"486 709 OFFCURVE",
+"425 659 OFFCURVE",
+"361 612 CURVE",
+"332 595 LINE",
+"272 552 OFFCURVE",
+"207 510 OFFCURVE",
+"136 468 CURVE",
+"172 403 LINE",
+"237 441 OFFCURVE",
+"298 481 OFFCURVE",
+"358 523 CURVE",
+"391 542 LINE",
+"463 596 OFFCURVE",
+"532 654 OFFCURVE",
+"599 716 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"589 472 OFFCURVE",
+"612 489 OFFCURVE",
+"612 528 CURVE SMOOTH",
+"612 567 OFFCURVE",
+"589 584 OFFCURVE",
+"561 584 CURVE SMOOTH",
+"532 584 OFFCURVE",
+"509 567 OFFCURVE",
+"509 528 CURVE SMOOTH",
+"509 489 OFFCURVE",
+"532 472 OFFCURVE",
+"561 472 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"280 275 OFFCURVE",
+"302 291 OFFCURVE",
+"302 328 CURVE SMOOTH",
+"302 365 OFFCURVE",
+"280 381 OFFCURVE",
+"253 381 CURVE SMOOTH",
+"225 381 OFFCURVE",
+"203 365 OFFCURVE",
+"203 328 CURVE SMOOTH",
+"203 291 OFFCURVE",
+"225 275 OFFCURVE",
+"253 275 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 849;
+}
+);
+leftMetricsKey = u1B276;
+unicode = 1B2DC;
+},
+{
+glyphname = u1B2DD;
+lastChange = "2020-04-13 09:33:58 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"543 478 LINE",
+"567 478 LINE",
+"582 450 OFFCURVE",
+"588 426 OFFCURVE",
+"588 393 CURVE SMOOTH",
+"588 348 OFFCURVE",
+"573 310 OFFCURVE",
+"537 266 CURVE",
+"526 266 LINE",
+"453 199 OFFCURVE",
+"386 150 OFFCURVE",
+"295 93 CURVE",
+"336 35 LINE",
+"436 105 OFFCURVE",
+"507 164 OFFCURVE",
+"556 210 CURVE",
+"579 229 LINE",
+"641 294 OFFCURVE",
+"658 342 OFFCURVE",
+"658 393 CURVE SMOOTH",
+"658 442 OFFCURVE",
+"646 485 OFFCURVE",
+"579 559 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"387 -126 OFFCURVE",
+"422 -171 OFFCURVE",
+"492 -203 CURVE",
+"563 -194 LINE",
+"634 -120 OFFCURVE",
+"652 -70 OFFCURVE",
+"652 -21 CURVE SMOOTH",
+"652 31 OFFCURVE",
+"620 74 OFFCURVE",
+"547 110 CURVE",
+"473 100 LINE",
+"413 33 OFFCURVE",
+"387 -21 OFFCURVE",
+"387 -67 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"519 58 LINE",
+"563 32 OFFCURVE",
+"580 2 OFFCURVE",
+"580 -30 CURVE SMOOTH",
+"580 -64 OFFCURVE",
+"567 -104 OFFCURVE",
+"525 -154 CURVE",
+"521 -154 LINE",
+"480 -125 OFFCURVE",
+"459 -92 OFFCURVE",
+"459 -62 CURVE SMOOTH",
+"459 -30 OFFCURVE",
+"473 7 OFFCURVE",
+"515 58 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"593 588 LINE",
+"506 510 OFFCURVE",
+"421 450 OFFCURVE",
+"333 393 CURVE",
+"333 322 LINE",
+"457 254 OFFCURVE",
+"583 173 OFFCURVE",
+"688 86 CURVE",
+"731 142 LINE",
+"685 178 OFFCURVE",
+"639 206 OFFCURVE",
+"548 266 CURVE",
+"533 266 LINE",
+"499 295 OFFCURVE",
+"453 331 OFFCURVE",
+"377 376 CURVE",
+"377 338 LINE",
+"465 395 OFFCURVE",
+"520 435 OFFCURVE",
+"563 478 CURVE",
+"602 502 LINE",
+"615 513 OFFCURVE",
+"628 524 OFFCURVE",
+"642 537 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"600 939 LINE",
+"514 878 OFFCURVE",
+"443 831 OFFCURVE",
+"369 788 CURVE",
+"353 781 LINE",
+"292 746 OFFCURVE",
+"230 712 OFFCURVE",
+"160 677 CURVE",
+"191 615 LINE",
+"260 650 OFFCURVE",
+"322 683 OFFCURVE",
+"383 719 CURVE",
+"405 729 LINE",
+"479 772 OFFCURVE",
+"554 820 OFFCURVE",
+"644 885 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 732 LINE",
+"494 654 OFFCURVE",
+"356 574 OFFCURVE",
+"236 514 CURVE",
+"269 452 LINE",
+"401 519 OFFCURVE",
+"522 590 OFFCURVE",
+"652 675 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"266 901 LINE",
+"342 752 OFFCURVE",
+"385 661 OFFCURVE",
+"421 546 CURVE",
+"483 591 LINE",
+"444 710 OFFCURVE",
+"406 794 OFFCURVE",
+"333 934 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"150 391 OFFCURVE",
+"173 408 OFFCURVE",
+"173 447 CURVE SMOOTH",
+"173 486 OFFCURVE",
+"150 503 OFFCURVE",
+"122 503 CURVE SMOOTH",
+"93 503 OFFCURVE",
+"70 486 OFFCURVE",
+"70 447 CURVE SMOOTH",
+"70 408 OFFCURVE",
+"93 391 OFFCURVE",
+"122 391 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"232 196 OFFCURVE",
+"255 213 OFFCURVE",
+"255 252 CURVE SMOOTH",
+"255 291 OFFCURVE",
+"232 308 OFFCURVE",
+"204 308 CURVE SMOOTH",
+"175 308 OFFCURVE",
+"152 291 OFFCURVE",
+"152 252 CURVE SMOOTH",
+"152 213 OFFCURVE",
+"175 196 OFFCURVE",
+"204 196 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"254 -9 OFFCURVE",
+"277 8 OFFCURVE",
+"277 47 CURVE SMOOTH",
+"277 86 OFFCURVE",
+"254 103 OFFCURVE",
+"226 103 CURVE SMOOTH",
+"197 103 OFFCURVE",
+"174 86 OFFCURVE",
+"174 47 CURVE SMOOTH",
+"174 8 OFFCURVE",
+"197 -9 OFFCURVE",
+"226 -9 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 841;
+}
+);
+leftMetricsKey = u1B29F;
+rightMetricsKey = u1B214;
+unicode = 1B2DD;
+},
+{
+glyphname = u1B2DE;
+lastChange = "2020-04-13 09:33:38 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"316 272 OFFCURVE",
+"255 235 OFFCURVE",
+"192 208 CURVE",
+"196 121 OFFCURVE",
+"197 74 OFFCURVE",
+"197 20 CURVE SMOOTH",
+"197 -59 OFFCURVE",
+"191 -122 OFFCURVE",
+"178 -193 CURVE",
+"252 -203 LINE",
+"265 -132 OFFCURVE",
+"269 -59 OFFCURVE",
+"269 20 CURVE SMOOTH",
+"269 69 OFFCURVE",
+"267 120 OFFCURVE",
+"260 199 CURVE",
+"223 139 LINE",
+"250 153 OFFCURVE",
+"276 167 OFFCURVE",
+"301 182 CURVE SMOOTH",
+"322 194 OFFCURVE",
+"343 211 OFFCURVE",
+"376 241 CURVE",
+"381 240 LINE",
+"384 185 OFFCURVE",
+"384 145 OFFCURVE",
+"384 91 CURVE SMOOTH",
+"384 73 OFFCURVE",
+"382 55 OFFCURVE",
+"381 36 CURVE",
+"441 32 LINE",
+"447 121 OFFCURVE",
+"445 199 OFFCURVE",
+"432 300 CURVE",
+"372 315 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"589 427 OFFCURVE",
+"535 394 OFFCURVE",
+"468 357 CURVE",
+"484 259 OFFCURVE",
+"490 183 OFFCURVE",
+"490 108 CURVE SMOOTH",
+"490 40 OFFCURVE",
+"487 0 OFFCURVE",
+"484 -49 CURVE",
+"556 -55 LINE",
+"561 1 OFFCURVE",
+"562 43 OFFCURVE",
+"562 111 CURVE SMOOTH",
+"562 191 OFFCURVE",
+"557 257 OFFCURVE",
+"540 348 CURVE",
+"510 298 LINE",
+"534 311 OFFCURVE",
+"557 325 OFFCURVE",
+"580 338 CURVE SMOOTH",
+"595 347 OFFCURVE",
+"618 365 OFFCURVE",
+"648 396 CURVE",
+"654 395 LINE",
+"660 336 OFFCURVE",
+"663 284 OFFCURVE",
+"663 221 CURVE SMOOTH",
+"663 205 OFFCURVE",
+"662 189 OFFCURVE",
+"662 173 CURVE",
+"732 171 LINE",
+"736 269 OFFCURVE",
+"729 352 OFFCURVE",
+"711 449 CURVE",
+"641 473 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"522 437 OFFCURVE",
+"544 453 OFFCURVE",
+"544 491 CURVE SMOOTH",
+"544 528 OFFCURVE",
+"522 544 OFFCURVE",
+"495 544 CURVE SMOOTH",
+"467 544 OFFCURVE",
+"445 528 OFFCURVE",
+"445 491 CURVE SMOOTH",
+"445 453 OFFCURVE",
+"467 437 OFFCURVE",
+"495 437 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"328 328 OFFCURVE",
+"350 344 OFFCURVE",
+"350 381 CURVE SMOOTH",
+"350 419 OFFCURVE",
+"328 435 OFFCURVE",
+"301 435 CURVE SMOOTH",
+"273 435 OFFCURVE",
+"251 419 OFFCURVE",
+"251 381 CURVE SMOOTH",
+"251 344 OFFCURVE",
+"273 328 OFFCURVE",
+"301 328 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"500 939 LINE",
+"420 882 OFFCURVE",
+"352 837 OFFCURVE",
+"284 796 CURVE",
+"265 789 LINE",
+"200 751 OFFCURVE",
+"135 716 OFFCURVE",
+"60 678 CURVE",
+"93 615 LINE",
+"164 651 OFFCURVE",
+"227 685 OFFCURVE",
+"291 722 CURVE",
+"312 730 LINE",
+"383 773 OFFCURVE",
+"458 821 OFFCURVE",
+"546 884 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"519 714 LINE",
+"403 636 OFFCURVE",
+"264 556 OFFCURVE",
+"144 496 CURVE",
+"176 431 LINE",
+"308 498 OFFCURVE",
+"429 569 OFFCURVE",
+"559 654 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"176 896 LINE",
+"252 747 OFFCURVE",
+"295 656 OFFCURVE",
+"331 541 CURVE",
+"394 586 LINE",
+"355 705 OFFCURVE",
+"317 789 OFFCURVE",
+"244 929 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 853;
+}
+);
+leftMetricsKey = u1B214;
+rightMetricsKey = u1B239;
+unicode = 1B2DE;
+},
+{
+glyphname = u1B2DF;
+lastChange = "2020-04-13 09:33:40 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"150 391 OFFCURVE",
+"173 408 OFFCURVE",
+"173 447 CURVE SMOOTH",
+"173 486 OFFCURVE",
+"150 503 OFFCURVE",
+"122 503 CURVE SMOOTH",
+"93 503 OFFCURVE",
+"70 486 OFFCURVE",
+"70 447 CURVE SMOOTH",
+"70 408 OFFCURVE",
+"93 391 OFFCURVE",
+"122 391 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"232 196 OFFCURVE",
+"255 213 OFFCURVE",
+"255 252 CURVE SMOOTH",
+"255 291 OFFCURVE",
+"232 308 OFFCURVE",
+"204 308 CURVE SMOOTH",
+"175 308 OFFCURVE",
+"152 291 OFFCURVE",
+"152 252 CURVE SMOOTH",
+"152 213 OFFCURVE",
+"175 196 OFFCURVE",
+"204 196 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"304 -9 OFFCURVE",
+"327 8 OFFCURVE",
+"327 47 CURVE SMOOTH",
+"327 86 OFFCURVE",
+"304 103 OFFCURVE",
+"276 103 CURVE SMOOTH",
+"247 103 OFFCURVE",
+"224 86 OFFCURVE",
+"224 47 CURVE SMOOTH",
+"224 8 OFFCURVE",
+"247 -9 OFFCURVE",
+"276 -9 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"580 919 LINE",
+"497 860 OFFCURVE",
+"427 814 OFFCURVE",
+"356 772 CURVE",
+"329 760 LINE",
+"269 725 OFFCURVE",
+"209 693 OFFCURVE",
+"140 658 CURVE",
+"171 593 LINE",
+"240 628 OFFCURVE",
+"301 661 OFFCURVE",
+"363 696 CURVE",
+"384 704 LINE",
+"457 748 OFFCURVE",
+"533 797 OFFCURVE",
+"624 862 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"606 715 LINE",
+"489 637 OFFCURVE",
+"351 557 OFFCURVE",
+"231 497 CURVE",
+"262 433 LINE",
+"394 500 OFFCURVE",
+"515 571 OFFCURVE",
+"645 656 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"244 886 LINE",
+"320 737 OFFCURVE",
+"363 644 OFFCURVE",
+"399 551 CURVE",
+"461 596 LINE",
+"422 693 OFFCURVE",
+"384 779 OFFCURVE",
+"311 919 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 463 LINE",
+"638 407 OFFCURVE",
+"657 369 OFFCURVE",
+"682 315 CURVE SMOOTH",
+"709 256 OFFCURVE",
+"735 196 OFFCURVE",
+"761 129 CURVE",
+"761 203 LINE",
+"707 156 OFFCURVE",
+"646 110 OFFCURVE",
+"554 49 CURVE",
+"526 29 LINE",
+"463 -10 OFFCURVE",
+"390 -53 OFFCURVE",
+"301 -104 CURVE",
+"337 -167 LINE",
+"419 -122 OFFCURVE",
+"490 -80 OFFCURVE",
+"554 -40 CURVE",
+"580 -21 LINE",
+"685 48 OFFCURVE",
+"759 103 OFFCURVE",
+"831 162 CURVE",
+"778 293 OFFCURVE",
+"719 414 OFFCURVE",
+"668 510 CURVE",
+"589 532 LINE",
+"502 474 OFFCURVE",
+"424 426 OFFCURVE",
+"326 367 CURVE",
+"448 148 OFFCURVE",
+"508 25 OFFCURVE",
+"608 -203 CURVE",
+"674 -174 LINE",
+"580 43 OFFCURVE",
+"491 220 OFFCURVE",
+"402 384 CURVE",
+"410 337 LINE",
+"440 354 OFFCURVE",
+"470 372 OFFCURVE",
+"500 390 CURVE SMOOTH",
+"540 414 OFFCURVE",
+"566 433 OFFCURVE",
+"606 464 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"676 365 LINE",
+"611 318 OFFCURVE",
+"532 270 OFFCURVE",
+"459 230 CURVE",
+"496 171 LINE",
+"570 213 OFFCURVE",
+"646 260 OFFCURVE",
+"719 312 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 921;
+}
+);
+leftMetricsKey = u1B29F;
+rightMetricsKey = u1B1BC;
+unicode = 1B2DF;
+},
+{
+glyphname = u1B2E0;
+lastChange = "2020-04-13 09:36:52 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"150 443 OFFCURVE",
+"173 460 OFFCURVE",
+"173 499 CURVE SMOOTH",
+"173 538 OFFCURVE",
+"150 555 OFFCURVE",
+"122 555 CURVE SMOOTH",
+"93 555 OFFCURVE",
+"70 538 OFFCURVE",
+"70 499 CURVE SMOOTH",
+"70 460 OFFCURVE",
+"93 443 OFFCURVE",
+"122 443 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"180 181 OFFCURVE",
+"203 198 OFFCURVE",
+"203 237 CURVE SMOOTH",
+"203 276 OFFCURVE",
+"180 293 OFFCURVE",
+"152 293 CURVE SMOOTH",
+"123 293 OFFCURVE",
+"100 276 OFFCURVE",
+"100 237 CURVE SMOOTH",
+"100 198 OFFCURVE",
+"123 181 OFFCURVE",
+"152 181 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"171 -79 OFFCURVE",
+"194 -62 OFFCURVE",
+"194 -23 CURVE SMOOTH",
+"194 16 OFFCURVE",
+"171 33 OFFCURVE",
+"143 33 CURVE SMOOTH",
+"114 33 OFFCURVE",
+"91 16 OFFCURVE",
+"91 -23 CURVE SMOOTH",
+"91 -62 OFFCURVE",
+"114 -79 OFFCURVE",
+"143 -79 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"449 939 LINE",
+"419 695 OFFCURVE",
+"379 554 OFFCURVE",
+"251 377 CURVE",
+"311 336 LINE",
+"436 512 OFFCURVE",
+"490 658 OFFCURVE",
+"523 931 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"449 696 LINE",
+"553 595 OFFCURVE",
+"624 498 OFFCURVE",
+"679 394 CURVE",
+"742 430 LINE",
+"673 554 OFFCURVE",
+"598 643 OFFCURVE",
+"483 755 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"293 650 OFFCURVE",
+"316 667 OFFCURVE",
+"316 706 CURVE SMOOTH",
+"316 745 OFFCURVE",
+"293 762 OFFCURVE",
+"265 762 CURVE SMOOTH",
+"236 762 OFFCURVE",
+"213 745 OFFCURVE",
+"213 706 CURVE SMOOTH",
+"213 667 OFFCURVE",
+"236 650 OFFCURVE",
+"265 650 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"699 729 OFFCURVE",
+"722 746 OFFCURVE",
+"722 785 CURVE SMOOTH",
+"722 824 OFFCURVE",
+"699 841 OFFCURVE",
+"671 841 CURVE SMOOTH",
+"642 841 OFFCURVE",
+"619 824 OFFCURVE",
+"619 785 CURVE SMOOTH",
+"619 746 OFFCURVE",
+"642 729 OFFCURVE",
+"671 729 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"470 407 LINE",
+"447 109 OFFCURVE",
+"403 17 OFFCURVE",
+"273 -161 CURVE",
+"331 -203 LINE",
+"463 -24 OFFCURVE",
+"517 78 OFFCURVE",
+"544 401 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"475 148 LINE",
+"554 61 OFFCURVE",
+"635 -48 OFFCURVE",
+"707 -169 CURVE",
+"769 -131 LINE",
+"681 15 OFFCURVE",
+"597 117 OFFCURVE",
+"509 211 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"336 90 OFFCURVE",
+"359 107 OFFCURVE",
+"359 146 CURVE SMOOTH",
+"359 185 OFFCURVE",
+"336 202 OFFCURVE",
+"308 202 CURVE SMOOTH",
+"279 202 OFFCURVE",
+"256 185 OFFCURVE",
+"256 146 CURVE SMOOTH",
+"256 107 OFFCURVE",
+"279 90 OFFCURVE",
+"308 90 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"728 149 OFFCURVE",
+"751 166 OFFCURVE",
+"751 205 CURVE SMOOTH",
+"751 244 OFFCURVE",
+"728 261 OFFCURVE",
+"700 261 CURVE SMOOTH",
+"671 261 OFFCURVE",
+"648 244 OFFCURVE",
+"648 205 CURVE SMOOTH",
+"648 166 OFFCURVE",
+"671 149 OFFCURVE",
+"700 149 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 849;
+}
+);
+leftMetricsKey = u1B29F;
+rightMetricsKey = u1B195;
+unicode = 1B2E0;
+},
+{
+glyphname = u1B2E1;
+lastChange = "2020-04-13 09:37:11 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"448 222 OFFCURVE",
+"417 309 OFFCURVE",
+"359 439 CURVE",
+"279 447 LINE",
+"225 357 OFFCURVE",
+"181 304 OFFCURVE",
+"118 235 CURVE",
+"166 126 OFFCURVE",
+"205 3 OFFCURVE",
+"232 -106 CURVE",
+"306 -123 LINE",
+"378 -55 OFFCURVE",
+"427 5 OFFCURVE",
+"489 90 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"425 115 LINE",
+"407 91 OFFCURVE",
+"391 69 OFFCURVE",
+"375 49 CURVE SMOOTH",
+"338 3 OFFCURVE",
+"319 -17 OFFCURVE",
+"289 -55 CURVE",
+"284 -54 LINE",
+"273 12 OFFCURVE",
+"255 69 OFFCURVE",
+"240 112 CURVE SMOOTH",
+"224 159 OFFCURVE",
+"206 208 OFFCURVE",
+"184 259 CURVE",
+"186 211 LINE",
+"207 235 OFFCURVE",
+"225 256 OFFCURVE",
+"242 276 CURVE SMOOTH",
+"262 299 OFFCURVE",
+"283 333 OFFCURVE",
+"311 382 CURVE",
+"315 382 LINE",
+"336 327 OFFCURVE",
+"355 274 OFFCURVE",
+"373 221 CURVE SMOOTH",
+"390 172 OFFCURVE",
+"407 120 OFFCURVE",
+"422 61 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"362 291 LINE",
+"314 214 OFFCURVE",
+"267 158 OFFCURVE",
+"215 99 CURVE",
+"231 30 LINE",
+"302 103 OFFCURVE",
+"350 163 OFFCURVE",
+"405 246 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"277 788 LINE",
+"230 633 OFFCURVE",
+"177 533 OFFCURVE",
+"80 403 CURVE",
+"134 361 LINE",
+"241 503 OFFCURVE",
+"294 609 OFFCURVE",
+"346 770 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"281 664 LINE",
+"337 601 OFFCURVE",
+"387 529 OFFCURVE",
+"439 440 CURVE",
+"498 477 LINE",
+"441 573 OFFCURVE",
+"390 642 OFFCURVE",
+"321 711 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"671 939 LINE",
+"626 794 OFFCURVE",
+"561 677 OFFCURVE",
+"467 564 CURVE",
+"521 523 LINE",
+"620 648 OFFCURVE",
+"691 769 OFFCURVE",
+"744 918 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"445 780 LINE",
+"495 758 OFFCURVE",
+"542 733 OFFCURVE",
+"586 707 CURVE",
+"608 700 LINE",
+"658 669 OFFCURVE",
+"703 635 OFFCURVE",
+"743 597 CURVE",
+"787 649 LINE",
+"745 687 OFFCURVE",
+"696 725 OFFCURVE",
+"643 759 CURVE",
+"622 766 LINE",
+"576 794 OFFCURVE",
+"527 820 OFFCURVE",
+"477 842 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"485 275 LINE",
+"579 153 OFFCURVE",
+"671 24 OFFCURVE",
+"744 -115 CURVE",
+"806 -78 LINE",
+"768 -11 OFFCURVE",
+"740 43 OFFCURVE",
+"673 143 CURVE",
+"665 143 LINE",
+"633 200 OFFCURVE",
+"594 242 OFFCURVE",
+"531 326 CURVE",
+"526 298 LINE",
+"584 349 OFFCURVE",
+"637 398 OFFCURVE",
+"680 457 CURVE",
+"716 497 LINE",
+"729 513 OFFCURVE",
+"742 531 OFFCURVE",
+"755 549 CURVE",
+"695 586 LINE",
+"624 487 OFFCURVE",
+"561 416 OFFCURVE",
+"485 346 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"658 457 LINE",
+"684 457 LINE",
+"711 417 OFFCURVE",
+"721 377 OFFCURVE",
+"721 332 CURVE SMOOTH",
+"721 273 OFFCURVE",
+"709 213 OFFCURVE",
+"669 143 CURVE",
+"660 143 LINE",
+"601 44 OFFCURVE",
+"532 -43 OFFCURVE",
+"432 -159 CURVE",
+"489 -203 LINE",
+"575 -105 OFFCURVE",
+"633 -27 OFFCURVE",
+"677 37 CURVE",
+"706 73 LINE",
+"778 186 OFFCURVE",
+"791 256 OFFCURVE",
+"791 333 CURVE SMOOTH",
+"791 396 OFFCURVE",
+"772 453 OFFCURVE",
+"713 534 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 916;
+}
+);
+leftMetricsKey = u1B185;
+rightMetricsKey = u1B17C;
+unicode = 1B2E1;
+},
+{
+glyphname = u1B2E2;
+lastChange = "2020-04-13 09:37:22 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"289 881 LINE",
+"339 770 OFFCURVE",
+"369 707 OFFCURVE",
+"400 601 CURVE",
+"454 652 LINE",
+"416 770 OFFCURVE",
+"395 826 OFFCURVE",
+"354 908 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"588 495 OFFCURVE",
+"611 512 OFFCURVE",
+"611 551 CURVE SMOOTH",
+"611 590 OFFCURVE",
+"588 607 OFFCURVE",
+"560 607 CURVE SMOOTH",
+"531 607 OFFCURVE",
+"508 590 OFFCURVE",
+"508 551 CURVE SMOOTH",
+"508 512 OFFCURVE",
+"531 495 OFFCURVE",
+"560 495 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"70 697 LINE",
+"115 606 OFFCURVE",
+"145 537 OFFCURVE",
+"174 442 CURVE",
+"250 431 LINE",
+"338 512 OFFCURVE",
+"420 595 OFFCURVE",
+"503 692 CURVE SMOOTH",
+"552 750 OFFCURVE",
+"595 809 OFFCURVE",
+"637 868 CURVE",
+"642 867 LINE",
+"668 795 OFFCURVE",
+"685 742 OFFCURVE",
+"704 676 CURVE SMOOTH",
+"711 652 OFFCURVE",
+"718 628 OFFCURVE",
+"724 601 CURVE",
+"796 618 LINE",
+"769 728 OFFCURVE",
+"744 799 OFFCURVE",
+"688 929 CURVE",
+"606 939 LINE",
+"531 837 OFFCURVE",
+"469 762 OFFCURVE",
+"373 655 CURVE SMOOTH",
+"328 605 OFFCURVE",
+"280 555 OFFCURVE",
+"229 497 CURVE",
+"224 498 LINE",
+"203 569 OFFCURVE",
+"182 633 OFFCURVE",
+"157 687 CURVE SMOOTH",
+"151 700 OFFCURVE",
+"144 714 OFFCURVE",
+"137 728 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"415 339 OFFCURVE",
+"438 356 OFFCURVE",
+"438 395 CURVE SMOOTH",
+"438 434 OFFCURVE",
+"415 451 OFFCURVE",
+"387 451 CURVE SMOOTH",
+"358 451 OFFCURVE",
+"335 434 OFFCURVE",
+"335 395 CURVE SMOOTH",
+"335 356 OFFCURVE",
+"358 339 OFFCURVE",
+"387 339 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"731 561 LINE",
+"656 469 OFFCURVE",
+"580 397 OFFCURVE",
+"483 320 CURVE",
+"545 177 OFFCURVE",
+"578 85 OFFCURVE",
+"607 -38 CURVE",
+"676 -56 LINE",
+"744 0 OFFCURVE",
+"820 71 OFFCURVE",
+"887 147 CURVE",
+"833 195 LINE",
+"820 180 OFFCURVE",
+"807 166 OFFCURVE",
+"794 152 CURVE SMOOTH",
+"747 102 OFFCURVE",
+"702 59 OFFCURVE",
+"665 17 CURVE",
+"660 18 LINE",
+"646 92 OFFCURVE",
+"627 159 OFFCURVE",
+"609 208 CURVE SMOOTH",
+"594 249 OFFCURVE",
+"576 291 OFFCURVE",
+"554 336 CURVE",
+"534 264 LINE",
+"628 342 OFFCURVE",
+"702 410 OFFCURVE",
+"788 512 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"466 243 LINE",
+"424 211 OFFCURVE",
+"381 182 OFFCURVE",
+"336 155 CURVE",
+"310 144 LINE",
+"264 117 OFFCURVE",
+"216 92 OFFCURVE",
+"165 67 CURVE",
+"196 2 LINE",
+"245 25 OFFCURVE",
+"292 49 OFFCURVE",
+"337 76 CURVE",
+"371 91 LINE",
+"420 121 OFFCURVE",
+"466 151 OFFCURVE",
+"506 183 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"453 -92 LINE",
+"409 41 OFFCURVE",
+"360 163 OFFCURVE",
+"298 306 CURVE",
+"229 276 LINE",
+"297 125 OFFCURVE",
+"346 1 OFFCURVE",
+"388 -123 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"530 28 LINE",
+"449 -34 OFFCURVE",
+"347 -93 OFFCURVE",
+"251 -141 CURVE",
+"283 -203 LINE",
+"379 -155 OFFCURVE",
+"485 -95 OFFCURVE",
+"572 -28 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 987;
+}
+);
+leftMetricsKey = u1B1B7;
+rightMetricsKey = u1B286;
+unicode = 1B2E2;
+},
+{
+glyphname = u1B2E3;
+lastChange = "2020-04-13 09:37:46 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"718 586 LINE",
+"732 531 OFFCURVE",
+"743 480 OFFCURVE",
+"755 433 CURVE SMOOTH",
+"770 372 OFFCURVE",
+"784 308 OFFCURVE",
+"797 234 CURVE",
+"802 291 LINE",
+"780 264 OFFCURVE",
+"759 240 OFFCURVE",
+"738 217 CURVE SMOOTH",
+"700 175 OFFCURVE",
+"671 152 OFFCURVE",
+"637 118 CURVE",
+"632 119 LINE",
+"625 177 OFFCURVE",
+"619 224 OFFCURVE",
+"605 289 CURVE SMOOTH",
+"575 430 OFFCURVE",
+"528 600 OFFCURVE",
+"443 889 CURVE",
+"375 869 LINE",
+"466 573 OFFCURVE",
+"534 318 OFFCURVE",
+"582 71 CURVE",
+"654 53 LINE",
+"734 116 OFFCURVE",
+"798 176 OFFCURVE",
+"859 247 CURVE",
+"833 394 OFFCURVE",
+"805 516 OFFCURVE",
+"762 655 CURVE",
+"693 661 LINE",
+"639 580 OFFCURVE",
+"592 522 OFFCURVE",
+"518 444 CURVE",
+"568 401 LINE",
+"595 428 OFFCURVE",
+"616 450 OFFCURVE",
+"634 470 CURVE SMOOTH",
+"659 497 OFFCURVE",
+"690 545 OFFCURVE",
+"714 586 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"599 215 LINE",
+"691 299 OFFCURVE",
+"727 340 OFFCURVE",
+"781 428 CURVE",
+"752 477 LINE",
+"699 404 OFFCURVE",
+"646 341 OFFCURVE",
+"557 259 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"433 501 LINE",
+"453 522 OFFCURVE",
+"472 543 OFFCURVE",
+"490 564 CURVE",
+"512 582 LINE",
+"601 684 OFFCURVE",
+"677 781 OFFCURVE",
+"760 900 CURVE",
+"700 939 LINE",
+"637 847 OFFCURVE",
+"566 752 OFFCURVE",
+"489 660 CURVE",
+"465 638 LINE",
+"438 607 OFFCURVE",
+"411 576 OFFCURVE",
+"383 546 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"384 227 LINE",
+"372 212 OFFCURVE",
+"360 199 OFFCURVE",
+"349 186 CURVE SMOOTH",
+"307 137 OFFCURVE",
+"282 105 OFFCURVE",
+"245 64 CURVE",
+"241 64 LINE",
+"235 114 OFFCURVE",
+"216 179 OFFCURVE",
+"207 212 CURVE SMOOTH",
+"191 273 OFFCURVE",
+"171 338 OFFCURVE",
+"149 399 CURVE",
+"152 340 LINE",
+"174 362 OFFCURVE",
+"193 381 OFFCURVE",
+"210 399 CURVE SMOOTH",
+"241 432 OFFCURVE",
+"269 472 OFFCURVE",
+"296 512 CURVE",
+"300 512 LINE",
+"313 457 OFFCURVE",
+"331 398 OFFCURVE",
+"345 351 CURVE SMOOTH",
+"392 190 OFFCURVE",
+"424 32 OFFCURVE",
+"455 -203 CURVE",
+"526 -192 LINE",
+"481 137 OFFCURVE",
+"426 344 OFFCURVE",
+"345 574 CURVE",
+"276 584 LINE",
+"223 512 OFFCURVE",
+"170 457 OFFCURVE",
+"90 375 CURVE",
+"128 254 OFFCURVE",
+"164 126 OFFCURVE",
+"192 10 CURVE",
+"256 0 LINE",
+"334 68 OFFCURVE",
+"364 101 OFFCURVE",
+"407 166 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"341 410 LINE",
+"286 339 OFFCURVE",
+"232 286 OFFCURVE",
+"159 218 CURVE",
+"192 167 LINE",
+"262 229 OFFCURVE",
+"320 290 OFFCURVE",
+"362 347 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"508 132 LINE",
+"492 114 OFFCURVE",
+"475 96 OFFCURVE",
+"457 78 CURVE",
+"431 57 LINE",
+"372 0 OFFCURVE",
+"304 -57 OFFCURVE",
+"220 -119 CURVE",
+"262 -173 LINE",
+"330 -123 OFFCURVE",
+"393 -70 OFFCURVE",
+"451 -17 CURVE",
+"476 0 LINE",
+"504 27 OFFCURVE",
+"531 54 OFFCURVE",
+"557 81 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 949;
+}
+);
+leftMetricsKey = u1B1C8;
+rightMetricsKey = u1B1C8;
+unicode = 1B2E3;
+},
+{
+glyphname = u1B2E4;
+lastChange = "2020-04-13 09:37:58 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"595 330 OFFCURVE",
+"577 404 OFFCURVE",
+"551 503 CURVE",
+"477 529 LINE",
+"372 473 OFFCURVE",
+"282 434 OFFCURVE",
+"162 386 CURVE",
+"189 296 OFFCURVE",
+"208 212 OFFCURVE",
+"224 122 CURVE",
+"294 92 LINE",
+"399 128 OFFCURVE",
+"497 170 OFFCURVE",
+"612 231 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"552 272 LINE",
+"501 246 OFFCURVE",
+"454 224 OFFCURVE",
+"406 204 CURVE SMOOTH",
+"356 183 OFFCURVE",
+"324 173 OFFCURVE",
+"289 158 CURVE",
+"284 159 LINE",
+"280 211 OFFCURVE",
+"268 264 OFFCURVE",
+"264 282 CURVE SMOOTH",
+"257 313 OFFCURVE",
+"247 356 OFFCURVE",
+"234 407 CURVE",
+"230 346 LINE",
+"275 363 OFFCURVE",
+"321 382 OFFCURVE",
+"366 403 CURVE SMOOTH",
+"416 426 OFFCURVE",
+"442 437 OFFCURVE",
+"485 462 CURVE",
+"490 461 LINE",
+"497 424 OFFCURVE",
+"508 377 OFFCURVE",
+"514 352 CURVE SMOOTH",
+"525 306 OFFCURVE",
+"534 257 OFFCURVE",
+"542 202 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"514 396 LINE",
+"407 341 OFFCURVE",
+"327 305 OFFCURVE",
+"227 268 CURVE",
+"248 218 LINE",
+"352 258 OFFCURVE",
+"441 296 OFFCURVE",
+"550 354 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"696 172 LINE",
+"641 89 OFFCURVE",
+"591 23 OFFCURVE",
+"539 -38 CURVE SMOOTH",
+"499 -84 OFFCURVE",
+"472 -114 OFFCURVE",
+"433 -149 CURVE",
+"429 -149 LINE",
+"406 -98 OFFCURVE",
+"384 -58 OFFCURVE",
+"361 -14 CURVE SMOOTH",
+"350 7 OFFCURVE",
+"337 29 OFFCURVE",
+"324 51 CURVE",
+"263 11 LINE",
+"323 -77 OFFCURVE",
+"345 -128 OFFCURVE",
+"373 -195 CURVE",
+"473 -203 LINE",
+"585 -99 OFFCURVE",
+"649 -20 OFFCURVE",
+"757 133 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"494 -7 OFFCURVE",
+"515 8 OFFCURVE",
+"515 43 CURVE SMOOTH",
+"515 78 OFFCURVE",
+"494 93 OFFCURVE",
+"468 93 CURVE SMOOTH",
+"441 93 OFFCURVE",
+"420 78 OFFCURVE",
+"420 43 CURVE SMOOTH",
+"420 8 OFFCURVE",
+"441 -7 OFFCURVE",
+"468 -7 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"214 -162 OFFCURVE",
+"236 -146 OFFCURVE",
+"236 -109 CURVE SMOOTH",
+"236 -72 OFFCURVE",
+"214 -56 OFFCURVE",
+"187 -56 CURVE SMOOTH",
+"159 -56 OFFCURVE",
+"137 -72 OFFCURVE",
+"137 -109 CURVE SMOOTH",
+"137 -146 OFFCURVE",
+"159 -162 OFFCURVE",
+"187 -162 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"589 939 LINE",
+"530 899 OFFCURVE",
+"470 863 OFFCURVE",
+"408 829 CURVE",
+"371 814 LINE",
+"282 767 OFFCURVE",
+"186 724 OFFCURVE",
+"80 683 CURVE",
+"105 615 LINE",
+"225 664 OFFCURVE",
+"330 711 OFFCURVE",
+"430 765 CURVE",
+"467 781 LINE",
+"521 811 OFFCURVE",
+"574 844 OFFCURVE",
+"628 881 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"159 871 LINE",
+"399 792 OFFCURVE",
+"439 752 OFFCURVE",
+"439 697 CURVE SMOOTH",
+"439 651 OFFCURVE",
+"406 621 OFFCURVE",
+"149 530 CURVE",
+"178 462 LINE",
+"446 573 OFFCURVE",
+"511 608 OFFCURVE",
+"511 697 CURVE SMOOTH",
+"511 800 OFFCURVE",
+"429 852 OFFCURVE",
+"184 939 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 837;
+}
+);
+leftMetricsKey = u1B172;
+rightMetricsKey = u1B188;
+unicode = 1B2E4;
+},
+{
+glyphname = u1B2E5;
+lastChange = "2020-04-13 09:38:01 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"471 116 LINE",
+"517 134 OFFCURVE",
+"558 150 OFFCURVE",
+"597 168 CURVE",
+"629 178 LINE",
+"675 200 OFFCURVE",
+"712 223 OFFCURVE",
+"754 252 CURVE",
+"759 251 LINE",
+"765 189 OFFCURVE",
+"768 135 OFFCURVE",
+"768 77 CURVE SMOOTH",
+"768 64 OFFCURVE",
+"768 50 OFFCURVE",
+"768 36 CURVE",
+"840 37 LINE",
+"840 131 OFFCURVE",
+"834 196 OFFCURVE",
+"817 307 CURVE",
+"755 333 LINE",
+"710 305 OFFCURVE",
+"668 280 OFFCURVE",
+"625 258 CURVE",
+"589 243 LINE",
+"544 222 OFFCURVE",
+"498 201 OFFCURVE",
+"444 180 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"332 311 LINE",
+"237 210 OFFCURVE",
+"154 136 OFFCURVE",
+"40 53 CURVE",
+"82 -2 LINE",
+"202 86 OFFCURVE",
+"288 161 OFFCURVE",
+"386 267 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"195 132 LINE",
+"231 59 OFFCURVE",
+"278 -80 OFFCURVE",
+"303 -203 CURVE",
+"373 -189 LINE",
+"344 -60 OFFCURVE",
+"288 97 OFFCURVE",
+"247 185 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"203 -152 OFFCURVE",
+"226 -135 OFFCURVE",
+"226 -96 CURVE SMOOTH",
+"226 -57 OFFCURVE",
+"203 -40 OFFCURVE",
+"175 -40 CURVE SMOOTH",
+"146 -40 OFFCURVE",
+"123 -57 OFFCURVE",
+"123 -96 CURVE SMOOTH",
+"123 -135 OFFCURVE",
+"146 -152 OFFCURVE",
+"175 -152 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"427 31 OFFCURVE",
+"450 48 OFFCURVE",
+"450 87 CURVE SMOOTH",
+"450 126 OFFCURVE",
+"427 143 OFFCURVE",
+"399 143 CURVE SMOOTH",
+"370 143 OFFCURVE",
+"347 126 OFFCURVE",
+"347 87 CURVE SMOOTH",
+"347 48 OFFCURVE",
+"370 31 OFFCURVE",
+"399 31 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"674 718 LINE",
+"635 693 OFFCURVE",
+"591 667 OFFCURVE",
+"543 641 CURVE",
+"514 630 LINE",
+"460 602 OFFCURVE",
+"403 575 OFFCURVE",
+"343 550 CURVE",
+"359 482 LINE",
+"420 509 OFFCURVE",
+"478 535 OFFCURVE",
+"534 564 CURVE",
+"563 575 LINE",
+"618 604 OFFCURVE",
+"671 635 OFFCURVE",
+"725 671 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"670 -33 LINE",
+"656 144 OFFCURVE",
+"639 278 OFFCURVE",
+"620 392 CURVE",
+"607 437 LINE",
+"581 580 OFFCURVE",
+"550 691 OFFCURVE",
+"507 821 CURVE",
+"451 776 LINE",
+"491 653 OFFCURVE",
+"520 541 OFFCURVE",
+"544 405 CURVE",
+"552 359 LINE",
+"570 249 OFFCURVE",
+"584 122 OFFCURVE",
+"594 -39 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"616 927 LINE",
+"492 848 OFFCURVE",
+"397 800 OFFCURVE",
+"258 736 CURVE",
+"303 584 OFFCURVE",
+"332 468 OFFCURVE",
+"364 318 CURVE",
+"436 291 LINE",
+"487 311 OFFCURVE",
+"534 331 OFFCURVE",
+"580 352 CURVE",
+"613 364 LINE",
+"679 395 OFFCURVE",
+"742 427 OFFCURVE",
+"808 465 CURVE",
+"772 633 OFFCURVE",
+"737 764 OFFCURVE",
+"690 912 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"635 852 LINE",
+"652 790 OFFCURVE",
+"667 727 OFFCURVE",
+"680 681 CURVE SMOOTH",
+"699 612 OFFCURVE",
+"715 545 OFFCURVE",
+"729 479 CURVE",
+"769 528 LINE",
+"713 497 OFFCURVE",
+"652 464 OFFCURVE",
+"591 435 CURVE",
+"557 423 LINE",
+"505 399 OFFCURVE",
+"470 381 OFFCURVE",
+"432 364 CURVE",
+"427 365 LINE",
+"416 427 OFFCURVE",
+"405 480 OFFCURVE",
+"389 542 CURVE SMOOTH",
+"372 607 OFFCURVE",
+"353 675 OFFCURVE",
+"331 745 CURVE",
+"305 678 LINE",
+"371 707 OFFCURVE",
+"439 739 OFFCURVE",
+"505 775 CURVE SMOOTH",
+"555 802 OFFCURVE",
+"588 823 OFFCURVE",
+"630 853 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 960;
+}
+);
+leftMetricsKey = u1B26F;
+rightMetricsKey = u1B27A;
+unicode = 1B2E5;
+},
+{
+glyphname = u1B2E6;
+lastChange = "2020-04-13 09:38:23 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"365 287 LINE",
+"292 198 OFFCURVE",
+"236 141 OFFCURVE",
+"153 82 CURVE",
+"166 25 LINE",
+"252 89 OFFCURVE",
+"336 168 OFFCURVE",
+"401 249 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"399 -193 LINE",
+"387 -108 OFFCURVE",
+"371 -32 OFFCURVE",
+"352 41 CURVE",
+"338 65 LINE",
+"316 145 OFFCURVE",
+"289 220 OFFCURVE",
+"258 294 CURVE",
+"252 327 LINE",
+"237 360 OFFCURVE",
+"222 393 OFFCURVE",
+"206 426 CURVE",
+"146 394 LINE",
+"168 353 OFFCURVE",
+"187 310 OFFCURVE",
+"204 271 CURVE",
+"221 246 LINE",
+"252 172 OFFCURVE",
+"275 99 OFFCURVE",
+"295 20 CURVE",
+"295 -5 LINE",
+"309 -66 OFFCURVE",
+"321 -131 OFFCURVE",
+"332 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"298 407 LINE",
+"236 328 OFFCURVE",
+"179 270 OFFCURVE",
+"100 202 CURVE",
+"132 108 OFFCURVE",
+"151 37 OFFCURVE",
+"168 -48 CURVE",
+"243 -71 LINE",
+"322 -19 OFFCURVE",
+"399 47 OFFCURVE",
+"463 118 CURVE",
+"439 223 OFFCURVE",
+"409 304 OFFCURVE",
+"372 396 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"326 343 LINE",
+"342 305 OFFCURVE",
+"353 271 OFFCURVE",
+"365 236 CURVE SMOOTH",
+"379 194 OFFCURVE",
+"391 153 OFFCURVE",
+"403 112 CURVE",
+"427 173 LINE",
+"383 122 OFFCURVE",
+"344 83 OFFCURVE",
+"306 51 CURVE SMOOTH",
+"274 24 OFFCURVE",
+"250 9 OFFCURVE",
+"227 -14 CURVE",
+"222 -13 LINE",
+"216 36 OFFCURVE",
+"203 81 OFFCURVE",
+"196 104 CURVE SMOOTH",
+"186 137 OFFCURVE",
+"176 169 OFFCURVE",
+"163 201 CURVE",
+"149 163 LINE",
+"190 198 OFFCURVE",
+"223 229 OFFCURVE",
+"255 261 CURVE SMOOTH",
+"281 287 OFFCURVE",
+"296 306 OFFCURVE",
+"322 343 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"478 223 LINE",
+"572 128 OFFCURVE",
+"660 30 OFFCURVE",
+"753 -84 CURVE",
+"808 -36 LINE",
+"770 9 OFFCURVE",
+"737 46 OFFCURVE",
+"671 120 CURVE",
+"660 120 LINE",
+"624 169 OFFCURVE",
+"588 209 OFFCURVE",
+"526 270 CURVE",
+"525 242 LINE",
+"579 286 OFFCURVE",
+"635 342 OFFCURVE",
+"668 383 CURVE",
+"707 415 LINE",
+"721 431 OFFCURVE",
+"735 448 OFFCURVE",
+"749 464 CURVE",
+"690 510 LINE",
+"615 423 OFFCURVE",
+"551 355 OFFCURVE",
+"478 294 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"648 383 LINE",
+"672 383 LINE",
+"702 340 OFFCURVE",
+"712 303 OFFCURVE",
+"712 257 CURVE SMOOTH",
+"712 217 OFFCURVE",
+"696 169 OFFCURVE",
+"664 120 CURVE",
+"654 120 LINE",
+"590 36 OFFCURVE",
+"540 -16 OFFCURVE",
+"457 -98 CURVE",
+"511 -152 LINE",
+"585 -80 OFFCURVE",
+"634 -22 OFFCURVE",
+"674 27 CURVE",
+"704 58 LINE",
+"769 145 OFFCURVE",
+"784 201 OFFCURVE",
+"784 257 CURVE SMOOTH",
+"784 322 OFFCURVE",
+"764 377 OFFCURVE",
+"698 450 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"671 939 LINE",
+"598 859 OFFCURVE",
+"534 796 OFFCURVE",
+"467 737 CURVE",
+"444 723 LINE",
+"395 680 OFFCURVE",
+"345 639 OFFCURVE",
+"289 596 CURVE",
+"334 538 LINE",
+"385 577 OFFCURVE",
+"435 617 OFFCURVE",
+"484 659 CURVE",
+"503 669 LINE",
+"579 737 OFFCURVE",
+"653 810 OFFCURVE",
+"727 891 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"674 668 LINE",
+"591 584 OFFCURVE",
+"485 495 OFFCURVE",
+"387 421 CURVE",
+"433 363 LINE",
+"534 440 OFFCURVE",
+"646 534 OFFCURVE",
+"729 619 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"340 855 LINE",
+"415 727 OFFCURVE",
+"486 604 OFFCURVE",
+"531 479 CURVE",
+"588 530 LINE",
+"542 646 OFFCURVE",
+"490 747 OFFCURVE",
+"405 892 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 918;
+}
+);
+leftMetricsKey = u1B205;
+rightMetricsKey = u1B214;
+unicode = 1B2E6;
+},
+{
+glyphname = u1B2E7;
+lastChange = "2020-04-13 09:38:36 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"191 116 OFFCURVE",
+"160 67 OFFCURVE",
+"160 5 CURVE SMOOTH",
+"160 -116 OFFCURVE",
+"230 -198 OFFCURVE",
+"383 -203 CURVE",
+"389 -135 LINE",
+"273 -135 OFFCURVE",
+"232 -78 OFFCURVE",
+"232 8 CURVE SMOOTH",
+"232 62 OFFCURVE",
+"248 96 OFFCURVE",
+"301 130 CURVE",
+"286 217 LINE",
+"174 217 OFFCURVE",
+"142 261 OFFCURVE",
+"142 343 CURVE SMOOTH",
+"142 394 OFFCURVE",
+"162 428 OFFCURVE",
+"226 455 CURVE",
+"194 513 LINE",
+"106 470 OFFCURVE",
+"70 417 OFFCURVE",
+"70 336 CURVE SMOOTH",
+"70 290 OFFCURVE",
+"80 252 OFFCURVE",
+"100 221 CURVE SMOOTH",
+"123 185 OFFCURVE",
+"161 161 OFFCURVE",
+"228 156 CURVE",
+"229 151 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"773 462 LINE",
+"818 506 OFFCURVE",
+"846 549 OFFCURVE",
+"846 627 CURVE SMOOTH",
+"846 743 OFFCURVE",
+"776 819 OFFCURVE",
+"629 833 CURVE",
+"619 766 LINE",
+"734 757 OFFCURVE",
+"772 699 OFFCURVE",
+"772 626 CURVE SMOOTH",
+"772 560 OFFCURVE",
+"749 519 OFFCURVE",
+"699 489 CURVE",
+"724 400 LINE",
+"812 388 OFFCURVE",
+"871 326 OFFCURVE",
+"871 241 CURVE SMOOTH",
+"871 161 OFFCURVE",
+"842 116 OFFCURVE",
+"775 72 CURVE",
+"818 18 LINE",
+"902 79 OFFCURVE",
+"943 141 OFFCURVE",
+"943 243 CURVE SMOOTH",
+"943 279 OFFCURVE",
+"937 313 OFFCURVE",
+"924 344 CURVE SMOOTH",
+"897 406 OFFCURVE",
+"844 439 OFFCURVE",
+"774 457 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"742 237 OFFCURVE",
+"696 357 OFFCURVE",
+"640 475 CURVE",
+"561 491 LINE",
+"479 421 OFFCURVE",
+"418 373 OFFCURVE",
+"310 304 CURVE",
+"376 157 OFFCURVE",
+"411 65 OFFCURVE",
+"445 -45 CURVE",
+"530 -61 LINE",
+"611 -12 OFFCURVE",
+"692 46 OFFCURVE",
+"775 117 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"716 161 LINE",
+"681 131 OFFCURVE",
+"648 103 OFFCURVE",
+"612 77 CURVE SMOOTH",
+"571 47 OFFCURVE",
+"546 31 OFFCURVE",
+"508 4 CURVE",
+"503 5 LINE",
+"491 56 OFFCURVE",
+"466 128 OFFCURVE",
+"448 171 CURVE SMOOTH",
+"429 217 OFFCURVE",
+"407 268 OFFCURVE",
+"380 328 CURVE",
+"378 266 LINE",
+"421 293 OFFCURVE",
+"458 319 OFFCURVE",
+"494 345 CURVE SMOOTH",
+"533 373 OFFCURVE",
+"555 388 OFFCURVE",
+"587 420 CURVE",
+"592 419 LINE",
+"612 366 OFFCURVE",
+"628 319 OFFCURVE",
+"648 267 CURVE SMOOTH",
+"670 211 OFFCURVE",
+"689 157 OFFCURVE",
+"708 99 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"638 329 LINE",
+"568 269 OFFCURVE",
+"503 217 OFFCURVE",
+"415 162 CURVE",
+"439 96 LINE",
+"538 158 OFFCURVE",
+"608 214 OFFCURVE",
+"683 275 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"582 712 LINE",
+"472 604 OFFCURVE",
+"374 520 OFFCURVE",
+"248 440 CURVE",
+"288 380 LINE",
+"425 469 OFFCURVE",
+"512 543 OFFCURVE",
+"633 661 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"233 857 LINE",
+"314 705 OFFCURVE",
+"362 604 OFFCURVE",
+"407 482 CURVE",
+"466 533 LINE",
+"418 648 OFFCURVE",
+"384 736 OFFCURVE",
+"297 894 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"541 939 LINE",
+"469 858 OFFCURVE",
+"409 798 OFFCURVE",
+"344 743 CURVE",
+"323 731 LINE",
+"273 691 OFFCURVE",
+"220 652 OFFCURVE",
+"156 609 CURVE",
+"199 550 LINE",
+"257 590 OFFCURVE",
+"307 627 OFFCURVE",
+"354 665 CURVE",
+"375 676 LINE",
+"451 739 OFFCURVE",
+"519 805 OFFCURVE",
+"598 893 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 1013;
+}
+);
+leftMetricsKey = u1B1D0;
+unicode = 1B2E7;
+},
+{
+glyphname = u1B2E8;
+lastChange = "2020-04-13 09:38:49 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"593 239 LINE",
+"543 258 LINE",
+"535 69 OFFCURVE",
+"526 15 OFFCURVE",
+"501 -87 CURVE",
+"572 -102 LINE",
+"587 -6 OFFCURVE",
+"595 82 OFFCURVE",
+"591 174 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"692 142 OFFCURVE",
+"654 186 OFFCURVE",
+"586 255 CURVE",
+"569 174 LINE",
+"595 174 LINE",
+"629 118 OFFCURVE",
+"650 88 OFFCURVE",
+"701 7 CURVE",
+"756 47 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"749 283 OFFCURVE",
+"759 235 OFFCURVE",
+"765 211 CURVE SMOOTH",
+"778 157 OFFCURVE",
+"790 99 OFFCURVE",
+"800 41 CURVE",
+"873 55 LINE",
+"851 185 OFFCURVE",
+"820 306 OFFCURVE",
+"784 410 CURVE",
+"712 423 LINE",
+"600 329 OFFCURVE",
+"471 236 OFFCURVE",
+"330 150 CURVE",
+"360 35 OFFCURVE",
+"387 -85 OFFCURVE",
+"401 -203 CURVE",
+"474 -194 LINE",
+"459 -76 OFFCURVE",
+"432 47 OFFCURVE",
+"399 164 CURVE",
+"399 108 LINE",
+"480 156 OFFCURVE",
+"558 208 OFFCURVE",
+"633 265 CURVE SMOOTH",
+"664 288 OFFCURVE",
+"694 315 OFFCURVE",
+"729 350 CURVE",
+"734 349 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"590 285 LINE",
+"545 444 OFFCURVE",
+"497 592 OFFCURVE",
+"423 774 CURVE",
+"370 714 LINE",
+"437 548 OFFCURVE",
+"485 384 OFFCURVE",
+"523 245 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"550 939 LINE",
+"411 799 OFFCURVE",
+"286 697 OFFCURVE",
+"130 600 CURVE",
+"168 539 LINE",
+"320 636 OFFCURVE",
+"450 733 OFFCURVE",
+"603 892 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"656 768 LINE",
+"601 712 OFFCURVE",
+"537 657 OFFCURVE",
+"468 604 CURVE",
+"444 592 LINE",
+"369 537 OFFCURVE",
+"289 485 OFFCURVE",
+"211 438 CURVE",
+"247 373 LINE",
+"318 414 OFFCURVE",
+"393 463 OFFCURVE",
+"465 517 CURVE",
+"494 533 LINE",
+"573 592 OFFCURVE",
+"648 655 OFFCURVE",
+"711 721 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"701 468 OFFCURVE",
+"724 485 OFFCURVE",
+"724 524 CURVE SMOOTH",
+"724 563 OFFCURVE",
+"701 580 OFFCURVE",
+"673 580 CURVE SMOOTH",
+"644 580 OFFCURVE",
+"621 563 OFFCURVE",
+"621 524 CURVE SMOOTH",
+"621 485 OFFCURVE",
+"644 468 OFFCURVE",
+"673 468 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"395 247 OFFCURVE",
+"418 264 OFFCURVE",
+"418 303 CURVE SMOOTH",
+"418 342 OFFCURVE",
+"395 359 OFFCURVE",
+"367 359 CURVE SMOOTH",
+"338 359 OFFCURVE",
+"315 342 OFFCURVE",
+"315 303 CURVE SMOOTH",
+"315 264 OFFCURVE",
+"338 247 OFFCURVE",
+"367 247 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"172 99 LINE",
+"200 99 LINE",
+"224 45 OFFCURVE",
+"256 -30 OFFCURVE",
+"287 -116 CURVE",
+"353 -90 LINE",
+"317 -2 OFFCURVE",
+"270 93 OFFCURVE",
+"216 173 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"156 232 LINE",
+"133 87 OFFCURVE",
+"115 5 OFFCURVE",
+"70 -129 CURVE",
+"137 -150 LINE",
+"167 -60 OFFCURVE",
+"182 11 OFFCURVE",
+"196 99 CURVE",
+"213 145 LINE",
+"217 169 OFFCURVE",
+"221 195 OFFCURVE",
+"224 222 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 953;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B270;
+unicode = 1B2E8;
+},
+{
+glyphname = u1B2E9;
+lastChange = "2020-04-13 09:38:52 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"365 552 LINE",
+"468 627 OFFCURVE",
+"581 737 OFFCURVE",
+"711 899 CURVE",
+"653 939 LINE",
+"526 780 OFFCURVE",
+"423 684 OFFCURVE",
+"322 607 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"677 630 OFFCURVE",
+"625 572 OFFCURVE",
+"453 440 CURVE",
+"497 386 LINE",
+"691 532 OFFCURVE",
+"749 607 OFFCURVE",
+"749 696 CURVE SMOOTH",
+"749 765 OFFCURVE",
+"721 818 OFFCURVE",
+"622 882 CURVE",
+"595 818 LINE",
+"661 771 OFFCURVE",
+"677 734 OFFCURVE",
+"677 698 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"784 -72 LINE",
+"784 63 OFFCURVE",
+"769 183 OFFCURVE",
+"725 351 CURVE",
+"669 319 LINE",
+"704 162 OFFCURVE",
+"713 57 OFFCURVE",
+"713 -76 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"754 408 OFFCURVE",
+"706 348 OFFCURVE",
+"529 233 CURVE",
+"568 175 LINE",
+"749 291 OFFCURVE",
+"826 365 OFFCURVE",
+"826 468 CURVE SMOOTH",
+"826 544 OFFCURVE",
+"796 594 OFFCURVE",
+"700 668 CURVE",
+"666 600 LINE",
+"741 544 OFFCURVE",
+"754 516 OFFCURVE",
+"754 471 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"455 207 LINE",
+"420 67 OFFCURVE",
+"369 -58 OFFCURVE",
+"306 -168 CURVE",
+"367 -203 LINE",
+"433 -80 OFFCURVE",
+"485 45 OFFCURVE",
+"523 192 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"261 87 LINE",
+"347 25 OFFCURVE",
+"429 -44 OFFCURVE",
+"532 -164 CURVE",
+"586 -119 LINE",
+"483 -3 OFFCURVE",
+"397 76 OFFCURVE",
+"304 142 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"285 -99 OFFCURVE",
+"307 -83 OFFCURVE",
+"307 -46 CURVE SMOOTH",
+"307 -9 OFFCURVE",
+"285 8 OFFCURVE",
+"258 8 CURVE SMOOTH",
+"230 8 OFFCURVE",
+"208 -9 OFFCURVE",
+"208 -46 CURVE SMOOTH",
+"208 -83 OFFCURVE",
+"230 -99 OFFCURVE",
+"258 -99 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"604 -18 OFFCURVE",
+"626 -2 OFFCURVE",
+"626 35 CURVE SMOOTH",
+"626 73 OFFCURVE",
+"604 89 OFFCURVE",
+"578 89 CURVE SMOOTH",
+"550 89 OFFCURVE",
+"528 73 OFFCURVE",
+"528 35 CURVE SMOOTH",
+"528 -2 OFFCURVE",
+"550 -18 OFFCURVE",
+"578 -18 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"305 530 LINE",
+"272 407 OFFCURVE",
+"208 247 OFFCURVE",
+"132 129 CURVE",
+"193 96 LINE",
+"268 221 OFFCURVE",
+"334 374 OFFCURVE",
+"374 512 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"96 406 LINE",
+"213 330 OFFCURVE",
+"298 238 OFFCURVE",
+"367 156 CURVE",
+"420 201 LINE",
+"344 291 OFFCURVE",
+"258 374 OFFCURVE",
+"134 464 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"126 219 OFFCURVE",
+"148 235 OFFCURVE",
+"148 272 CURVE SMOOTH",
+"148 310 OFFCURVE",
+"126 326 OFFCURVE",
+"99 326 CURVE SMOOTH",
+"72 326 OFFCURVE",
+"50 310 OFFCURVE",
+"50 272 CURVE SMOOTH",
+"50 235 OFFCURVE",
+"72 219 OFFCURVE",
+"99 219 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"452 308 OFFCURVE",
+"474 325 OFFCURVE",
+"474 362 CURVE SMOOTH",
+"474 399 OFFCURVE",
+"452 415 OFFCURVE",
+"426 415 CURVE SMOOTH",
+"398 415 OFFCURVE",
+"376 399 OFFCURVE",
+"376 362 CURVE SMOOTH",
+"376 325 OFFCURVE",
+"398 308 OFFCURVE",
+"426 308 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 956;
+}
+);
+leftMetricsKey = u1B1D7;
+rightMetricsKey = u1B179;
+unicode = 1B2E9;
+},
+{
+glyphname = u1B2EA;
+lastChange = "2020-04-13 09:39:35 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"306 530 LINE",
+"284 435 OFFCURVE",
+"257 374 OFFCURVE",
+"206 304 CURVE",
+"255 271 LINE",
+"304 344 OFFCURVE",
+"340 422 OFFCURVE",
+"364 516 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"173 421 LINE",
+"203 412 OFFCURVE",
+"237 398 OFFCURVE",
+"270 381 CURVE",
+"289 375 LINE",
+"320 360 OFFCURVE",
+"350 342 OFFCURVE",
+"374 325 CURVE",
+"410 372 LINE",
+"384 389 OFFCURVE",
+"352 407 OFFCURVE",
+"318 425 CURVE",
+"293 433 LINE",
+"255 451 OFFCURVE",
+"218 468 OFFCURVE",
+"189 477 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"521 644 LINE",
+"502 554 OFFCURVE",
+"481 501 OFFCURVE",
+"429 423 CURVE",
+"479 392 LINE",
+"525 460 OFFCURVE",
+"560 542 OFFCURVE",
+"581 631 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"391 539 LINE",
+"421 529 OFFCURVE",
+"458 512 OFFCURVE",
+"494 493 CURVE",
+"509 489 LINE",
+"542 470 OFFCURVE",
+"572 450 OFFCURVE",
+"595 432 CURVE",
+"628 482 LINE",
+"598 503 OFFCURVE",
+"566 522 OFFCURVE",
+"535 540 CURVE",
+"511 549 LINE",
+"476 567 OFFCURVE",
+"442 583 OFFCURVE",
+"413 594 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"510 752 LINE",
+"392 683 OFFCURVE",
+"261 614 OFFCURVE",
+"129 551 CURVE",
+"158 489 LINE",
+"302 559 OFFCURVE",
+"413 616 OFFCURVE",
+"544 693 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"527 -171 LINE",
+"458 -1 OFFCURVE",
+"408 110 OFFCURVE",
+"335 267 CURVE",
+"332 196 LINE",
+"383 223 OFFCURVE",
+"433 251 OFFCURVE",
+"482 280 CURVE SMOOTH",
+"525 306 OFFCURVE",
+"547 323 OFFCURVE",
+"582 347 CURVE",
+"586 347 LINE",
+"604 304 OFFCURVE",
+"624 258 OFFCURVE",
+"642 218 CURVE SMOOTH",
+"667 163 OFFCURVE",
+"688 109 OFFCURVE",
+"711 48 CURVE",
+"711 121 LINE",
+"636 74 OFFCURVE",
+"566 32 OFFCURVE",
+"451 -30 CURVE",
+"409 -49 LINE",
+"358 -76 OFFCURVE",
+"299 -106 OFFCURVE",
+"230 -140 CURVE",
+"262 -202 LINE",
+"327 -170 OFFCURVE",
+"385 -141 OFFCURVE",
+"437 -114 CURVE",
+"484 -92 LINE",
+"604 -27 OFFCURVE",
+"692 27 OFFCURVE",
+"777 83 CURVE",
+"732 200 OFFCURVE",
+"690 297 OFFCURVE",
+"637 397 CURVE",
+"561 414 LINE",
+"475 353 OFFCURVE",
+"379 301 OFFCURVE",
+"264 239 CURVE",
+"352 63 OFFCURVE",
+"405 -64 OFFCURVE",
+"460 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"636 264 LINE",
+"539 200 OFFCURVE",
+"476 165 OFFCURVE",
+"378 114 CURVE",
+"413 58 LINE",
+"513 109 OFFCURVE",
+"596 159 OFFCURVE",
+"669 206 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"497 929 LINE",
+"422 882 OFFCURVE",
+"353 841 OFFCURVE",
+"283 803 CURVE",
+"257 794 LINE",
+"194 760 OFFCURVE",
+"130 729 OFFCURVE",
+"60 699 CURVE",
+"88 634 LINE",
+"156 664 OFFCURVE",
+"219 694 OFFCURVE",
+"281 727 CURVE",
+"305 735 LINE",
+"378 775 OFFCURVE",
+"451 819 OFFCURVE",
+"535 870 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 886 LINE",
+"250 752 OFFCURVE",
+"279 676 OFFCURVE",
+"309 575 CURVE",
+"373 607 LINE",
+"334 726 OFFCURVE",
+"314 790 OFFCURVE",
+"255 915 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 867;
+}
+);
+leftMetricsKey = u1B214;
+rightMetricsKey = u1B1BC;
+unicode = 1B2EA;
+},
+{
+glyphname = u1B2EB;
+lastChange = "2020-04-13 09:39:38 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"237 737 OFFCURVE",
+"259 753 OFFCURVE",
+"259 790 CURVE SMOOTH",
+"259 827 OFFCURVE",
+"237 843 OFFCURVE",
+"210 843 CURVE SMOOTH",
+"182 843 OFFCURVE",
+"160 827 OFFCURVE",
+"160 790 CURVE SMOOTH",
+"160 753 OFFCURVE",
+"182 737 OFFCURVE",
+"210 737 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"564 833 OFFCURVE",
+"586 849 OFFCURVE",
+"586 886 CURVE SMOOTH",
+"586 923 OFFCURVE",
+"564 939 OFFCURVE",
+"537 939 CURVE SMOOTH",
+"509 939 OFFCURVE",
+"487 923 OFFCURVE",
+"487 886 CURVE SMOOTH",
+"487 849 OFFCURVE",
+"509 833 OFFCURVE",
+"537 833 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"392 40 OFFCURVE",
+"413 55 OFFCURVE",
+"413 90 CURVE SMOOTH",
+"413 125 OFFCURVE",
+"392 140 OFFCURVE",
+"366 140 CURVE SMOOTH",
+"339 140 OFFCURVE",
+"318 125 OFFCURVE",
+"318 90 CURVE SMOOTH",
+"318 55 OFFCURVE",
+"339 40 OFFCURVE",
+"366 40 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"706 119 OFFCURVE",
+"729 135 OFFCURVE",
+"729 172 CURVE SMOOTH",
+"729 209 OFFCURVE",
+"707 225 OFFCURVE",
+"680 225 CURVE SMOOTH",
+"652 225 OFFCURVE",
+"630 209 OFFCURVE",
+"630 172 CURVE SMOOTH",
+"630 135 OFFCURVE",
+"652 119 OFFCURVE",
+"680 119 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"648 589 LINE",
+"591 569 OFFCURVE",
+"533 549 OFFCURVE",
+"474 529 CURVE",
+"432 518 LINE",
+"377 499 OFFCURVE",
+"319 481 OFFCURVE",
+"260 464 CURVE",
+"273 398 LINE",
+"332 416 OFFCURVE",
+"391 435 OFFCURVE",
+"451 455 CURVE",
+"491 465 LINE",
+"558 488 OFFCURVE",
+"625 512 OFFCURVE",
+"668 529 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"568 -36 LINE",
+"559 90 OFFCURVE",
+"548 199 OFFCURVE",
+"534 297 CURVE",
+"526 339 LINE",
+"507 459 OFFCURVE",
+"484 563 OFFCURVE",
+"457 667 CURVE",
+"446 716 LINE",
+"426 788 OFFCURVE",
+"403 861 OFFCURVE",
+"378 939 CURVE",
+"310 919 LINE",
+"335 839 OFFCURVE",
+"358 763 OFFCURVE",
+"378 692 CURVE",
+"394 650 LINE",
+"421 539 OFFCURVE",
+"444 433 OFFCURVE",
+"463 316 CURVE",
+"465 274 LINE",
+"478 180 OFFCURVE",
+"486 77 OFFCURVE",
+"492 -41 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"568 776 LINE",
+"519 757 OFFCURVE",
+"469 740 OFFCURVE",
+"418 722 CURVE",
+"393 716 LINE",
+"325 693 OFFCURVE",
+"256 671 OFFCURVE",
+"182 648 CURVE",
+"222 506 OFFCURVE",
+"246 376 OFFCURVE",
+"267 248 CURVE",
+"346 216 LINE",
+"386 228 OFFCURVE",
+"437 243 OFFCURVE",
+"490 259 CURVE",
+"529 268 LINE",
+"600 291 OFFCURVE",
+"673 314 OFFCURVE",
+"739 336 CURVE",
+"711 489 OFFCURVE",
+"682 627 OFFCURVE",
+"642 750 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"584 705 LINE",
+"598 650 OFFCURVE",
+"608 607 OFFCURVE",
+"620 551 CURVE SMOOTH",
+"636 479 OFFCURVE",
+"649 409 OFFCURVE",
+"659 346 CURVE",
+"697 400 LINE",
+"634 377 OFFCURVE",
+"572 356 OFFCURVE",
+"513 338 CURVE",
+"472 328 LINE",
+"417 311 OFFCURVE",
+"383 302 OFFCURVE",
+"337 285 CURVE",
+"332 286 LINE",
+"324 349 OFFCURVE",
+"316 408 OFFCURVE",
+"309 442 CURVE SMOOTH",
+"294 511 OFFCURVE",
+"276 584 OFFCURVE",
+"255 657 CURVE",
+"229 590 LINE",
+"291 609 OFFCURVE",
+"353 628 OFFCURVE",
+"413 648 CURVE",
+"442 655 LINE",
+"497 674 OFFCURVE",
+"527 687 OFFCURVE",
+"579 706 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"172 49 LINE",
+"200 49 LINE",
+"224 -5 OFFCURVE",
+"256 -80 OFFCURVE",
+"287 -166 CURVE",
+"353 -140 LINE",
+"317 -52 OFFCURVE",
+"270 43 OFFCURVE",
+"216 123 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"156 182 LINE",
+"133 37 OFFCURVE",
+"115 -45 OFFCURVE",
+"70 -179 CURVE",
+"137 -200 LINE",
+"167 -110 OFFCURVE",
+"182 -39 OFFCURVE",
+"196 49 CURVE",
+"213 95 LINE",
+"217 119 OFFCURVE",
+"221 145 OFFCURVE",
+"224 172 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 829;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B21B;
+unicode = 1B2EB;
+},
+{
+glyphname = u1B2EC;
+lastChange = "2020-04-13 09:39:40 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"831 169 OFFCURVE",
+"779 320 OFFCURVE",
+"732 430 CURVE",
+"652 443 LINE",
+"559 352 OFFCURVE",
+"465 275 OFFCURVE",
+"369 203 CURVE",
+"421 75 OFFCURVE",
+"463 -77 OFFCURVE",
+"486 -174 CURVE",
+"570 -198 LINE",
+"663 -135 OFFCURVE",
+"775 -44 OFFCURVE",
+"862 38 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"796 77 LINE",
+"762 44 OFFCURVE",
+"726 12 OFFCURVE",
+"689 -18 CURVE SMOOTH",
+"631 -65 OFFCURVE",
+"596 -95 OFFCURVE",
+"551 -131 CURVE",
+"547 -131 LINE",
+"535 -68 OFFCURVE",
+"517 -8 OFFCURVE",
+"497 57 CURVE SMOOTH",
+"479 115 OFFCURVE",
+"459 173 OFFCURVE",
+"439 227 CURVE",
+"437 165 LINE",
+"477 194 OFFCURVE",
+"517 226 OFFCURVE",
+"558 260 CURVE SMOOTH",
+"607 301 OFFCURVE",
+"625 321 OFFCURVE",
+"677 370 CURVE",
+"681 370 LINE",
+"702 311 OFFCURVE",
+"719 263 OFFCURVE",
+"738 207 CURVE SMOOTH",
+"760 143 OFFCURVE",
+"778 79 OFFCURVE",
+"791 19 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"732 274 LINE",
+"646 184 OFFCURVE",
+"550 103 OFFCURVE",
+"446 26 CURVE",
+"480 -33 LINE",
+"586 44 OFFCURVE",
+"684 124 OFFCURVE",
+"769 210 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"550 787 LINE",
+"478 711 OFFCURVE",
+"390 633 OFFCURVE",
+"311 572 CURVE",
+"340 505 LINE",
+"432 577 OFFCURVE",
+"525 661 OFFCURVE",
+"593 726 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"442 940 LINE",
+"377 870 OFFCURVE",
+"299 798 OFFCURVE",
+"184 702 CURVE",
+"250 574 OFFCURVE",
+"298 467 OFFCURVE",
+"342 357 CURVE",
+"423 343 LINE",
+"515 407 OFFCURVE",
+"606 484 OFFCURVE",
+"701 571 CURVE",
+"644 708 OFFCURVE",
+"592 811 OFFCURVE",
+"530 932 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"480 872 LINE",
+"507 818 OFFCURVE",
+"529 774 OFFCURVE",
+"551 726 CURVE SMOOTH",
+"581 661 OFFCURVE",
+"608 601 OFFCURVE",
+"631 543 CURVE",
+"633 608 LINE",
+"596 573 OFFCURVE",
+"561 542 OFFCURVE",
+"528 514 CURVE SMOOTH",
+"475 469 OFFCURVE",
+"443 446 OFFCURVE",
+"400 409 CURVE",
+"396 409 LINE",
+"379 460 OFFCURVE",
+"359 507 OFFCURVE",
+"331 569 CURVE SMOOTH",
+"310 615 OFFCURVE",
+"285 666 OFFCURVE",
+"254 727 CURVE",
+"254 666 LINE",
+"296 702 OFFCURVE",
+"330 732 OFFCURVE",
+"362 761 CURVE SMOOTH",
+"408 802 OFFCURVE",
+"433 826 OFFCURVE",
+"476 872 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"80 95 OFFCURVE",
+"109 47 OFFCURVE",
+"177 7 CURVE",
+"248 16 LINE",
+"316 95 OFFCURVE",
+"334 160 OFFCURVE",
+"334 221 CURVE SMOOTH",
+"334 281 OFFCURVE",
+"300 322 OFFCURVE",
+"232 360 CURVE",
+"158 350 LINE",
+"100 268 OFFCURVE",
+"80 201 OFFCURVE",
+"80 152 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"204 306 LINE",
+"244 274 OFFCURVE",
+"259 239 OFFCURVE",
+"259 210 CURVE SMOOTH",
+"259 167 OFFCURVE",
+"249 122 OFFCURVE",
+"209 58 CURVE",
+"204 57 LINE",
+"169 92 OFFCURVE",
+"154 123 OFFCURVE",
+"154 156 CURVE SMOOTH",
+"154 198 OFFCURVE",
+"167 242 OFFCURVE",
+"199 305 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 952;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B1C8;
+unicode = 1B2EC;
+},
+{
+glyphname = u1B2ED;
+lastChange = "2020-04-13 09:43:01 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"186 343 OFFCURVE",
+"208 313 OFFCURVE",
+"264 293 CURVE",
+"332 304 LINE",
+"373 351 OFFCURVE",
+"385 382 OFFCURVE",
+"385 416 CURVE SMOOTH",
+"385 449 OFFCURVE",
+"363 475 OFFCURVE",
+"302 497 CURVE",
+"235 487 LINE",
+"196 447 OFFCURVE",
+"186 416 OFFCURVE",
+"186 382 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"410 469 OFFCURVE",
+"432 439 OFFCURVE",
+"488 419 CURVE",
+"556 430 LINE",
+"596 477 OFFCURVE",
+"609 508 OFFCURVE",
+"609 542 CURVE SMOOTH",
+"609 575 OFFCURVE",
+"587 601 OFFCURVE",
+"526 623 CURVE",
+"459 613 LINE",
+"420 573 OFFCURVE",
+"410 542 OFFCURVE",
+"410 508 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"510 752 LINE",
+"392 683 OFFCURVE",
+"261 614 OFFCURVE",
+"129 551 CURVE",
+"158 489 LINE",
+"302 559 OFFCURVE",
+"413 616 OFFCURVE",
+"544 693 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"527 -171 LINE",
+"458 -1 OFFCURVE",
+"408 110 OFFCURVE",
+"335 267 CURVE",
+"332 196 LINE",
+"383 223 OFFCURVE",
+"433 251 OFFCURVE",
+"482 280 CURVE SMOOTH",
+"525 306 OFFCURVE",
+"547 323 OFFCURVE",
+"582 347 CURVE",
+"586 347 LINE",
+"604 304 OFFCURVE",
+"624 258 OFFCURVE",
+"642 218 CURVE SMOOTH",
+"666 163 OFFCURVE",
+"688 109 OFFCURVE",
+"711 48 CURVE",
+"711 121 LINE",
+"636 74 OFFCURVE",
+"566 32 OFFCURVE",
+"461 -25 CURVE",
+"409 -49 LINE",
+"358 -76 OFFCURVE",
+"299 -106 OFFCURVE",
+"230 -140 CURVE",
+"262 -202 LINE",
+"327 -170 OFFCURVE",
+"385 -141 OFFCURVE",
+"437 -114 CURVE",
+"484 -92 LINE",
+"604 -27 OFFCURVE",
+"692 27 OFFCURVE",
+"777 83 CURVE",
+"732 200 OFFCURVE",
+"690 297 OFFCURVE",
+"637 397 CURVE",
+"561 414 LINE",
+"475 353 OFFCURVE",
+"379 301 OFFCURVE",
+"264 239 CURVE",
+"352 63 OFFCURVE",
+"405 -64 OFFCURVE",
+"460 -203 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"636 264 LINE",
+"539 200 OFFCURVE",
+"476 165 OFFCURVE",
+"378 114 CURVE",
+"413 58 LINE",
+"513 109 OFFCURVE",
+"596 159 OFFCURVE",
+"669 206 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"497 929 LINE",
+"420 882 OFFCURVE",
+"350 839 OFFCURVE",
+"279 800 CURVE",
+"253 790 LINE",
+"192 758 OFFCURVE",
+"129 728 OFFCURVE",
+"60 698 CURVE",
+"88 633 LINE",
+"156 663 OFFCURVE",
+"219 693 OFFCURVE",
+"280 726 CURVE",
+"308 737 LINE",
+"380 776 OFFCURVE",
+"453 820 OFFCURVE",
+"535 870 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"189 886 LINE",
+"250 752 OFFCURVE",
+"279 676 OFFCURVE",
+"309 575 CURVE",
+"373 607 LINE",
+"334 726 OFFCURVE",
+"314 790 OFFCURVE",
+"255 915 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"500 574 LINE",
+"532 570 OFFCURVE",
+"546 554 OFFCURVE",
+"546 533 CURVE SMOOTH",
+"546 514 OFFCURVE",
+"538 493 OFFCURVE",
+"515 467 CURVE",
+"511 467 LINE",
+"479 474 OFFCURVE",
+"467 491 OFFCURVE",
+"467 516 CURVE SMOOTH",
+"467 533 OFFCURVE",
+"473 554 OFFCURVE",
+"496 574 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"276 448 LINE",
+"308 444 OFFCURVE",
+"322 428 OFFCURVE",
+"322 407 CURVE SMOOTH",
+"322 388 OFFCURVE",
+"314 367 OFFCURVE",
+"291 341 CURVE",
+"287 341 LINE",
+"255 348 OFFCURVE",
+"243 365 OFFCURVE",
+"243 390 CURVE SMOOTH",
+"243 407 OFFCURVE",
+"249 428 OFFCURVE",
+"272 448 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 867;
+}
+);
+leftMetricsKey = u1B214;
+rightMetricsKey = u1B1BC;
+unicode = 1B2ED;
+},
+{
+glyphname = u1B2EE;
+lastChange = "2020-04-13 09:40:30 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"355 675 LINE",
+"319 643 OFFCURVE",
+"277 610 OFFCURVE",
+"233 578 CURVE",
+"213 569 LINE",
+"161 532 OFFCURVE",
+"108 498 OFFCURVE",
+"60 471 CURVE",
+"93 409 LINE",
+"140 435 OFFCURVE",
+"191 468 OFFCURVE",
+"241 503 CURVE",
+"265 515 LINE",
+"312 548 OFFCURVE",
+"358 584 OFFCURVE",
+"400 621 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"400 492 LINE",
+"315 420 OFFCURVE",
+"254 378 OFFCURVE",
+"154 323 CURVE",
+"189 261 LINE",
+"290 317 OFFCURVE",
+"363 370 OFFCURVE",
+"446 438 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"296 485 OFFCURVE",
+"255 580 OFFCURVE",
+"198 704 CURVE",
+"135 674 LINE",
+"201 536 OFFCURVE",
+"237 446 OFFCURVE",
+"275 343 CURVE",
+"331 384 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"222 90 LINE",
+"351 18 OFFCURVE",
+"447 -53 OFFCURVE",
+"531 -124 CURVE",
+"577 -68 LINE",
+"533 -33 OFFCURVE",
+"501 -11 OFFCURVE",
+"423 42 CURVE",
+"409 42 LINE",
+"374 73 OFFCURVE",
+"320 111 OFFCURVE",
+"265 141 CURVE",
+"262 120 LINE",
+"313 154 OFFCURVE",
+"364 195 OFFCURVE",
+"404 237 CURVE",
+"445 264 LINE",
+"459 277 OFFCURVE",
+"472 289 OFFCURVE",
+"486 303 CURVE",
+"435 353 LINE",
+"355 277 OFFCURVE",
+"295 230 OFFCURVE",
+"209 171 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"377 237 LINE",
+"408 237 LINE",
+"430 202 OFFCURVE",
+"435 179 OFFCURVE",
+"435 149 CURVE SMOOTH",
+"435 114 OFFCURVE",
+"428 77 OFFCURVE",
+"413 42 CURVE",
+"403 42 LINE",
+"353 -28 OFFCURVE",
+"295 -79 OFFCURVE",
+"204 -149 CURVE",
+"249 -203 LINE",
+"332 -133 OFFCURVE",
+"390 -77 OFFCURVE",
+"433 -25 CURVE",
+"453 -4 LINE",
+"488 45 OFFCURVE",
+"505 93 OFFCURVE",
+"505 150 CURVE SMOOTH",
+"505 193 OFFCURVE",
+"491 228 OFFCURVE",
+"456 278 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"667 70 LINE",
+"754 153 OFFCURVE",
+"834 239 OFFCURVE",
+"905 344 CURVE",
+"847 384 LINE",
+"817 341 OFFCURVE",
+"790 305 OFFCURVE",
+"763 272 CURVE SMOOTH",
+"723 223 OFFCURVE",
+"696 194 OFFCURVE",
+"646 142 CURVE",
+"642 142 LINE",
+"631 204 OFFCURVE",
+"614 257 OFFCURVE",
+"597 317 CURVE SMOOTH",
+"553 469 OFFCURVE",
+"499 617 OFFCURVE",
+"438 783 CURVE",
+"443 737 LINE",
+"468 755 OFFCURVE",
+"493 773 OFFCURVE",
+"518 792 CURVE SMOOTH",
+"548 815 OFFCURVE",
+"575 841 OFFCURVE",
+"609 877 CURVE",
+"613 877 LINE",
+"631 825 OFFCURVE",
+"650 772 OFFCURVE",
+"666 729 CURVE SMOOTH",
+"690 665 OFFCURVE",
+"712 599 OFFCURVE",
+"732 538 CURVE",
+"741 604 LINE",
+"672 543 OFFCURVE",
+"603 496 OFFCURVE",
+"525 445 CURVE",
+"556 384 LINE",
+"651 442 OFFCURVE",
+"728 497 OFFCURVE",
+"800 559 CURVE",
+"752 709 OFFCURVE",
+"714 814 OFFCURVE",
+"659 937 CURVE",
+"579 939 LINE",
+"520 882 OFFCURVE",
+"449 825 OFFCURVE",
+"365 764 CURVE",
+"471 502 OFFCURVE",
+"522 337 OFFCURVE",
+"588 80 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"663 772 LINE",
+"604 718 OFFCURVE",
+"545 673 OFFCURVE",
+"465 619 CURVE",
+"507 564 LINE",
+"590 618 OFFCURVE",
+"656 670 OFFCURVE",
+"715 722 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"691 317 OFFCURVE",
+"717 268 OFFCURVE",
+"738 221 CURVE",
+"756 193 LINE",
+"776 143 OFFCURVE",
+"792 95 OFFCURVE",
+"808 35 CURVE",
+"875 51 LINE",
+"852 128 OFFCURVE",
+"832 185 OFFCURVE",
+"807 243 CURVE",
+"789 273 LINE",
+"769 314 OFFCURVE",
+"747 357 OFFCURVE",
+"718 409 CURVE",
+"658 376 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 985;
+}
+);
+leftMetricsKey = u1B214;
+rightMetricsKey = u1B274;
+unicode = 1B2EE;
+},
+{
+glyphname = u1B2EF;
+lastChange = "2020-04-13 09:40:55 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"732 325 OFFCURVE",
+"708 426 OFFCURVE",
+"673 531 CURVE",
+"605 554 LINE",
+"503 496 OFFCURVE",
+"394 445 OFFCURVE",
+"269 391 CURVE",
+"297 292 OFFCURVE",
+"319 192 OFFCURVE",
+"335 100 CURVE",
+"405 73 LINE",
+"507 109 OFFCURVE",
+"621 162 OFFCURVE",
+"747 227 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"684 274 LINE",
+"637 249 OFFCURVE",
+"590 226 OFFCURVE",
+"541 204 CURVE SMOOTH",
+"483 178 OFFCURVE",
+"444 159 OFFCURVE",
+"401 138 CURVE",
+"396 139 LINE",
+"392 187 OFFCURVE",
+"380 239 OFFCURVE",
+"373 272 CURVE SMOOTH",
+"363 317 OFFCURVE",
+"352 364 OFFCURVE",
+"340 405 CURVE",
+"339 347 LINE",
+"381 364 OFFCURVE",
+"426 384 OFFCURVE",
+"474 407 CURVE SMOOTH",
+"527 432 OFFCURVE",
+"562 454 OFFCURVE",
+"611 485 CURVE",
+"616 484 LINE",
+"624 445 OFFCURVE",
+"640 389 OFFCURVE",
+"647 362 CURVE SMOOTH",
+"659 313 OFFCURVE",
+"669 263 OFFCURVE",
+"677 211 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"649 411 LINE",
+"549 355 OFFCURVE",
+"463 316 OFFCURVE",
+"343 269 CURVE",
+"367 212 LINE",
+"482 256 OFFCURVE",
+"584 302 OFFCURVE",
+"694 365 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"815 -51 LINE",
+"790 17 OFFCURVE",
+"749 81 OFFCURVE",
+"704 140 CURVE",
+"648 98 LINE",
+"695 37 OFFCURVE",
+"732 -26 OFFCURVE",
+"751 -80 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"509 -197 LINE",
+"509 -116 OFFCURVE",
+"507 -52 OFFCURVE",
+"497 34 CURVE",
+"426 25 LINE",
+"435 -51 OFFCURVE",
+"438 -122 OFFCURVE",
+"438 -196 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"363 542 LINE",
+"329 659 OFFCURVE",
+"286 770 OFFCURVE",
+"244 859 CURVE",
+"182 832 LINE",
+"224 752 OFFCURVE",
+"265 640 OFFCURVE",
+"300 524 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"611 921 LINE",
+"553 887 OFFCURVE",
+"501 859 OFFCURVE",
+"450 832 CURVE",
+"430 825 LINE",
+"380 798 OFFCURVE",
+"330 773 OFFCURVE",
+"276 747 CURVE",
+"250 739 LINE",
+"202 716 OFFCURVE",
+"150 694 OFFCURVE",
+"92 671 CURVE",
+"117 608 LINE",
+"175 633 OFFCURVE",
+"225 656 OFFCURVE",
+"272 677 CURVE",
+"293 683 LINE",
+"349 709 OFFCURVE",
+"400 734 OFFCURVE",
+"454 762 CURVE",
+"474 768 LINE",
+"527 796 OFFCURVE",
+"582 827 OFFCURVE",
+"647 864 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"542 617 LINE",
+"505 760 OFFCURVE",
+"473 849 OFFCURVE",
+"429 939 CURVE",
+"369 914 LINE",
+"408 834 OFFCURVE",
+"441 739 OFFCURVE",
+"479 602 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"725 770 LINE",
+"462 624 OFFCURVE",
+"300 551 OFFCURVE",
+"109 476 CURVE",
+"135 411 LINE",
+"322 485 OFFCURVE",
+"503 566 OFFCURVE",
+"760 709 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"172 49 LINE",
+"200 49 LINE",
+"224 -5 OFFCURVE",
+"246 -54 OFFCURVE",
+"277 -140 CURVE",
+"343 -114 LINE",
+"307 -26 OFFCURVE",
+"270 43 OFFCURVE",
+"216 123 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"156 182 LINE",
+"133 37 OFFCURVE",
+"115 -45 OFFCURVE",
+"70 -179 CURVE",
+"137 -200 LINE",
+"167 -110 OFFCURVE",
+"182 -39 OFFCURVE",
+"196 49 CURVE",
+"213 95 LINE",
+"217 119 OFFCURVE",
+"221 145 OFFCURVE",
+"224 172 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 915;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B2D6;
+unicode = 1B2EF;
+},
+{
+glyphname = u1B2F0;
+lastChange = "2020-04-13 09:41:11 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"506 356 OFFCURVE",
+"403 305 OFFCURVE",
+"301 259 CURVE",
+"333 118 OFFCURVE",
+"336 35 OFFCURVE",
+"339 -32 CURVE",
+"410 -30 LINE",
+"407 56 OFFCURVE",
+"399 141 OFFCURVE",
+"372 251 CURVE",
+"341 200 LINE",
+"463 255 OFFCURVE",
+"539 298 OFFCURVE",
+"627 359 CURVE",
+"631 359 LINE",
+"671 326 OFFCURVE",
+"681 298 OFFCURVE",
+"681 254 CURVE SMOOTH",
+"681 209 OFFCURVE",
+"662 175 OFFCURVE",
+"621 145 CURVE",
+"632 67 LINE",
+"687 47 OFFCURVE",
+"708 21 OFFCURVE",
+"708 -34 CURVE SMOOTH",
+"708 -85 OFFCURVE",
+"685 -118 OFFCURVE",
+"635 -149 CURVE",
+"674 -203 LINE",
+"749 -152 OFFCURVE",
+"780 -103 OFFCURVE",
+"780 -36 CURVE SMOOTH",
+"780 33 OFFCURVE",
+"744 87 OFFCURVE",
+"678 111 CURVE",
+"678 115 LINE",
+"720 149 OFFCURVE",
+"753 201 OFFCURVE",
+"753 254 CURVE SMOOTH",
+"753 310 OFFCURVE",
+"734 359 OFFCURVE",
+"671 419 CURVE",
+"600 419 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"548 110 OFFCURVE",
+"571 127 OFFCURVE",
+"571 166 CURVE SMOOTH",
+"571 205 OFFCURVE",
+"548 222 OFFCURVE",
+"520 222 CURVE SMOOTH",
+"491 222 OFFCURVE",
+"468 205 OFFCURVE",
+"468 166 CURVE SMOOTH",
+"468 127 OFFCURVE",
+"491 110 OFFCURVE",
+"520 110 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"569 -89 OFFCURVE",
+"592 -72 OFFCURVE",
+"592 -33 CURVE SMOOTH",
+"592 6 OFFCURVE",
+"569 23 OFFCURVE",
+"541 23 CURVE SMOOTH",
+"512 23 OFFCURVE",
+"489 6 OFFCURVE",
+"489 -33 CURVE SMOOTH",
+"489 -72 OFFCURVE",
+"512 -89 OFFCURVE",
+"541 -89 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"550 437 OFFCURVE",
+"572 453 OFFCURVE",
+"572 491 CURVE SMOOTH",
+"572 528 OFFCURVE",
+"550 544 OFFCURVE",
+"523 544 CURVE SMOOTH",
+"495 544 OFFCURVE",
+"473 528 OFFCURVE",
+"473 491 CURVE SMOOTH",
+"473 453 OFFCURVE",
+"495 437 OFFCURVE",
+"523 437 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"356 328 OFFCURVE",
+"378 344 OFFCURVE",
+"378 381 CURVE SMOOTH",
+"378 419 OFFCURVE",
+"356 435 OFFCURVE",
+"329 435 CURVE SMOOTH",
+"301 435 OFFCURVE",
+"279 419 OFFCURVE",
+"279 381 CURVE SMOOTH",
+"279 344 OFFCURVE",
+"301 328 OFFCURVE",
+"329 328 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"528 939 LINE",
+"445 880 OFFCURVE",
+"374 833 OFFCURVE",
+"304 792 CURVE",
+"282 783 LINE",
+"221 747 OFFCURVE",
+"159 714 OFFCURVE",
+"88 678 CURVE",
+"119 613 LINE",
+"189 649 OFFCURVE",
+"251 682 OFFCURVE",
+"313 718 CURVE",
+"341 730 LINE",
+"412 772 OFFCURVE",
+"484 820 OFFCURVE",
+"572 882 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"547 714 LINE",
+"431 636 OFFCURVE",
+"292 556 OFFCURVE",
+"172 496 CURVE",
+"204 431 LINE",
+"336 498 OFFCURVE",
+"457 569 OFFCURVE",
+"587 654 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"201 896 LINE",
+"277 747 OFFCURVE",
+"320 656 OFFCURVE",
+"356 541 CURVE",
+"417 585 LINE",
+"378 704 OFFCURVE",
+"340 788 OFFCURVE",
+"267 928 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"172 46 LINE",
+"200 46 LINE",
+"224 -8 OFFCURVE",
+"256 -83 OFFCURVE",
+"287 -169 CURVE",
+"353 -143 LINE",
+"317 -55 OFFCURVE",
+"270 40 OFFCURVE",
+"216 120 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"156 179 LINE",
+"133 34 OFFCURVE",
+"115 -48 OFFCURVE",
+"70 -182 CURVE",
+"137 -203 LINE",
+"167 -113 OFFCURVE",
+"182 -42 OFFCURVE",
+"196 46 CURVE",
+"213 92 LINE",
+"217 116 OFFCURVE",
+"221 142 OFFCURVE",
+"224 169 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 910;
+}
+);
+leftMetricsKey = u1B1B9;
+rightMetricsKey = u1B2DC;
+unicode = 1B2F0;
+},
+{
+glyphname = u1B2F1;
+lastChange = "2020-04-13 09:42:24 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"345 624 LINE",
+"388 458 OFFCURVE",
+"406 305 OFFCURVE",
+"406 179 CURVE SMOOTH",
+"406 18 OFFCURVE",
+"396 -73 OFFCURVE",
+"355 -187 CURVE",
+"421 -203 LINE",
+"465 -88 OFFCURVE",
+"476 8 OFFCURVE",
+"476 178 CURVE SMOOTH",
+"476 320 OFFCURVE",
+"455 477 OFFCURVE",
+"413 639 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"509 -155 OFFCURVE",
+"555 -197 OFFCURVE",
+"668 -197 CURVE",
+"710 -168 LINE",
+"713 -131 OFFCURVE",
+"714 -103 OFFCURVE",
+"714 -85 CURVE SMOOTH",
+"714 -1 OFFCURVE",
+"671 28 OFFCURVE",
+"547 30 CURVE",
+"515 0 LINE",
+"511 -31 OFFCURVE",
+"509 -56 OFFCURVE",
+"509 -78 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"567 -24 LINE",
+"649 -24 OFFCURVE",
+"667 -51 OFFCURVE",
+"660 -141 CURVE",
+"657 -144 LINE",
+"582 -141 OFFCURVE",
+"558 -117 OFFCURVE",
+"564 -27 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"158 116 OFFCURVE",
+"108 51 OFFCURVE",
+"108 -1 CURVE SMOOTH",
+"108 -36 OFFCURVE",
+"117 -67 OFFCURVE",
+"145 -116 CURVE",
+"202 -129 LINE",
+"308 -68 OFFCURVE",
+"358 -9 OFFCURVE",
+"358 52 CURVE SMOOTH",
+"358 84 OFFCURVE",
+"351 113 OFFCURVE",
+"326 161 CURVE",
+"275 174 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"285 118 LINE",
+"293 98 OFFCURVE",
+"296 82 OFFCURVE",
+"296 58 CURVE SMOOTH",
+"296 18 OFFCURVE",
+"269 -25 OFFCURVE",
+"189 -75 CURVE",
+"185 -74 LINE",
+"176 -47 OFFCURVE",
+"173 -31 OFFCURVE",
+"173 -8 CURVE SMOOTH",
+"173 26 OFFCURVE",
+"195 63 OFFCURVE",
+"281 119 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"536 105 OFFCURVE",
+"592 63 OFFCURVE",
+"644 63 CURVE SMOOTH",
+"669 63 OFFCURVE",
+"690 68 OFFCURVE",
+"736 93 CURVE",
+"760 139 LINE",
+"737 239 OFFCURVE",
+"704 299 OFFCURVE",
+"634 299 CURVE SMOOTH",
+"603 299 OFFCURVE",
+"574 292 OFFCURVE",
+"533 271 CURVE",
+"513 234 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"572 230 LINE",
+"586 234 OFFCURVE",
+"601 237 OFFCURVE",
+"618 237 CURVE SMOOTH",
+"666 237 OFFCURVE",
+"688 218 OFFCURVE",
+"703 140 CURVE",
+"701 136 LINE",
+"685 131 OFFCURVE",
+"669 129 OFFCURVE",
+"654 129 CURVE SMOOTH",
+"604 129 OFFCURVE",
+"583 152 OFFCURVE",
+"570 226 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"525 372 OFFCURVE",
+"577 339 OFFCURVE",
+"621 339 CURVE SMOOTH",
+"648 339 OFFCURVE",
+"677 351 OFFCURVE",
+"721 389 CURVE",
+"735 445 LINE",
+"692 529 OFFCURVE",
+"646 572 OFFCURVE",
+"600 572 CURVE SMOOTH",
+"570 572 OFFCURVE",
+"530 552 OFFCURVE",
+"490 520 CURVE",
+"480 476 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"536 488 LINE",
+"553 499 OFFCURVE",
+"574 509 OFFCURVE",
+"596 509 CURVE SMOOTH",
+"625 509 OFFCURVE",
+"653 492 OFFCURVE",
+"680 430 CURVE",
+"679 426 LINE",
+"659 407 OFFCURVE",
+"640 400 OFFCURVE",
+"625 400 CURVE SMOOTH",
+"592 400 OFFCURVE",
+"573 417 OFFCURVE",
+"535 484 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"136 416 OFFCURVE",
+"92 350 OFFCURVE",
+"92 299 CURVE SMOOTH",
+"92 271 OFFCURVE",
+"101 239 OFFCURVE",
+"122 197 CURVE",
+"176 181 LINE",
+"301 237 OFFCURVE",
+"346 283 OFFCURVE",
+"346 350 CURVE SMOOTH",
+"346 383 OFFCURVE",
+"342 411 OFFCURVE",
+"324 463 CURVE",
+"275 481 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"273 417 LINE",
+"279 401 OFFCURVE",
+"282 384 OFFCURVE",
+"282 365 CURVE SMOOTH",
+"282 318 OFFCURVE",
+"255 283 OFFCURVE",
+"171 238 CURVE",
+"166 239 LINE",
+"160 258 OFFCURVE",
+"157 278 OFFCURVE",
+"157 296 CURVE SMOOTH",
+"157 332 OFFCURVE",
+"178 365 OFFCURVE",
+"268 418 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"379 939 LINE",
+"279 746 OFFCURVE",
+"206 655 OFFCURVE",
+"80 540 CURVE",
+"129 487 LINE",
+"261 607 OFFCURVE",
+"346 711 OFFCURVE",
+"446 907 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"353 798 LINE",
+"476 734 OFFCURVE",
+"623 649 OFFCURVE",
+"734 561 CURVE",
+"778 619 LINE",
+"651 720 OFFCURVE",
+"524 788 OFFCURVE",
+"386 857 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 868;
+}
+);
+leftMetricsKey = u1B185;
+rightMetricsKey = u1B185;
+unicode = 1B2F1;
+},
+{
+glyphname = u1B2F2;
+lastChange = "2020-04-13 09:42:21 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"552 433 LINE",
+"542 491 OFFCURVE",
+"522 554 OFFCURVE",
+"512 587 CURVE SMOOTH",
+"490 656 OFFCURVE",
+"467 723 OFFCURVE",
+"437 791 CURVE",
+"424 726 LINE",
+"489 777 OFFCURVE",
+"555 822 OFFCURVE",
+"648 880 CURVE",
+"606 939 LINE",
+"521 883 OFFCURVE",
+"446 832 OFFCURVE",
+"367 769 CURVE",
+"425 653 OFFCURVE",
+"465 512 OFFCURVE",
+"499 382 CURVE",
+"567 366 LINE",
+"625 408 OFFCURVE",
+"690 448 OFFCURVE",
+"764 489 CURVE",
+"731 549 LINE",
+"714 539 OFFCURVE",
+"697 529 OFFCURVE",
+"680 519 CURVE SMOOTH",
+"639 495 OFFCURVE",
+"594 462 OFFCURVE",
+"557 432 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"494 540 LINE",
+"572 597 OFFCURVE",
+"626 632 OFFCURVE",
+"708 683 CURVE",
+"669 741 LINE",
+"595 696 OFFCURVE",
+"542 661 OFFCURVE",
+"473 612 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"285 640 LINE",
+"303 588 OFFCURVE",
+"323 524 OFFCURVE",
+"336 481 CURVE SMOOTH",
+"356 416 OFFCURVE",
+"373 351 OFFCURVE",
+"390 279 CURVE",
+"412 355 LINE",
+"326 293 OFFCURVE",
+"280 255 OFFCURVE",
+"197 191 CURVE",
+"240 136 LINE",
+"326 206 OFFCURVE",
+"379 248 OFFCURVE",
+"456 303 CURVE",
+"423 448 OFFCURVE",
+"385 569 OFFCURVE",
+"335 694 CURVE",
+"265 706 LINE",
+"196 660 OFFCURVE",
+"149 629 OFFCURVE",
+"80 576 CURVE",
+"121 520 LINE",
+"137 532 OFFCURVE",
+"152 543 OFFCURVE",
+"166 553 CURVE SMOOTH",
+"213 586 OFFCURVE",
+"238 606 OFFCURVE",
+"281 640 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"333 525 LINE",
+"258 471 OFFCURVE",
+"213 439 OFFCURVE",
+"132 378 CURVE",
+"171 321 LINE",
+"243 370 OFFCURVE",
+"297 416 OFFCURVE",
+"359 458 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"822 121 OFFCURVE",
+"776 236 OFFCURVE",
+"729 350 CURVE",
+"654 365 LINE",
+"556 289 OFFCURVE",
+"473 235 OFFCURVE",
+"363 168 CURVE",
+"415 40 OFFCURVE",
+"451 -77 OFFCURVE",
+"478 -183 CURVE",
+"552 -203 LINE",
+"659 -145 OFFCURVE",
+"746 -87 OFFCURVE",
+"853 -10 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"787 31 LINE",
+"747 1 OFFCURVE",
+"709 -26 OFFCURVE",
+"672 -50 CURVE SMOOTH",
+"616 -87 OFFCURVE",
+"584 -109 OFFCURVE",
+"539 -138 CURVE",
+"535 -138 LINE",
+"524 -74 OFFCURVE",
+"506 -17 OFFCURVE",
+"488 41 CURVE SMOOTH",
+"471 95 OFFCURVE",
+"452 148 OFFCURVE",
+"431 203 CURVE",
+"431 128 LINE",
+"483 159 OFFCURVE",
+"530 190 OFFCURVE",
+"578 223 CURVE SMOOTH",
+"620 252 OFFCURVE",
+"638 268 OFFCURVE",
+"673 298 CURVE",
+"677 298 LINE",
+"690 255 OFFCURVE",
+"708 206 OFFCURVE",
+"719 176 CURVE SMOOTH",
+"744 107 OFFCURVE",
+"765 42 OFFCURVE",
+"780 -29 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"723 199 LINE",
+"632 130 OFFCURVE",
+"562 85 OFFCURVE",
+"450 18 CURVE",
+"484 -43 LINE",
+"598 24 OFFCURVE",
+"670 72 OFFCURVE",
+"760 137 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 943;
+}
+);
+leftMetricsKey = u1B246;
+rightMetricsKey = u1B246;
+unicode = 1B2F2;
+},
+{
+glyphname = u1B2F3;
+lastChange = "2020-04-12 09:16:45 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"150 367 OFFCURVE",
+"173 384 OFFCURVE",
+"173 423 CURVE SMOOTH",
+"173 462 OFFCURVE",
+"150 479 OFFCURVE",
+"122 479 CURVE SMOOTH",
+"93 479 OFFCURVE",
+"70 462 OFFCURVE",
+"70 423 CURVE SMOOTH",
+"70 384 OFFCURVE",
+"93 367 OFFCURVE",
+"122 367 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"205 138 OFFCURVE",
+"228 155 OFFCURVE",
+"228 194 CURVE SMOOTH",
+"228 233 OFFCURVE",
+"205 250 OFFCURVE",
+"177 250 CURVE SMOOTH",
+"148 250 OFFCURVE",
+"125 233 OFFCURVE",
+"125 194 CURVE SMOOTH",
+"125 155 OFFCURVE",
+"148 138 OFFCURVE",
+"177 138 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"259 -93 OFFCURVE",
+"282 -76 OFFCURVE",
+"282 -37 CURVE SMOOTH",
+"282 2 OFFCURVE",
+"259 19 OFFCURVE",
+"231 19 CURVE SMOOTH",
+"202 19 OFFCURVE",
+"179 2 OFFCURVE",
+"179 -37 CURVE SMOOTH",
+"179 -76 OFFCURVE",
+"202 -93 OFFCURVE",
+"231 -93 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"791 169 OFFCURVE",
+"739 320 OFFCURVE",
+"692 430 CURVE",
+"612 443 LINE",
+"519 352 OFFCURVE",
+"425 275 OFFCURVE",
+"329 203 CURVE",
+"381 75 OFFCURVE",
+"423 -77 OFFCURVE",
+"446 -174 CURVE",
+"530 -198 LINE",
+"623 -135 OFFCURVE",
+"735 -44 OFFCURVE",
+"822 38 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"756 77 LINE",
+"722 44 OFFCURVE",
+"686 12 OFFCURVE",
+"649 -18 CURVE SMOOTH",
+"591 -65 OFFCURVE",
+"556 -95 OFFCURVE",
+"511 -131 CURVE",
+"507 -131 LINE",
+"495 -68 OFFCURVE",
+"477 -8 OFFCURVE",
+"457 57 CURVE SMOOTH",
+"439 115 OFFCURVE",
+"419 173 OFFCURVE",
+"399 227 CURVE",
+"397 165 LINE",
+"437 194 OFFCURVE",
+"477 226 OFFCURVE",
+"518 260 CURVE SMOOTH",
+"567 301 OFFCURVE",
+"585 321 OFFCURVE",
+"637 370 CURVE",
+"641 370 LINE",
+"662 311 OFFCURVE",
+"679 263 OFFCURVE",
+"698 207 CURVE SMOOTH",
+"720 143 OFFCURVE",
+"738 79 OFFCURVE",
+"751 19 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"692 274 LINE",
+"606 184 OFFCURVE",
+"510 103 OFFCURVE",
+"406 26 CURVE",
+"440 -33 LINE",
+"546 44 OFFCURVE",
+"644 124 OFFCURVE",
+"729 210 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"510 787 LINE",
+"438 711 OFFCURVE",
+"350 633 OFFCURVE",
+"271 572 CURVE",
+"300 505 LINE",
+"392 577 OFFCURVE",
+"485 661 OFFCURVE",
+"553 726 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"402 940 LINE",
+"337 870 OFFCURVE",
+"259 798 OFFCURVE",
+"144 702 CURVE",
+"210 574 OFFCURVE",
+"258 467 OFFCURVE",
+"302 357 CURVE",
+"383 343 LINE",
+"475 407 OFFCURVE",
+"566 484 OFFCURVE",
+"661 571 CURVE",
+"604 708 OFFCURVE",
+"552 811 OFFCURVE",
+"490 932 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"440 872 LINE",
+"467 818 OFFCURVE",
+"489 774 OFFCURVE",
+"511 726 CURVE SMOOTH",
+"541 661 OFFCURVE",
+"568 601 OFFCURVE",
+"591 543 CURVE",
+"593 608 LINE",
+"556 573 OFFCURVE",
+"521 542 OFFCURVE",
+"488 514 CURVE SMOOTH",
+"435 469 OFFCURVE",
+"403 446 OFFCURVE",
+"360 409 CURVE",
+"356 409 LINE",
+"339 460 OFFCURVE",
+"319 507 OFFCURVE",
+"291 569 CURVE SMOOTH",
+"270 615 OFFCURVE",
+"245 666 OFFCURVE",
+"214 727 CURVE",
+"214 666 LINE",
+"256 702 OFFCURVE",
+"290 732 OFFCURVE",
+"322 761 CURVE SMOOTH",
+"368 802 OFFCURVE",
+"393 826 OFFCURVE",
+"436 872 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 912;
+}
+);
+leftMetricsKey = u1B29F;
+rightMetricsKey = u1B2EC;
+unicode = 1B2F3;
+},
+{
+glyphname = u1B2F4;
+lastChange = "2020-04-13 09:42:16 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"835 631 LINE",
+"766 532 OFFCURVE",
+"707 458 OFFCURVE",
+"638 389 CURVE",
+"680 332 LINE",
+"752 404 OFFCURVE",
+"817 484 OFFCURVE",
+"873 559 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"452 796 LINE",
+"566 534 OFFCURVE",
+"613 362 OFFCURVE",
+"663 169 CURVE",
+"747 152 LINE",
+"821 220 OFFCURVE",
+"892 306 OFFCURVE",
+"959 394 CURVE",
+"925 546 OFFCURVE",
+"878 698 OFFCURVE",
+"819 850 CURVE",
+"764 793 LINE",
+"818 642 OFFCURVE",
+"860 517 OFFCURVE",
+"892 364 CURVE",
+"896 432 LINE",
+"874 401 OFFCURVE",
+"855 374 OFFCURVE",
+"835 349 CURVE SMOOTH",
+"793 297 OFFCURVE",
+"764 263 OFFCURVE",
+"722 213 CURVE",
+"718 213 LINE",
+"707 280 OFFCURVE",
+"690 335 OFFCURVE",
+"673 395 CURVE SMOOTH",
+"635 526 OFFCURVE",
+"589 664 OFFCURVE",
+"517 825 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"609 496 LINE",
+"715 623 OFFCURVE",
+"800 739 OFFCURVE",
+"892 911 CURVE",
+"827 939 LINE",
+"749 795 OFFCURVE",
+"684 705 OFFCURVE",
+"600 600 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"455 531 OFFCURVE",
+"478 548 OFFCURVE",
+"478 587 CURVE SMOOTH",
+"478 626 OFFCURVE",
+"455 643 OFFCURVE",
+"427 643 CURVE SMOOTH",
+"398 643 OFFCURVE",
+"375 626 OFFCURVE",
+"375 587 CURVE SMOOTH",
+"375 548 OFFCURVE",
+"398 531 OFFCURVE",
+"427 531 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"677 807 OFFCURVE",
+"700 824 OFFCURVE",
+"700 863 CURVE SMOOTH",
+"700 902 OFFCURVE",
+"677 919 OFFCURVE",
+"649 919 CURVE SMOOTH",
+"620 919 OFFCURVE",
+"597 902 OFFCURVE",
+"597 863 CURVE SMOOTH",
+"597 824 OFFCURVE",
+"620 807 OFFCURVE",
+"649 807 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"511 222 LINE",
+"448 147 OFFCURVE",
+"397 103 OFFCURVE",
+"307 23 CURVE",
+"353 -27 LINE",
+"431 37 OFFCURVE",
+"495 97 OFFCURVE",
+"553 160 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"144 394 LINE",
+"235 184 OFFCURVE",
+"289 13 OFFCURVE",
+"339 -186 CURVE",
+"423 -203 LINE",
+"499 -144 OFFCURVE",
+"564 -88 OFFCURVE",
+"638 -9 CURVE",
+"603 134 OFFCURVE",
+"571 248 OFFCURVE",
+"515 388 CURVE",
+"459 345 LINE",
+"505 212 OFFCURVE",
+"539 100 OFFCURVE",
+"571 -35 CURVE",
+"579 33 LINE",
+"553 4 OFFCURVE",
+"528 -22 OFFCURVE",
+"502 -45 CURVE SMOOTH",
+"461 -82 OFFCURVE",
+"435 -106 OFFCURVE",
+"400 -141 CURVE",
+"396 -141 LINE",
+"387 -83 OFFCURVE",
+"372 -31 OFFCURVE",
+"356 23 CURVE SMOOTH",
+"316 159 OFFCURVE",
+"271 293 OFFCURVE",
+"212 424 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"301 145 LINE",
+"400 239 OFFCURVE",
+"485 331 OFFCURVE",
+"563 442 CURVE",
+"505 481 LINE",
+"426 371 OFFCURVE",
+"361 299 OFFCURVE",
+"273 220 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"160 60 OFFCURVE",
+"183 77 OFFCURVE",
+"183 116 CURVE SMOOTH",
+"183 155 OFFCURVE",
+"160 172 OFFCURVE",
+"132 172 CURVE SMOOTH",
+"103 172 OFFCURVE",
+"80 155 OFFCURVE",
+"80 116 CURVE SMOOTH",
+"80 77 OFFCURVE",
+"103 60 OFFCURVE",
+"132 60 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"361 391 OFFCURVE",
+"383 407 OFFCURVE",
+"383 444 CURVE SMOOTH",
+"383 481 OFFCURVE",
+"361 497 OFFCURVE",
+"334 497 CURVE SMOOTH",
+"306 497 OFFCURVE",
+"284 481 OFFCURVE",
+"284 444 CURVE SMOOTH",
+"284 407 OFFCURVE",
+"306 391 OFFCURVE",
+"334 391 CURVE SMOOTH"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 1049;
+}
+);
+leftMetricsKey = u1B23E;
+rightMetricsKey = u1B23E;
+unicode = 1B2F4;
+},
+{
+glyphname = u1B2F5;
+lastChange = "2020-04-13 09:42:11 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"399 -194 LINE",
+"495 -109 OFFCURVE",
+"559 -49 OFFCURVE",
+"646 62 CURVE",
+"589 105 LINE",
+"559 67 OFFCURVE",
+"531 33 OFFCURVE",
+"502 1 CURVE SMOOTH",
+"457 -49 OFFCURVE",
+"415 -94 OFFCURVE",
+"376 -131 CURVE",
+"372 -130 LINE",
+"355 -66 OFFCURVE",
+"339 -13 OFFCURVE",
+"318 44 CURVE SMOOTH",
+"269 179 OFFCURVE",
+"215 300 OFFCURVE",
+"155 430 CURVE",
+"163 367 LINE",
+"186 388 OFFCURVE",
+"207 408 OFFCURVE",
+"226 428 CURVE SMOOTH",
+"243 446 OFFCURVE",
+"269 478 OFFCURVE",
+"303 524 CURVE",
+"307 524 LINE",
+"331 473 OFFCURVE",
+"348 436 OFFCURVE",
+"370 386 CURVE SMOOTH",
+"398 322 OFFCURVE",
+"424 257 OFFCURVE",
+"452 177 CURVE",
+"449 290 LINE",
+"393 217 OFFCURVE",
+"330 163 OFFCURVE",
+"272 114 CURVE",
+"299 33 LINE",
+"360 83 OFFCURVE",
+"439 151 OFFCURVE",
+"509 231 CURVE",
+"467 350 OFFCURVE",
+"410 473 OFFCURVE",
+"353 587 CURVE",
+"277 596 LINE",
+"219 519 OFFCURVE",
+"166 464 OFFCURVE",
+"90 393 CURVE",
+"188 185 OFFCURVE",
+"260 12 OFFCURVE",
+"314 -172 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"370 433 LINE",
+"312 366 OFFCURVE",
+"263 315 OFFCURVE",
+"204 264 CURVE",
+"233 204 LINE",
+"300 263 OFFCURVE",
+"361 325 OFFCURVE",
+"407 375 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"433 48 OFFCURVE",
+"458 3 OFFCURVE",
+"481 -45 CURVE",
+"500 -74 LINE",
+"516 -110 OFFCURVE",
+"532 -147 OFFCURVE",
+"548 -189 CURVE",
+"614 -163 LINE",
+"592 -109 OFFCURVE",
+"572 -63 OFFCURVE",
+"552 -22 CURVE",
+"532 7 LINE",
+"511 48 OFFCURVE",
+"489 88 OFFCURVE",
+"463 131 CURVE",
+"407 93 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"677 120 LINE",
+"784 224 OFFCURVE",
+"853 299 OFFCURVE",
+"924 400 CURVE",
+"866 441 LINE",
+"837 400 OFFCURVE",
+"807 360 OFFCURVE",
+"775 321 CURVE SMOOTH",
+"734 272 OFFCURVE",
+"690 226 OFFCURVE",
+"654 185 CURVE",
+"650 185 LINE",
+"636 241 OFFCURVE",
+"620 297 OFFCURVE",
+"599 353 CURVE SMOOTH",
+"549 489 OFFCURVE",
+"487 626 OFFCURVE",
+"411 770 CURVE",
+"429 704 LINE",
+"450 723 OFFCURVE",
+"469 744 OFFCURVE",
+"487 763 CURVE SMOOTH",
+"514 792 OFFCURVE",
+"533 816 OFFCURVE",
+"561 855 CURVE",
+"565 855 LINE",
+"591 805 OFFCURVE",
+"613 759 OFFCURVE",
+"637 714 CURVE SMOOTH",
+"670 652 OFFCURVE",
+"699 593 OFFCURVE",
+"727 531 CURVE",
+"719 630 LINE",
+"656 556 OFFCURVE",
+"604 507 OFFCURVE",
+"541 453 CURVE",
+"573 372 LINE",
+"660 449 OFFCURVE",
+"723 509 OFFCURVE",
+"784 583 CURVE",
+"730 694 OFFCURVE",
+"666 816 OFFCURVE",
+"612 911 CURVE",
+"529 921 LINE",
+"473 849 OFFCURVE",
+"421 792 OFFCURVE",
+"350 724 CURVE",
+"467 517 OFFCURVE",
+"529 372 OFFCURVE",
+"598 139 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"623 758 LINE",
+"577 703 OFFCURVE",
+"527 649 OFFCURVE",
+"475 601 CURVE",
+"516 554 LINE",
+"571 602 OFFCURVE",
+"626 661 OFFCURVE",
+"674 716 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"716 373 OFFCURVE",
+"741 324 OFFCURVE",
+"763 279 CURVE",
+"779 255 LINE",
+"803 202 OFFCURVE",
+"822 154 OFFCURVE",
+"838 108 CURVE",
+"907 130 LINE",
+"883 194 OFFCURVE",
+"858 252 OFFCURVE",
+"830 309 CURVE",
+"812 335 LINE",
+"792 376 OFFCURVE",
+"770 417 OFFCURVE",
+"745 460 CURVE",
+"687 425 LINE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 1004;
+}
+);
+leftMetricsKey = u1B274;
+rightMetricsKey = u1B274;
+unicode = 1B2F5;
+},
+{
+glyphname = u1B2F6;
+lastChange = "2020-04-13 09:41:42 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"273 543 LINE",
+"370 571 OFFCURVE",
+"461 599 OFFCURVE",
+"556 634 CURVE",
+"528 634 LINE",
+"544 590 OFFCURVE",
+"553 556 OFFCURVE",
+"567 502 CURVE",
+"574 541 LINE",
+"531 526 OFFCURVE",
+"489 513 OFFCURVE",
+"447 500 CURVE",
+"417 494 LINE",
+"377 482 OFFCURVE",
+"336 471 OFFCURVE",
+"292 460 CURVE",
+"316 458 LINE",
+"307 504 OFFCURVE",
+"298 541 OFFCURVE",
+"284 589 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"308 276 LINE",
+"353 288 OFFCURVE",
+"405 302 OFFCURVE",
+"460 318 CURVE",
+"490 324 LINE",
+"546 341 OFFCURVE",
+"582 354 OFFCURVE",
+"628 368 CURVE",
+"631 365 LINE",
+"635 332 OFFCURVE",
+"638 287 OFFCURVE",
+"642 260 CURVE SMOOTH",
+"649 212 OFFCURVE",
+"653 166 OFFCURVE",
+"656 115 CURVE",
+"683 163 LINE",
+"627 144 OFFCURVE",
+"575 127 OFFCURVE",
+"520 112 CURVE",
+"480 104 LINE",
+"430 91 OFFCURVE",
+"384 79 OFFCURVE",
+"339 65 CURVE",
+"336 68 LINE",
+"336 106 OFFCURVE",
+"336 151 OFFCURVE",
+"332 188 CURVE SMOOTH",
+"328 225 OFFCURVE",
+"323 262 OFFCURVE",
+"318 299 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"672 302 LINE",
+"618 283 OFFCURVE",
+"561 264 OFFCURVE",
+"504 247 CURVE",
+"471 240 LINE",
+"415 224 OFFCURVE",
+"359 209 OFFCURVE",
+"306 197 CURVE",
+"316 143 LINE",
+"365 155 OFFCURVE",
+"420 170 OFFCURVE",
+"476 186 CURVE",
+"506 191 LINE",
+"570 210 OFFCURVE",
+"635 231 OFFCURVE",
+"697 253 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"261 214 OFFCURVE",
+"270 123 OFFCURVE",
+"275 35 CURVE",
+"335 4 LINE",
+"381 16 OFFCURVE",
+"433 28 OFFCURVE",
+"483 41 CURVE",
+"511 45 LINE",
+"584 65 OFFCURVE",
+"653 86 OFFCURVE",
+"724 112 CURVE",
+"717 220 OFFCURVE",
+"706 303 OFFCURVE",
+"686 407 CURVE",
+"632 431 LINE",
+"579 413 OFFCURVE",
+"528 397 OFFCURVE",
+"478 381 CURVE",
+"448 375 LINE",
+"384 356 OFFCURVE",
+"319 338 OFFCURVE",
+"247 321 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"240 519 OFFCURVE",
+"248 477 OFFCURVE",
+"256 431 CURVE",
+"318 409 LINE",
+"349 417 OFFCURVE",
+"391 428 OFFCURVE",
+"434 441 CURVE",
+"467 448 LINE",
+"520 465 OFFCURVE",
+"572 483 OFFCURVE",
+"628 505 CURVE",
+"614 570 OFFCURVE",
+"602 615 OFFCURVE",
+"581 665 CURVE",
+"526 683 LINE",
+"423 645 OFFCURVE",
+"328 616 OFFCURVE",
+"225 584 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"344 -162 OFFCURVE",
+"367 -145 OFFCURVE",
+"367 -106 CURVE SMOOTH",
+"367 -67 OFFCURVE",
+"344 -50 OFFCURVE",
+"316 -50 CURVE SMOOTH",
+"287 -50 OFFCURVE",
+"264 -67 OFFCURVE",
+"264 -106 CURVE SMOOTH",
+"264 -145 OFFCURVE",
+"287 -162 OFFCURVE",
+"316 -162 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"705 -105 OFFCURVE",
+"728 -88 OFFCURVE",
+"728 -49 CURVE SMOOTH",
+"728 -10 OFFCURVE",
+"705 7 OFFCURVE",
+"677 7 CURVE SMOOTH",
+"648 7 OFFCURVE",
+"625 -10 OFFCURVE",
+"625 -49 CURVE SMOOTH",
+"625 -88 OFFCURVE",
+"648 -105 OFFCURVE",
+"677 -105 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"375 939 LINE",
+"292 792 OFFCURVE",
+"209 707 OFFCURVE",
+"80 600 CURVE",
+"122 547 LINE",
+"257 659 OFFCURVE",
+"352 756 OFFCURVE",
+"438 909 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"358 813 LINE",
+"498 758 OFFCURVE",
+"628 692 OFFCURVE",
+"747 603 CURVE",
+"785 661 LINE",
+"645 759 OFFCURVE",
+"539 809 OFFCURVE",
+"390 873 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"386 585 LINE",
+"439 411 OFFCURVE",
+"464 260 OFFCURVE",
+"470 95 CURVE",
+"467 56 LINE",
+"468 38 OFFCURVE",
+"468 18 OFFCURVE",
+"468 -1 CURVE SMOOTH",
+"468 -60 OFFCURVE",
+"464 -126 OFFCURVE",
+"455 -196 CURVE",
+"521 -203 LINE",
+"529 -133 OFFCURVE",
+"534 -73 OFFCURVE",
+"534 2 CURVE SMOOTH",
+"534 25 OFFCURVE",
+"534 46 OFFCURVE",
+"533 68 CURVE",
+"526 109 LINE",
+"517 278 OFFCURVE",
+"493 431 OFFCURVE",
+"432 622 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 875;
+}
+);
+leftMetricsKey = u1B185;
+rightMetricsKey = u1B185;
+unicode = 1B2F6;
+},
+{
+glyphname = u1B2F7;
+lastChange = "2020-04-13 09:41:39 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"936 220 OFFCURVE",
+"894 348 OFFCURVE",
+"847 460 CURVE",
+"772 477 LINE",
+"665 391 OFFCURVE",
+"597 344 OFFCURVE",
+"494 279 CURVE",
+"546 151 OFFCURVE",
+"577 32 OFFCURVE",
+"604 -72 CURVE",
+"679 -94 LINE",
+"782 -38 OFFCURVE",
+"871 20 OFFCURVE",
+"967 89 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"901 130 LINE",
+"864 102 OFFCURVE",
+"827 77 OFFCURVE",
+"789 52 CURVE SMOOTH",
+"738 18 OFFCURVE",
+"706 -6 OFFCURVE",
+"667 -31 CURVE",
+"662 -30 LINE",
+"652 30 OFFCURVE",
+"636 82 OFFCURVE",
+"620 136 CURVE SMOOTH",
+"604 190 OFFCURVE",
+"586 243 OFFCURVE",
+"564 300 CURVE",
+"562 240 LINE",
+"604 267 OFFCURVE",
+"641 291 OFFCURVE",
+"679 318 CURVE SMOOTH",
+"722 349 OFFCURVE",
+"748 372 OFFCURVE",
+"793 411 CURVE",
+"798 410 LINE",
+"813 356 OFFCURVE",
+"829 305 OFFCURVE",
+"845 257 CURVE SMOOTH",
+"865 196 OFFCURVE",
+"882 137 OFFCURVE",
+"895 74 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"847 314 LINE",
+"760 242 OFFCURVE",
+"685 191 OFFCURVE",
+"571 120 CURVE",
+"605 62 LINE",
+"718 128 OFFCURVE",
+"797 184 OFFCURVE",
+"884 251 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"669 777 LINE",
+"587 704 OFFCURVE",
+"507 645 OFFCURVE",
+"430 592 CURVE",
+"455 524 LINE",
+"545 586 OFFCURVE",
+"630 650 OFFCURVE",
+"708 715 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"591 939 LINE",
+"505 866 OFFCURVE",
+"426 802 OFFCURVE",
+"322 725 CURVE",
+"388 597 OFFCURVE",
+"426 504 OFFCURVE",
+"468 392 CURVE",
+"547 374 LINE",
+"638 433 OFFCURVE",
+"724 497 OFFCURVE",
+"826 584 CURVE",
+"769 721 OFFCURVE",
+"731 804 OFFCURVE",
+"667 925 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"618 873 LINE",
+"640 824 OFFCURVE",
+"661 778 OFFCURVE",
+"681 735 CURVE SMOOTH",
+"711 672 OFFCURVE",
+"733 618 OFFCURVE",
+"757 559 CURVE",
+"758 619 LINE",
+"715 582 OFFCURVE",
+"675 550 OFFCURVE",
+"636 521 CURVE SMOOTH",
+"591 487 OFFCURVE",
+"561 465 OFFCURVE",
+"527 440 CURVE",
+"522 441 LINE",
+"505 496 OFFCURVE",
+"482 554 OFFCURVE",
+"463 598 CURVE SMOOTH",
+"444 641 OFFCURVE",
+"421 690 OFFCURVE",
+"391 750 CURVE",
+"393 690 LINE",
+"436 723 OFFCURVE",
+"472 751 OFFCURVE",
+"507 779 CURVE SMOOTH",
+"547 811 OFFCURVE",
+"575 835 OFFCURVE",
+"613 874 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"271 -174 OFFCURVE",
+"293 -158 OFFCURVE",
+"293 -121 CURVE SMOOTH",
+"293 -84 OFFCURVE",
+"271 -68 OFFCURVE",
+"244 -68 CURVE SMOOTH",
+"216 -68 OFFCURVE",
+"194 -84 OFFCURVE",
+"194 -121 CURVE SMOOTH",
+"194 -158 OFFCURVE",
+"216 -174 OFFCURVE",
+"244 -174 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"521 -20 OFFCURVE",
+"543 -4 OFFCURVE",
+"543 33 CURVE SMOOTH",
+"543 70 OFFCURVE",
+"521 86 OFFCURVE",
+"494 86 CURVE SMOOTH",
+"466 86 OFFCURVE",
+"444 70 OFFCURVE",
+"444 33 CURVE SMOOTH",
+"444 -4 OFFCURVE",
+"466 -20 OFFCURVE",
+"494 -20 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"341 497 LINE",
+"238 364 OFFCURVE",
+"146 282 OFFCURVE",
+"50 202 CURVE",
+"94 148 LINE",
+"192 228 OFFCURVE",
+"296 323 OFFCURVE",
+"395 452 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"338 352 OFFCURVE",
+"360 318 OFFCURVE",
+"360 272 CURVE SMOOTH",
+"360 220 OFFCURVE",
+"330 168 OFFCURVE",
+"113 -1 CURVE",
+"157 -55 LINE",
+"402 136 OFFCURVE",
+"430 198 OFFCURVE",
+"430 272 CURVE SMOOTH",
+"430 326 OFFCURVE",
+"406 376 OFFCURVE",
+"335 450 CURVE",
+"290 394 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"294 75 LINE",
+"346 -26 OFFCURVE",
+"360 -89 OFFCURVE",
+"371 -203 CURVE",
+"445 -194 LINE",
+"430 -68 OFFCURVE",
+"407 12 OFFCURVE",
+"346 128 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 1057;
+}
+);
+leftMetricsKey = u1B2BD;
+rightMetricsKey = u1B2EC;
+unicode = 1B2F7;
+},
+{
+glyphname = u1B2F8;
+lastChange = "2020-04-13 09:41:37 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"748 509 LINE",
+"665 431 OFFCURVE",
+"594 380 OFFCURVE",
+"518 337 CURVE",
+"544 186 OFFCURVE",
+"553 99 OFFCURVE",
+"553 -27 CURVE",
+"621 -27 LINE",
+"621 111 OFFCURVE",
+"605 211 OFFCURVE",
+"584 328 CURVE",
+"557 281 LINE",
+"633 324 OFFCURVE",
+"702 366 OFFCURVE",
+"800 457 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"733 712 OFFCURVE",
+"703 814 OFFCURVE",
+"652 929 CURVE",
+"580 939 LINE",
+"509 863 OFFCURVE",
+"454 812 OFFCURVE",
+"379 750 CURVE",
+"426 627 OFFCURVE",
+"451 529 OFFCURVE",
+"473 435 CURVE",
+"547 421 LINE",
+"611 470 OFFCURVE",
+"689 527 OFFCURVE",
+"762 593 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"695 631 LINE",
+"666 603 OFFCURVE",
+"637 579 OFFCURVE",
+"610 556 CURVE SMOOTH",
+"586 536 OFFCURVE",
+"560 512 OFFCURVE",
+"529 484 CURVE",
+"524 485 LINE",
+"512 546 OFFCURVE",
+"502 596 OFFCURVE",
+"493 625 CURVE SMOOTH",
+"479 672 OFFCURVE",
+"462 723 OFFCURVE",
+"439 784 CURVE",
+"448 721 LINE",
+"478 745 OFFCURVE",
+"507 770 OFFCURVE",
+"535 795 CURVE SMOOTH",
+"559 817 OFFCURVE",
+"581 845 OFFCURVE",
+"603 874 CURVE",
+"607 874 LINE",
+"624 822 OFFCURVE",
+"638 779 OFFCURVE",
+"653 733 CURVE SMOOTH",
+"669 683 OFFCURVE",
+"682 633 OFFCURVE",
+"694 576 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"648 785 LINE",
+"584 723 OFFCURVE",
+"517 665 OFFCURVE",
+"453 617 CURVE",
+"476 565 LINE",
+"551 619 OFFCURVE",
+"616 674 OFFCURVE",
+"686 738 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"323 729 LINE",
+"256 659 OFFCURVE",
+"194 610 OFFCURVE",
+"120 557 CURVE",
+"149 419 OFFCURVE",
+"157 351 OFFCURVE",
+"163 235 CURVE",
+"231 241 LINE",
+"220 374 OFFCURVE",
+"211 441 OFFCURVE",
+"186 546 CURVE",
+"158 493 LINE",
+"235 551 OFFCURVE",
+"298 601 OFFCURVE",
+"375 680 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"423 339 LINE",
+"344 274 OFFCURVE",
+"282 230 OFFCURVE",
+"196 185 CURVE",
+"207 106 OFFCURVE",
+"208 82 OFFCURVE",
+"213 7 CURVE",
+"272 -20 LINE",
+"291 -10 OFFCURVE",
+"314 5 OFFCURVE",
+"331 18 CURVE SMOOTH",
+"368 47 OFFCURVE",
+"403 74 OFFCURVE",
+"430 102 CURVE",
+"434 100 LINE",
+"434 61 OFFCURVE",
+"432 33 OFFCURVE",
+"432 16 CURVE SMOOTH",
+"432 -7 OFFCURVE",
+"432 -31 OFFCURVE",
+"429 -58 CURVE",
+"458 0 LINE",
+"388 -60 OFFCURVE",
+"335 -89 OFFCURVE",
+"223 -144 CURVE",
+"253 -203 LINE",
+"365 -147 OFFCURVE",
+"422 -113 OFFCURVE",
+"493 -56 CURVE",
+"496 13 OFFCURVE",
+"496 58 OFFCURVE",
+"492 145 CURVE",
+"426 170 LINE",
+"398 146 OFFCURVE",
+"380 128 OFFCURVE",
+"366 117 CURVE SMOOTH",
+"338 94 OFFCURVE",
+"303 65 OFFCURVE",
+"272 41 CURVE",
+"268 43 LINE",
+"268 83 OFFCURVE",
+"268 116 OFFCURVE",
+"267 128 CURVE SMOOTH",
+"266 142 OFFCURVE",
+"264 157 OFFCURVE",
+"262 176 CURVE",
+"244 138 LINE",
+"308 173 OFFCURVE",
+"380 219 OFFCURVE",
+"466 287 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"282 616 LINE",
+"305 538 OFFCURVE",
+"312 500 OFFCURVE",
+"324 410 CURVE",
+"390 421 LINE",
+"374 517 OFFCURVE",
+"358 577 OFFCURVE",
+"325 653 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"695 411 LINE",
+"717 330 OFFCURVE",
+"725 273 OFFCURVE",
+"729 186 CURVE",
+"789 191 LINE",
+"782 295 OFFCURVE",
+"770 351 OFFCURVE",
+"737 450 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 900;
+}
+);
+leftMetricsKey = u1B17E;
+rightMetricsKey = u1B17E;
+unicode = 1B2F8;
+},
+{
+glyphname = u1B2F9;
+lastChange = "2020-04-13 09:41:33 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"257 525 LINE",
+"242 568 OFFCURVE",
+"227 609 OFFCURVE",
+"205 651 CURVE SMOOTH",
+"181 696 OFFCURVE",
+"157 738 OFFCURVE",
+"133 773 CURVE",
+"80 738 LINE",
+"135 656 OFFCURVE",
+"180 573 OFFCURVE",
+"214 488 CURVE",
+"282 474 LINE",
+"389 564 OFFCURVE",
+"488 653 OFFCURVE",
+"578 772 CURVE",
+"524 811 LINE",
+"472 739 OFFCURVE",
+"415 677 OFFCURVE",
+"358 621 CURVE SMOOTH",
+"321 585 OFFCURVE",
+"291 556 OFFCURVE",
+"261 525 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"407 939 LINE",
+"326 820 OFFCURVE",
+"267 741 OFFCURVE",
+"181 661 CURVE",
+"212 606 LINE",
+"309 700 OFFCURVE",
+"376 778 OFFCURVE",
+"463 907 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"182 884 LINE",
+"215 835 OFFCURVE",
+"243 788 OFFCURVE",
+"268 742 CURVE",
+"287 716 LINE",
+"313 667 OFFCURVE",
+"336 618 OFFCURVE",
+"359 567 CURVE",
+"401 617 LINE",
+"379 665 OFFCURVE",
+"359 708 OFFCURVE",
+"335 753 CURVE",
+"314 783 LINE",
+"292 824 OFFCURVE",
+"267 867 OFFCURVE",
+"235 918 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"382 -203 LINE",
+"399 -123 OFFCURVE",
+"408 -40 OFFCURVE",
+"408 51 CURVE SMOOTH",
+"408 170 OFFCURVE",
+"393 272 OFFCURVE",
+"351 413 CURVE",
+"339 369 LINE",
+"376 395 OFFCURVE",
+"407 419 OFFCURVE",
+"439 446 CURVE SMOOTH",
+"471 473 OFFCURVE",
+"489 493 OFFCURVE",
+"518 529 CURVE",
+"522 529 LINE",
+"533 486 OFFCURVE",
+"544 442 OFFCURVE",
+"550 422 CURVE SMOOTH",
+"564 374 OFFCURVE",
+"575 322 OFFCURVE",
+"583 270 CURVE",
+"592 357 LINE",
+"512 272 OFFCURVE",
+"438 220 OFFCURVE",
+"354 174 CURVE",
+"392 126 LINE",
+"482 179 OFFCURVE",
+"561 236 OFFCURVE",
+"641 316 CURVE",
+"625 417 OFFCURVE",
+"605 486 OFFCURVE",
+"567 584 CURVE",
+"495 590 LINE",
+"433 515 OFFCURVE",
+"367 460 OFFCURVE",
+"281 402 CURVE",
+"323 260 OFFCURVE",
+"338 162 OFFCURVE",
+"338 55 CURVE SMOOTH",
+"338 -43 OFFCURVE",
+"329 -107 OFFCURVE",
+"313 -187 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"552 473 LINE",
+"474 385 OFFCURVE",
+"416 346 OFFCURVE",
+"326 290 CURVE",
+"364 258 LINE",
+"455 306 OFFCURVE",
+"508 352 OFFCURVE",
+"576 417 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"599 82 OFFCURVE",
+"621 98 OFFCURVE",
+"621 135 CURVE SMOOTH",
+"621 172 OFFCURVE",
+"599 188 OFFCURVE",
+"573 188 CURVE SMOOTH",
+"545 188 OFFCURVE",
+"523 172 OFFCURVE",
+"523 135 CURVE SMOOTH",
+"523 98 OFFCURVE",
+"545 82 OFFCURVE",
+"573 82 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"586 -59 OFFCURVE",
+"607 -43 OFFCURVE",
+"607 -8 CURVE SMOOTH",
+"607 28 OFFCURVE",
+"586 43 OFFCURVE",
+"561 43 CURVE SMOOTH",
+"535 43 OFFCURVE",
+"514 28 OFFCURVE",
+"514 -8 CURVE SMOOTH",
+"514 -43 OFFCURVE",
+"535 -59 OFFCURVE",
+"561 -59 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"558 -203 OFFCURVE",
+"580 -187 OFFCURVE",
+"580 -150 CURVE SMOOTH",
+"580 -113 OFFCURVE",
+"558 -97 OFFCURVE",
+"531 -97 CURVE SMOOTH",
+"503 -97 OFFCURVE",
+"482 -113 OFFCURVE",
+"482 -150 CURVE SMOOTH",
+"482 -187 OFFCURVE",
+"503 -203 OFFCURVE",
+"531 -203 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"234 -167 OFFCURVE",
+"256 -150 OFFCURVE",
+"256 -113 CURVE SMOOTH",
+"256 -76 OFFCURVE",
+"234 -60 OFFCURVE",
+"207 -60 CURVE SMOOTH",
+"180 -60 OFFCURVE",
+"158 -76 OFFCURVE",
+"158 -113 CURVE SMOOTH",
+"158 -150 OFFCURVE",
+"180 -167 OFFCURVE",
+"207 -167 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"238 -2 OFFCURVE",
+"260 14 OFFCURVE",
+"260 51 CURVE SMOOTH",
+"260 88 OFFCURVE",
+"238 105 OFFCURVE",
+"212 105 CURVE SMOOTH",
+"184 105 OFFCURVE",
+"162 88 OFFCURVE",
+"162 51 CURVE SMOOTH",
+"162 14 OFFCURVE",
+"184 -2 OFFCURVE",
+"212 -2 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"241 169 LINE",
+"226 281 OFFCURVE",
+"203 362 OFFCURVE",
+"161 457 CURVE",
+"101 429 LINE",
+"141 336 OFFCURVE",
+"163 265 OFFCURVE",
+"174 163 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 741;
+}
+);
+leftMetricsKey = u1B19D;
+unicode = 1B2F9;
+},
+{
+glyphname = u1B2FA;
+lastChange = "2020-04-13 09:41:20 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"858 502 OFFCURVE",
+"830 620 OFFCURVE",
+"796 738 CURVE",
+"728 757 LINE",
+"650 701 OFFCURVE",
+"571 650 OFFCURVE",
+"480 597 CURVE",
+"518 460 OFFCURVE",
+"542 346 OFFCURVE",
+"561 243 CURVE",
+"628 224 LINE",
+"712 262 OFFCURVE",
+"789 308 OFFCURVE",
+"885 372 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"785 153 LINE",
+"777 213 OFFCURVE",
+"767 271 OFFCURVE",
+"751 337 CURVE",
+"738 364 LINE",
+"717 474 OFFCURVE",
+"691 576 OFFCURVE",
+"666 667 CURVE",
+"662 705 LINE",
+"651 744 OFFCURVE",
+"641 781 OFFCURVE",
+"627 821 CURVE",
+"564 785 LINE",
+"578 743 OFFCURVE",
+"590 703 OFFCURVE",
+"603 661 CURVE",
+"623 620 LINE",
+"648 526 OFFCURVE",
+"672 424 OFFCURVE",
+"690 326 CURVE",
+"688 290 LINE",
+"702 232 OFFCURVE",
+"711 180 OFFCURVE",
+"718 129 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"830 412 LINE",
+"787 384 OFFCURVE",
+"749 360 OFFCURVE",
+"710 337 CURVE SMOOTH",
+"675 317 OFFCURVE",
+"654 306 OFFCURVE",
+"620 287 CURVE",
+"616 287 LINE",
+"610 339 OFFCURVE",
+"594 401 OFFCURVE",
+"585 444 CURVE SMOOTH",
+"574 495 OFFCURVE",
+"560 547 OFFCURVE",
+"545 600 CURVE",
+"530 552 LINE",
+"570 575 OFFCURVE",
+"610 600 OFFCURVE",
+"653 627 CURVE SMOOTH",
+"693 652 OFFCURVE",
+"709 665 OFFCURVE",
+"742 693 CURVE",
+"747 692 LINE",
+"759 641 OFFCURVE",
+"771 585 OFFCURVE",
+"783 538 CURVE SMOOTH",
+"798 477 OFFCURVE",
+"810 417 OFFCURVE",
+"822 354 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"800 597 LINE",
+"761 567 OFFCURVE",
+"723 540 OFFCURVE",
+"683 515 CURVE",
+"660 505 LINE",
+"626 484 OFFCURVE",
+"590 463 OFFCURVE",
+"552 443 CURVE",
+"579 391 LINE",
+"616 411 OFFCURVE",
+"650 432 OFFCURVE",
+"683 452 CURVE",
+"704 460 LINE",
+"747 487 OFFCURVE",
+"790 515 OFFCURVE",
+"830 543 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"709 939 LINE",
+"611 866 OFFCURVE",
+"512 804 OFFCURVE",
+"416 752 CURVE",
+"448 692 LINE",
+"549 746 OFFCURVE",
+"655 812 OFFCURVE",
+"754 888 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"901 260 LINE",
+"783 185 OFFCURVE",
+"695 138 OFFCURVE",
+"588 88 CURVE",
+"615 28 LINE",
+"732 83 OFFCURVE",
+"819 128 OFFCURVE",
+"940 204 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"521 210 OFFCURVE",
+"492 343 OFFCURVE",
+"455 467 CURVE",
+"391 483 LINE",
+"316 430 OFFCURVE",
+"245 392 OFFCURVE",
+"138 342 CURVE",
+"169 211 OFFCURVE",
+"192 94 OFFCURVE",
+"211 -15 CURVE",
+"281 -36 LINE",
+"372 1 OFFCURVE",
+"447 32 OFFCURVE",
+"545 86 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"439 -119 LINE",
+"429 -44 OFFCURVE",
+"423 -13 OFFCURVE",
+"412 52 CURVE",
+"398 81 LINE",
+"379 183 OFFCURVE",
+"356 287 OFFCURVE",
+"331 390 CURVE",
+"325 426 LINE",
+"315 475 OFFCURVE",
+"307 505 OFFCURVE",
+"294 548 CURVE",
+"231 514 LINE",
+"246 460 OFFCURVE",
+"254 430 OFFCURVE",
+"265 387 CURVE",
+"283 357 LINE",
+"308 255 OFFCURVE",
+"329 155 OFFCURVE",
+"346 54 CURVE",
+"346 22 LINE",
+"356 -39 OFFCURVE",
+"360 -67 OFFCURVE",
+"371 -143 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"490 130 LINE",
+"451 109 OFFCURVE",
+"413 90 OFFCURVE",
+"373 72 CURVE SMOOTH",
+"348 61 OFFCURVE",
+"308 41 OFFCURVE",
+"274 24 CURVE",
+"269 25 LINE",
+"264 78 OFFCURVE",
+"251 127 OFFCURVE",
+"240 182 CURVE SMOOTH",
+"230 231 OFFCURVE",
+"217 283 OFFCURVE",
+"201 345 CURVE",
+"188 295 LINE",
+"234 316 OFFCURVE",
+"276 338 OFFCURVE",
+"305 354 CURVE SMOOTH",
+"336 371 OFFCURVE",
+"370 395 OFFCURVE",
+"402 418 CURVE",
+"406 417 LINE",
+"418 369 OFFCURVE",
+"432 310 OFFCURVE",
+"442 267 CURVE SMOOTH",
+"457 201 OFFCURVE",
+"470 136 OFFCURVE",
+"481 70 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"451 306 LINE",
+"411 282 OFFCURVE",
+"381 265 OFFCURVE",
+"345 246 CURVE",
+"324 239 LINE",
+"288 221 OFFCURVE",
+"258 206 OFFCURVE",
+"221 189 CURVE",
+"227 128 LINE",
+"270 148 OFFCURVE",
+"305 165 OFFCURVE",
+"343 184 CURVE",
+"366 192 LINE",
+"408 214 OFFCURVE",
+"442 232 OFFCURVE",
+"484 257 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"396 667 LINE",
+"288 595 OFFCURVE",
+"180 535 OFFCURVE",
+"80 490 CURVE",
+"105 427 LINE",
+"206 472 OFFCURVE",
+"317 533 OFFCURVE",
+"436 612 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"563 2 LINE",
+"457 -53 OFFCURVE",
+"340 -105 OFFCURVE",
+"229 -142 CURVE",
+"250 -203 LINE",
+"370 -164 OFFCURVE",
+"482 -115 OFFCURVE",
+"595 -56 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 1040;
+}
+);
+rightMetricsKey = u1B2BB;
+unicode = 1B2FA;
+},
+{
+glyphname = u1B2FB;
+lastChange = "2020-04-13 09:41:17 +0000";
+layers = (
+{
+layerId = "CFFEBDE4-599A-46B2-9328-D96E42CD9C81";
+paths = (
+{
+closed = 1;
+nodes = (
+"80 31 OFFCURVE",
+"98 -2 OFFCURVE",
+"159 -43 CURVE",
+"230 -34 LINE",
+"275 44 OFFCURVE",
+"294 92 OFFCURVE",
+"294 142 CURVE SMOOTH",
+"294 191 OFFCURVE",
+"264 226 OFFCURVE",
+"214 250 CURVE",
+"140 240 LINE",
+"97 165 OFFCURVE",
+"80 119 OFFCURVE",
+"80 75 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"188 200 LINE",
+"221 182 OFFCURVE",
+"232 165 OFFCURVE",
+"232 137 CURVE SMOOTH",
+"232 103 OFFCURVE",
+"224 66 OFFCURVE",
+"192 5 CURVE",
+"187 4 LINE",
+"156 31 OFFCURVE",
+"146 56 OFFCURVE",
+"146 86 CURVE SMOOTH",
+"146 112 OFFCURVE",
+"153 148 OFFCURVE",
+"183 199 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"313 543 LINE",
+"410 571 OFFCURVE",
+"501 599 OFFCURVE",
+"596 634 CURVE",
+"568 634 LINE",
+"584 590 OFFCURVE",
+"593 556 OFFCURVE",
+"607 502 CURVE",
+"614 541 LINE",
+"571 526 OFFCURVE",
+"529 513 OFFCURVE",
+"487 500 CURVE",
+"457 494 LINE",
+"417 482 OFFCURVE",
+"376 471 OFFCURVE",
+"332 460 CURVE",
+"356 458 LINE",
+"347 504 OFFCURVE",
+"338 541 OFFCURVE",
+"324 589 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"364 280 LINE",
+"409 292 OFFCURVE",
+"445 302 OFFCURVE",
+"500 318 CURVE",
+"530 324 LINE",
+"586 341 OFFCURVE",
+"622 354 OFFCURVE",
+"668 368 CURVE",
+"671 365 LINE",
+"675 332 OFFCURVE",
+"678 287 OFFCURVE",
+"682 260 CURVE SMOOTH",
+"689 212 OFFCURVE",
+"693 166 OFFCURVE",
+"696 115 CURVE",
+"723 163 LINE",
+"667 144 OFFCURVE",
+"615 127 OFFCURVE",
+"560 112 CURVE",
+"520 104 LINE",
+"470 91 OFFCURVE",
+"440 83 OFFCURVE",
+"395 69 CURVE",
+"392 72 LINE",
+"392 110 OFFCURVE",
+"392 155 OFFCURVE",
+"388 192 CURVE SMOOTH",
+"384 229 OFFCURVE",
+"379 266 OFFCURVE",
+"374 303 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"712 302 LINE",
+"658 283 OFFCURVE",
+"601 264 OFFCURVE",
+"544 247 CURVE",
+"511 240 LINE",
+"455 224 OFFCURVE",
+"415 213 OFFCURVE",
+"362 201 CURVE",
+"372 147 LINE",
+"421 159 OFFCURVE",
+"460 170 OFFCURVE",
+"516 186 CURVE",
+"546 191 LINE",
+"610 210 OFFCURVE",
+"675 231 OFFCURVE",
+"737 253 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"317 218 OFFCURVE",
+"326 127 OFFCURVE",
+"331 39 CURVE",
+"391 8 LINE",
+"437 20 OFFCURVE",
+"473 28 OFFCURVE",
+"523 41 CURVE",
+"551 45 LINE",
+"624 65 OFFCURVE",
+"693 86 OFFCURVE",
+"764 112 CURVE",
+"757 220 OFFCURVE",
+"746 303 OFFCURVE",
+"726 407 CURVE",
+"672 431 LINE",
+"619 413 OFFCURVE",
+"568 397 OFFCURVE",
+"518 381 CURVE",
+"488 375 LINE",
+"424 356 OFFCURVE",
+"375 342 OFFCURVE",
+"303 325 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"280 519 OFFCURVE",
+"288 477 OFFCURVE",
+"296 431 CURVE",
+"358 409 LINE",
+"389 417 OFFCURVE",
+"431 428 OFFCURVE",
+"474 441 CURVE",
+"507 448 LINE",
+"560 465 OFFCURVE",
+"612 483 OFFCURVE",
+"668 505 CURVE",
+"654 570 OFFCURVE",
+"642 615 OFFCURVE",
+"621 665 CURVE",
+"566 683 LINE",
+"463 645 OFFCURVE",
+"368 616 OFFCURVE",
+"265 584 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"384 -162 OFFCURVE",
+"407 -145 OFFCURVE",
+"407 -106 CURVE SMOOTH",
+"407 -67 OFFCURVE",
+"384 -50 OFFCURVE",
+"356 -50 CURVE SMOOTH",
+"327 -50 OFFCURVE",
+"304 -67 OFFCURVE",
+"304 -106 CURVE SMOOTH",
+"304 -145 OFFCURVE",
+"327 -162 OFFCURVE",
+"356 -162 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"745 -105 OFFCURVE",
+"768 -88 OFFCURVE",
+"768 -49 CURVE SMOOTH",
+"768 -10 OFFCURVE",
+"745 7 OFFCURVE",
+"717 7 CURVE SMOOTH",
+"688 7 OFFCURVE",
+"665 -10 OFFCURVE",
+"665 -49 CURVE SMOOTH",
+"665 -88 OFFCURVE",
+"688 -105 OFFCURVE",
+"717 -105 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"415 939 LINE",
+"332 792 OFFCURVE",
+"249 707 OFFCURVE",
+"120 600 CURVE",
+"162 547 LINE",
+"297 659 OFFCURVE",
+"392 756 OFFCURVE",
+"478 909 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"398 813 LINE",
+"538 758 OFFCURVE",
+"668 692 OFFCURVE",
+"787 603 CURVE",
+"825 661 LINE",
+"685 759 OFFCURVE",
+"579 809 OFFCURVE",
+"430 873 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"426 585 LINE",
+"479 411 OFFCURVE",
+"504 260 OFFCURVE",
+"510 95 CURVE",
+"507 56 LINE",
+"508 38 OFFCURVE",
+"508 18 OFFCURVE",
+"508 -1 CURVE SMOOTH",
+"508 -60 OFFCURVE",
+"504 -126 OFFCURVE",
+"495 -196 CURVE",
+"561 -203 LINE",
+"569 -133 OFFCURVE",
+"574 -73 OFFCURVE",
+"574 2 CURVE SMOOTH",
+"574 25 OFFCURVE",
+"574 46 OFFCURVE",
+"573 68 CURVE",
+"566 109 LINE",
+"557 278 OFFCURVE",
+"533 431 OFFCURVE",
+"472 622 CURVE"
+);
+}
+);
+vertOrigin = 25;
+vertWidth = 1362;
+width = 915;
+}
+);
+leftMetricsKey = u1B1AA;
+rightMetricsKey = u1B2F6;
+unicode = 1B2FB;
+}
+);
+instances = (
+{
+customParameters = (
+{
+name = weightClass;
+value = 400;
+},
+{
+name = panose;
+value = (
+2,
+11,
+5,
+2,
+4,
+5,
+4,
+2,
+2,
+4
+);
+},
+{
+name = xHeight;
+value = "536";
+},
+{
+name = typoAscender;
+value = 1069;
+},
+{
+name = typoDescender;
+value = -321;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 1069;
+},
+{
+name = winDescent;
+value = 321;
+},
+{
+name = hheaAscender;
+value = 1069;
+},
+{
+name = hheaDescender;
+value = -321;
+},
+{
+name = hheaLineGap;
+value = 0;
+},
+{
+name = underlinePosition;
+value = -100;
+},
+{
+name = underlineThickness;
+value = 50;
+}
+);
+instanceInterpolations = {
+"CFFEBDE4-599A-46B2-9328-D96E42CD9C81" = 1;
+};
+name = Regular;
+}
+);
+manufacturer = "Lisa Huang";
+manufacturerURL = "http://www.google.com/get/noto/";
+unitsPerEm = 1000;
+versionMajor = 1;
+versionMinor = 0;
+}


### PR DESCRIPTION
This adds the GlyphsApp source for https://github.com/LisaHuang2017/noto-sans-nushu by @LisaHuang2017.

Question:
- I see that quite a few of the Noto fonts with Glyphs sources are accompanied by separate files for `GDEF, GPOS, GSUB` features. Is there a typical procedure followed to produce these?