### PR TITLE
Noto naskh arabic fix #1885

### DIFF
--- a/src/NotoNaskhArabic.glyphs
+++ b/src/NotoNaskhArabic.glyphs
@@ -1,8 +1,5 @@
 {
-.appVersion = "1240";
-DisplayStrings = (
-"/uni067C  /uni067C.fina  /uni067C.medi  /uni067C.init  /uni0689  /uni0689.fina  /uni0693  /uni0693.fina  /uni06B0  /uni06B0.fina  /uni06B0.medi  /uni06B0.init  /uni06AB  /uni06AB.fina  /uni06AB.medi  /uni06AB.init  /_082/uni06BC  /uni06BC.fina  /uni06BC.medi  /uni06BC.init  /uni06C4  /uni06C4.fina  /uni0620  /uni0620.fina  /uni0620.medi  /uni0620.init  "
-);
+.appVersion = "1342";
 classes = (
 {
 code = "uni0660 uni0661 uni0662 uni0663 uni0664 uni0665 uni0666 uni0667 uni0668 uni0669 uni06F0 uni06F1 uni06F2 uni06F3 uni06F4 uni06F5 uni06F6 uni06F7 uni06F8 uni06F9 uni06F4.locl uni06F7.locl";
@@ -44324,7 +44321,7 @@ unicode = FEF8;
 },
 {
 glyphname = uniFEF9;
-lastChange = "2019-12-19 06:51:11 +0000";
+lastChange = "2020-10-08 05:58:19 +0000";
 layers = (
 {
 anchors = (
@@ -44347,9 +44344,11 @@ position = "{65, 592}";
 );
 components = (
 {
+alignment = -1;
 name = uniFEFB;
 },
 {
+alignment = -1;
 name = uni0655;
 transform = "{1, 0, 0, 1, 118, -97}";
 }
@@ -44415,7 +44414,7 @@ unicode = FEF9;
 },
 {
 glyphname = uniFEFA;
-lastChange = "2019-12-19 06:51:11 +0000";
+lastChange = "2020-10-08 05:58:19 +0000";
 layers = (
 {
 anchors = (
@@ -44438,9 +44437,11 @@ position = "{66, 599}";
 );
 components = (
 {
+alignment = -1;
 name = uniFEFC;
 },
 {
+alignment = -1;
 name = uni0655;
 transform = "{1, 0, 0, 1, 152, -97}";
 }
@@ -74101,14 +74102,16 @@ width = 288;
 },
 {
 glyphname = uniFEFB_uni065F;
-lastChange = "2019-12-19 06:49:57 +0000";
+lastChange = "2020-10-08 05:58:19 +0000";
 layers = (
 {
 components = (
 {
+alignment = -1;
 name = uniFEFB;
 },
 {
+alignment = -1;
 name = uni065F;
 transform = "{1, 0, 0, 1, 123, -118}";
 }
@@ -74155,14 +74158,16 @@ width = 546;
 },
 {
 glyphname = uniFEFC_uni065F;
-lastChange = "2019-12-19 06:49:57 +0000";
+lastChange = "2020-10-08 05:58:19 +0000";
 layers = (
 {
 components = (
 {
+alignment = -1;
 name = uniFEFC;
 },
 {
+alignment = -1;
 name = uni065F;
 transform = "{1, 0, 0, 1, 157, -118}";
 }
@@ -109553,9 +109558,15 @@ width = 0;
 },
 {
 glyphname = _1029;
-lastChange = "2019-12-18 14:15:23 +0000";
+lastChange = "2020-10-08 05:58:54 +0000";
 layers = (
 {
+anchors = (
+{
+name = top;
+position = "{70, 785}";
+}
+);
 components = (
 {
 name = _1008;
@@ -109569,6 +109580,12 @@ layerId = master01;
 width = 0;
 },
 {
+anchors = (
+{
+name = top;
+position = "{70, 785}";
+}
+);
 components = (
 {
 alignment = -1;
@@ -109587,9 +109604,15 @@ width = 0;
 },
 {
 glyphname = _1031;
-lastChange = "2019-12-18 17:28:58 +0000";
+lastChange = "2020-10-08 05:59:19 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{250, -260}";
+}
+);
 components = (
 {
 name = _1008;
@@ -109603,6 +109626,12 @@ layerId = master01;
 width = 0;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{250, -260}";
+}
+);
 components = (
 {
 alignment = -1;

--- a/src/NotoNaskhArabicUI.glyphs
+++ b/src/NotoNaskhArabicUI.glyphs
@@ -115638,9 +115638,15 @@ width = 0;
 },
 {
 glyphname = _1029;
-lastChange = "2019-12-19 08:47:15 +0000";
+lastChange = "2020-10-09 14:00:00 +0000";
 layers = (
 {
+anchors = (
+{
+name = top;
+position = "{70, 920}";
+}
+);
 components = (
 {
 name = _1008;
@@ -115654,6 +115660,12 @@ layerId = master01;
 width = 0;
 },
 {
+anchors = (
+{
+name = top;
+position = "{70, 920}";
+}
+);
 components = (
 {
 alignment = -1;
@@ -115672,9 +115684,15 @@ width = 0;
 },
 {
 glyphname = _1031;
-lastChange = "2019-12-19 08:47:15 +0000";
+lastChange = "2020-10-09 14:00:00 +0000";
 layers = (
 {
+anchors = (
+{
+name = bottom;
+position = "{250, -130}";
+}
+);
 components = (
 {
 name = _1008;
@@ -115688,6 +115706,12 @@ layerId = master01;
 width = 0;
 },
 {
+anchors = (
+{
+name = bottom;
+position = "{250, -130}";
+}
+);
 components = (
 {
 alignment = -1;

--- a/test/Arabic/fontdiff-1885-Arabic.html
+++ b/test/Arabic/fontdiff-1885-Arabic.html
@@ -1,0 +1,3 @@
+<html lang="Arab">
+<p><span> ملأَملأً ملأُ ملأٌ ملإِ ملإٍ </span></p>
+</html>


### PR DESCRIPTION
We have fixed [#1885](https://github.com/googlefonts/noto-fonts/issues/1885) regarding the issues in browsers such as Chrome 85.
It was not possible to place correctly vowel symbols in the final form of Lam+alif+hamza in NotoNaskhArabic and UI.
Therefore anchors have been added in _1029 and _1031.
Test/Arabic was used in fontdiff to confirm that this did not affect any other combinations.

The anchors were placed by referring to when vowel symbols are placed on the isolated form of Lam+alif+hamza.
![image](https://user-images.githubusercontent.com/21096794/95695681-2830ef00-0c73-11eb-9e92-1e1ca211bd03.png)

This combination is used in words such as “سيملأُ ”, so we feel it is best to handle this as priority.
The tests have been added.
We will appreciate if this can be handled.
