### PR TITLE
Swap default repha-yaphala order

### DIFF
--- a/src/NotoSansGrantha/NotoSansGrantha.glyphs
+++ b/src/NotoSansGrantha/NotoSansGrantha.glyphs
@@ -10428,7 +10428,7 @@ category = Mark;
 subCategory = Nonspacing;
 },
 {
-glyphname = repha_yaPhalaa;
+glyphname = repha_yaPhalaa.alt;
 lastChange = "2020-05-24 21:49:22 +0000";
 layers = (
 {
@@ -10472,7 +10472,7 @@ category = Mark;
 subCategory = Nonspacing;
 },
 {
-glyphname = repha_yaPhalaa.alt;
+glyphname = repha_yaPhalaa;
 lastChange = "2020-05-24 21:49:22 +0000";
 layers = (
 {

--- a/src/NotoSerifGrantha/NotoSerifGrantha.glyphs
+++ b/src/NotoSerifGrantha/NotoSerifGrantha.glyphs
@@ -10187,7 +10187,7 @@ category = Mark;
 subCategory = Nonspacing;
 },
 {
-glyphname = repha_yaPhalaa;
+glyphname = repha_yaPhalaa.alt;
 lastChange = "2020-05-24 21:48:52 +0000";
 layers = (
 {
@@ -10237,7 +10237,7 @@ category = Mark;
 subCategory = Nonspacing;
 },
 {
-glyphname = repha_yaPhalaa.alt;
+glyphname = repha_yaPhalaa;
 lastChange = "2020-05-24 21:48:52 +0000";
 layers = (
 {


### PR DESCRIPTION
For some reason we originally went with the order ya-phala followed by repha, but we really should have done it the other way to visually show repha before ya-phala. This is the more accepted way. The main Unicode proposal https://unicode.org/L2/L2009/09372-grantha.pdf defines the current order (ya-phala repha) as a known aberration. 