### PR TITLE
Noto sans khmer fix #1688

### DIFF
--- a/src/NotoSansKhmer/Noto Sans Khmer GSUB.txt
+++ b/src/NotoSansKhmer/Noto Sans Khmer GSUB.txt
@@ -10,7 +10,7 @@ feature table begin
 0	abvf	6
 1	abvs	14, 15, 16, 17
 2	blwf	1, 2, 3, 4, 5
-3	blws	9, 10, 11, 12, 13
+3	blws	9, 10, 11, 13
 4	clig	23, 24, 25
 5	liga	26
 6	pref	0

--- a/test/Khmer/khm-1688.html
+++ b/test/Khmer/khm-1688.html
@@ -1,0 +1,3 @@
+<html lang="khm">
+	<p style="font-size: 4em; font-weight: 90;">ម៉េរិ  ម៉ិ  </p>
+</html>


### PR DESCRIPTION
We have fixed the [#1688](https://github.com/googlefonts/noto-fonts/issues/1688) regarding the issue in browsers such as Chrome and Firefox

It is defined in GSUB of Noto Sans Khmer, to replace “uni17CA” or “uni17C9.r” to “uni17BB”,  when a certain vowel follows a consonant including “muusikatoan”.
The following features and lookup are related:
- blwf Lookup 2
- blws Lookup 12

The direct cause for the notofonts/khmer#24 problem is due to the blws feature.
The lookup 12 in blws, replaces the "muusikatonan", which should not be replaced.
Therefore, it is desirable for it to skip this portion.
It has been confirmed that needed replacements are handled by blwf lookup 2.

I have also included the tests.