### PR TITLE
NotoOldHungarianUI.glyphs uploaded

### DIFF
--- a/src/NotoOldHungarianUI.glyphs
+++ b/src/NotoOldHungarianUI.glyphs
@@ -1,0 +1,16592 @@
+{
+classes = (
+{
+code = "uni10C80 uni10C81 uni10C82 uni10C83 uni10C84 uni10C85 uni10C86 uni10C87 uni10C88 uni10C89 uni10C8A uni10C8B uni10C8C uni10C8D uni10C8E uni10C8F uni10C90 uni10C91 uni10C92 uni10C93 uni10C94 uni10C95 uni10C96 uni10C97 uni10C98 uni10C99 uni10C9A uni10C9B uni10C9C uni10C9D uni10C9E uni10C9F uni10CA0 uni10CA1 uni10CA2 uni10CA3 uni10CA4 uni10CA5 uni10CA6 uni10CA7 uni10CA8 uni10CA9 uni10CAA uni10CAB uni10CAC uni10CAD uni10CAE uni10CAF uni10CB0 uni10CB1 uni10CB2 uni10CC0 uni10CC1 uni10CC2 uni10CC3 uni10CC4 uni10CC5 uni10CC6 uni10CC7 uni10CC8 uni10CC9 uni10CCA uni10CCB uni10CCC uni10CCD uni10CCE uni10CCF uni10CD0 uni10CD1 uni10CD2 uni10CD3 uni10CD4 uni10CD5 uni10CD6 uni10CD7 uni10CD8 uni10CD9 uni10CDA uni10CDB uni10CDC uni10CDD uni10CDE uni10CDF uni10CE0 uni10CE1 uni10CE2 uni10CE3 uni10CE4 uni10CE5 uni10CE6 uni10CE7 uni10CE8 uni10CE9 uni10CEA uni10CEB uni10CEC uni10CED uni10CEE uni10CEF uni10CF0 uni10CF1 uni10CF2";
+name = ltrm;
+},
+{
+code = "uni10C80.ltr uni10C81.ltr uni10C82.ltr uni10C83.ltr uni10C84.ltr uni10C85.ltr uni10C86.ltr uni10C87.ltr uni10C88.ltr uni10C89.ltr uni10C8A.ltr uni10C8B.ltr uni10C8C.ltr uni10C8D.ltr uni10C8E.ltr uni10C8F.ltr uni10C90.ltr uni10C91.ltr uni10C92.ltr uni10C93.ltr uni10C94.ltr uni10C95.ltr uni10C96.ltr uni10C97.ltr uni10C98.ltr uni10C99.ltr uni10C9A.ltr uni10C9B.ltr uni10C9C.ltr uni10C9D.ltr uni10C9E.ltr uni10C9F.ltr uni10CA0.ltr uni10CA1.ltr uni10CA2.ltr uni10CA3.ltr uni10CA4.ltr uni10CA5.ltr uni10CA6.ltr uni10CA7.ltr uni10CA8.ltr uni10CA9.ltr uni10CAA.ltr uni10CAB.ltr uni10CAC.ltr uni10CAD.ltr uni10CAE.ltr uni10CAF.ltr uni10CB0.ltr uni10CB1.ltr uni10CB2.ltr uni10CC0.ltr uni10CC1.ltr uni10CC2.ltr uni10CC3.ltr uni10CC4.ltr uni10CC5.ltr uni10CC6.ltr uni10CC7.ltr uni10CC8.ltr uni10CC9.ltr uni10CCA.ltr uni10CCB.ltr uni10CCC.ltr uni10CCD.ltr uni10CCE.ltr uni10CCF.ltr uni10CD0.ltr uni10CD1.ltr uni10CD2.ltr uni10CD3.ltr uni10CD4.ltr uni10CD5.ltr uni10CD6.ltr uni10CD7.ltr uni10CD8.ltr uni10CD9.ltr uni10CDA.ltr uni10CDB.ltr uni10CDC.ltr uni10CDD.ltr uni10CDE.ltr uni10CDF.ltr uni10CE0.ltr uni10CE1.ltr uni10CE2.ltr uni10CE3.ltr uni10CE4.ltr uni10CE5.ltr uni10CE6.ltr uni10CE7.ltr uni10CE8.ltr uni10CE9.ltr uni10CEA.ltr uni10CEB.ltr uni10CEC.ltr uni10CED.ltr uni10CEE.ltr uni10CEF.ltr uni10CF0.ltr uni10CF1.ltr uni10CF2.ltr";
+name = ltrm2;
+}
+);
+copyright = "Copyright 2018-2020 Google LLC. All Rights Reserved.";
+designer = "Monotype Design Team";
+designerURL = "http://www.monotype.com/studio";
+familyName = "Noto Old Hungarian UI";
+customParameters = (
+{
+name = glyphOrder;
+value = (
+.notdef,
+NULL,
+CR,
+NULL.1,
+CR.1,
+space,
+uni10C80,
+uni10C81,
+uni10C82,
+uni10C83,
+uni10C84,
+uni10C85,
+uni10C86,
+uni10C87,
+uni10C88,
+uni10C89,
+uni10C8A,
+uni10C8B,
+uni10C8C,
+uni10C8D,
+uni10C8E,
+uni10C8F,
+uni10C90,
+uni10C91,
+uni10C92,
+uni10C93,
+uni10C94,
+uni10C95,
+uni10C96,
+uni10C97,
+uni10C98,
+uni10C99,
+uni10C9A,
+uni10C9B,
+uni10C9C,
+uni10C9D,
+uni10C9E,
+uni10C9F,
+uni10CA0,
+uni10CA1,
+uni10CA2,
+uni10CA3,
+uni10CA4,
+uni10CA5,
+uni10CA6,
+uni10CA7,
+uni10CA8,
+uni10CA9,
+uni10CAA,
+uni10CAB,
+uni10CAC,
+uni10CAD,
+uni10CAE,
+uni10CAF,
+uni10CB0,
+uni10CB1,
+uni10CB2,
+uni10CC0,
+uni10CC1,
+uni10CC2,
+uni10CC3,
+uni10CC4,
+uni10CC5,
+uni10CC6,
+uni10CC7,
+uni10CC8,
+uni10CC9,
+uni10CCA,
+uni10CCB,
+uni10CCC,
+uni10CCD,
+uni10CCE,
+uni10CCF,
+uni10CD0,
+uni10CD1,
+uni10CD2,
+uni10CD3,
+uni10CD4,
+uni10CD5,
+uni10CD6,
+uni10CD7,
+uni10CD8,
+uni10CD9,
+uni10CDA,
+uni10CDB,
+uni10CDC,
+uni10CDD,
+uni10CDE,
+uni10CDF,
+uni10CE0,
+uni10CE1,
+uni10CE2,
+uni10CE3,
+uni10CE4,
+uni10CE5,
+uni10CE6,
+uni10CE7,
+uni10CE8,
+uni10CE9,
+uni10CEA,
+uni10CEB,
+uni10CEC,
+uni10CED,
+uni10CEE,
+uni10CEF,
+uni10CF0,
+uni10CF1,
+uni10CF2,
+uni10CFA,
+uni10CFB,
+uni10CFC,
+uni10CFD,
+uni10CFE,
+uni10CFF,
+uni10C80.ltr,
+uni10C81.ltr,
+uni10C82.ltr,
+uni10C83.ltr,
+uni10C84.ltr,
+uni10C85.ltr,
+uni10C86.ltr,
+uni10C87.ltr,
+uni10C88.ltr,
+uni10C89.ltr,
+uni10C8A.ltr,
+uni10C8B.ltr,
+uni10C8C.ltr,
+uni10C8D.ltr,
+uni10C8E.ltr,
+uni10C8F.ltr,
+uni10C90.ltr,
+uni10C91.ltr,
+uni10C92.ltr,
+uni10C93.ltr,
+uni10C94.ltr,
+uni10C95.ltr,
+uni10C96.ltr,
+uni10C97.ltr,
+uni10C98.ltr,
+uni10C99.ltr,
+uni10C9A.ltr,
+uni10C9B.ltr,
+uni10C9C.ltr,
+uni10C9D.ltr,
+uni10C9E.ltr,
+uni10C9F.ltr,
+uni10CA0.ltr,
+uni10CA1.ltr,
+uni10CA2.ltr,
+uni10CA3.ltr,
+uni10CA4.ltr,
+uni10CA5.ltr,
+uni10CA6.ltr,
+uni10CA7.ltr,
+uni10CA8.ltr,
+uni10CA9.ltr,
+uni10CAA.ltr,
+uni10CAB.ltr,
+uni10CAC.ltr,
+uni10CAD.ltr,
+uni10CAE.ltr,
+uni10CAF.ltr,
+uni10CB0.ltr,
+uni10CB1.ltr,
+uni10CB2.ltr,
+uni10CC0.ltr,
+uni10CC1.ltr,
+uni10CC2.ltr,
+uni10CC3.ltr,
+uni10CC4.ltr,
+uni10CC5.ltr,
+uni10CC6.ltr,
+uni10CC7.ltr,
+uni10CC8.ltr,
+uni10CC9.ltr,
+uni10CCA.ltr,
+uni10CCB.ltr,
+uni10CCC.ltr,
+uni10CCD.ltr,
+uni10CCE.ltr,
+uni10CCF.ltr,
+uni10CD0.ltr,
+uni10CD1.ltr,
+uni10CD2.ltr,
+uni10CD3.ltr,
+uni10CD4.ltr,
+uni10CD5.ltr,
+uni10CD6.ltr,
+uni10CD7.ltr,
+uni10CD8.ltr,
+uni10CD9.ltr,
+uni10CDA.ltr,
+uni10CDB.ltr,
+uni10CDC.ltr,
+uni10CDD.ltr,
+uni10CDE.ltr,
+uni10CDF.ltr,
+uni10CE0.ltr,
+uni10CE1.ltr,
+uni10CE2.ltr,
+uni10CE3.ltr,
+uni10CE4.ltr,
+uni10CE5.ltr,
+uni10CE6.ltr,
+uni10CE7.ltr,
+uni10CE8.ltr,
+uni10CE9.ltr,
+uni10CEA.ltr,
+uni10CEB.ltr,
+uni10CEC.ltr,
+uni10CED.ltr,
+uni10CEE.ltr,
+uni10CEF.ltr,
+uni10CF0.ltr,
+uni10CF1.ltr,
+uni10CF2.ltr
+);
+},
+{
+name = license;
+value = "This Font Software is licensed under the SIL Open Font License, Version 1.1. This Font Software is distributed on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the SIL Open Font License for the specific language, permissions and limitations governing your use of this Font Software.";
+},
+{
+name = licenseURL;
+value = "http://scripts.sil.org/OFL";
+},
+{
+name = trademark;
+value = "Noto is a trademark of Google LLC.";
+}
+);
+featurePrefixes = (
+{
+code = "###\012# OpenType Layout feature definitions\012# Format: Adobe FDK for OpenType (AFDKO) version 2.5\012# Generated on: 2020-11-25 17:5\012# Generated by: FontLab 7.1.4\012# Font PostScript name: NotoOldHungarianUI\012# Font copyright: Copyright 2018-2020 Google LLC. All Rights Reserved.\012#\012# Totals:\012# Languagesystems: 2\012# GSUB lookups: 2\012# GSUB features: 1 (ltrm)\012# GPOS lookups: 1\012# GPOS features: 1 (kern)\012\012#\012# Languagesystem definitions\012#\012\012languagesystem DFLT dflt; # Default default\012languagesystem hung dflt;\012\012#\012# Lookup definitions\012#\012\012lookup ltrm_1_2 {\012# GSUB lookup 2, type 11 (Single)\012  sub @ltrm by @ltrm2;\012} ltrm_1_2;\012\012\012#\012# Feature definitions\012#\012\012";
+name = Languagesystems;
+}
+);
+features = (
+{
+code = "# GSUB feature: Left-to-right mirrored forms\012# Lookups: 1\012\012  sub @ltrm' lookup ltrm_1_2;";
+name = ltrm;
+},
+{
+code = "# GPOS feature: Kerning\012# Lookups: 1\012\012\012  lookup kern_1 {\012  # GPOS lookup 1, type 2 (Pair adjustment)\012\012    pos uni10CC3 uni10CDC <-10 0 -10 0>;\012    pos uni10CC4 uni10CCC <-10 0 -10 0>;\012    pos uni10CC4 uni10CCD <-20 0 -20 0>;\012    pos uni10CC4 uni10CD6 <-20 0 -20 0>;\012    pos uni10CC4 uni10CD7 <-10 0 -10 0>;\012    pos uni10CC4 uni10CE4 <-20 0 -20 0>;\012    pos uni10CC4 uni10CF2 <-10 0 -10 0>;\012    pos uni10CC4 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CC4 uni10CCD.ltr <-20 0 -20 0>;\012    pos uni10CC4 uni10CD6.ltr <-20 0 -20 0>;\012    pos uni10CC4 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CC4 uni10CE4.ltr <-20 0 -20 0>;\012    pos uni10CC4 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CC5 uni10CEC <10 0 10 0>;\012    pos uni10CC7 uni10CE3 <-20 0 -20 0>;\012    pos uni10CC7 uni10CE6 <-30 0 -30 0>;\012    pos uni10CC8 uni10CD9 <30 0 30 0>;\012    pos uni10CCA uni10CD0 <-20 0 -20 0>;\012    pos uni10CCA uni10CE3 <-30 0 -30 0>;\012    pos uni10CCA uni10CEC <20 0 20 0>;\012    pos uni10CCB uni10CCA <-20 0 -20 0>;\012    pos uni10CCB uni10CE7 <-20 0 -20 0>;\012    pos uni10CCC uni10CD1 <-10 0 -10 0>;\012    pos uni10CCC uni10CE7 <-30 0 -30 0>;\012    pos uni10CCC uni10CF0 <-30 0 -30 0>;\012    pos uni10CD0 uni10CCA <-20 0 -20 0>;\012    pos uni10CD0 uni10CD3 <-30 0 -30 0>;\012    pos uni10CD0 uni10CDC <-50 0 -50 0>;\012    pos uni10CD0 uni10CE3 <-90 0 -90 0>;\012    pos uni10CD1 uni10CC1 <-20 0 -20 0>;\012    pos uni10CD1 uni10CC8 <20 0 20 0>;\012    pos uni10CD1 uni10CCA <-20 0 -20 0>;\012    pos uni10CD1 uni10CCB <-20 0 -20 0>;\012    pos uni10CD1 uni10CCE <-30 0 -30 0>;\012    pos uni10CD1 uni10CD0 <-20 0 -20 0>;\012    pos uni10CD1 uni10CD2 <-20 0 -20 0>;\012    pos uni10CD1 uni10CD3 <-30 0 -30 0>;\012    pos uni10CD1 uni10CD9 <10 0 10 0>;\012    pos uni10CD1 uni10CE1 <-20 0 -20 0>;\012    pos uni10CD1 uni10CE3 <-70 0 -70 0>;\012    pos uni10CD3 uni10CD1 <-20 0 -20 0>;\012    pos uni10CD3 uni10CD9 <-30 0 -30 0>;\012    pos uni10CD3 uni10CE7 <-30 0 -30 0>;\012    pos uni10CD4 uni10CD0 <-10 0 -10 0>;\012    pos uni10CD4 uni10CD1 <-20 0 -20 0>;\012    pos uni10CD4 uni10CD2 <-30 0 -30 0>;\012    pos uni10CD4 uni10CD4 <-10 0 -10 0>;\012    pos uni10CD4 uni10CE7 <-40 0 -40 0>;\012    pos uni10CD5 uni10CC1 <-20 0 -20 0>;\012    pos uni10CD5 uni10CDC <-20 0 -20 0>;\012    pos uni10CD5 uni10CE3 <-40 0 -40 0>;\012    pos uni10CDD uni10CE3 <-20 0 -20 0>;\012    pos uni10CDD uni10CE7 <-20 0 -20 0>;\012    pos uni10CE3 uni10CC7 <-2 0 -2 0>;\012    pos uni10CE3 uni10CC9 <-20 0 -20 0>;\012    pos uni10CE3 uni10CCA <-30 0 -30 0>;\012    pos uni10CE3 uni10CD5 <-40 0 -40 0>;\012    pos uni10CE3 uni10CD9 <-30 0 -30 0>;\012    pos uni10CE7 uni10CC7 <-60 0 -60 0>;\012    pos uni10CE7 uni10CC9 <-20 0 -20 0>;\012    pos uni10CE7 uni10CCE <-40 0 -40 0>;\012    pos uni10CE7 uni10CD0 <-40 0 -40 0>;\012    pos uni10CE7 uni10CD2 <-20 0 -20 0>;\012    pos uni10CE7 uni10CD3 <-30 0 -30 0>;\012    pos uni10CE7 uni10CDC <-60 0 -60 0>;\012    pos uni10CE7 uni10CDF <-40 0 -40 0>;\012    pos uni10CE7 uni10CE3 <-70 0 -70 0>;\012    pos uni10CEC uni10CC5 <10 0 10 0>;\012    pos uni10CEC uni10CCA <10 0 10 0>;\012    pos uni10CED uni10CE7 <-20 0 -20 0>;\012    pos uni10CF0 uni10CC7 <-30 0 -30 0>;\012    pos uni10CF0 uni10CCE <-50 0 -50 0>;\012    pos uni10CF0 uni10CD3 <-20 0 -20 0>;\012    pos uni10CF0 uni10CDC <-80 0 -80 0>;\012    pos uni10CF0 uni10CDF <-30 0 -30 0>;\012    pos uni10CF0 uni10CE3 <-60 0 -60 0>;\012\012    subtable;\012\012    pos .notdef uni10CC0 <-40 0 -40 0>;\012    pos .notdef uni10CC1 <-30 0 -30 0>;\012    pos .notdef uni10CC2 <20 0 20 0>;\012    pos .notdef uni10CC4 <-30 0 -30 0>;\012    pos .notdef uni10CC7 <-10 0 -10 0>;\012    pos .notdef uni10CC9 <-20 0 -20 0>;\012    pos .notdef uni10CCB <10 0 10 0>;\012    pos .notdef uni10CCC <-10 0 -10 0>;\012    pos .notdef uni10CCD <40 0 40 0>;\012    pos .notdef uni10CCE <20 0 20 0>;\012    pos .notdef uni10CD0 <-30 0 -30 0>;\012    pos .notdef uni10CD1 <-50 0 -50 0>;\012    pos .notdef uni10CD2 <-30 0 -30 0>;\012    pos .notdef uni10CD4 <-40 0 -40 0>;\012    pos .notdef uni10CD6 <40 0 40 0>;\012    pos .notdef uni10CD7 <-10 0 -10 0>;\012    pos .notdef uni10CD9 <20 0 20 0>;\012    pos .notdef uni10CE3 <-30 0 -30 0>;\012    pos .notdef uni10CE4 <40 0 40 0>;\012    pos .notdef uni10CE6 <-60 0 -60 0>;\012    pos .notdef uni10CE7 <-80 0 -80 0>;\012    pos .notdef uni10CE8 <20 0 20 0>;\012    pos .notdef uni10CE9 <20 0 20 0>;\012    pos .notdef uni10CEC <10 0 10 0>;\012    pos .notdef uni10CED <-40 0 -40 0>;\012    pos .notdef uni10CF0 <-60 0 -60 0>;\012    pos .notdef uni10CF2 <-10 0 -10 0>;\012    pos .notdef uni10CC0.ltr <-40 0 -40 0>;\012    pos .notdef uni10CC2.ltr <20 0 20 0>;\012    pos .notdef uni10CCC.ltr <-10 0 -10 0>;\012    pos .notdef uni10CCD.ltr <40 0 40 0>;\012    pos .notdef uni10CD6.ltr <40 0 40 0>;\012    pos .notdef uni10CD7.ltr <-10 0 -10 0>;\012    pos .notdef uni10CE4.ltr <40 0 40 0>;\012    pos .notdef uni10CE6.ltr <-60 0 -60 0>;\012    pos .notdef uni10CE8.ltr <20 0 20 0>;\012    pos .notdef uni10CE9.ltr <20 0 20 0>;\012    pos .notdef uni10CF0.ltr <-60 0 -60 0>;\012    pos .notdef uni10CF2.ltr <-10 0 -10 0>;\012    pos NULL.1 uni10CC0 <-40 0 -40 0>;\012    pos NULL.1 uni10CC1 <-30 0 -30 0>;\012    pos NULL.1 uni10CC2 <20 0 20 0>;\012    pos NULL.1 uni10CC4 <-30 0 -30 0>;\012    pos NULL.1 uni10CC7 <-10 0 -10 0>;\012    pos NULL.1 uni10CC9 <-20 0 -20 0>;\012    pos NULL.1 uni10CCB <10 0 10 0>;\012    pos NULL.1 uni10CCC <-10 0 -10 0>;\012    pos NULL.1 uni10CCD <40 0 40 0>;\012    pos NULL.1 uni10CCE <20 0 20 0>;\012    pos NULL.1 uni10CD0 <-30 0 -30 0>;\012    pos NULL.1 uni10CD1 <-50 0 -50 0>;\012    pos NULL.1 uni10CD2 <-30 0 -30 0>;\012    pos NULL.1 uni10CD4 <-40 0 -40 0>;\012    pos NULL.1 uni10CD6 <40 0 40 0>;\012    pos NULL.1 uni10CD7 <-10 0 -10 0>;\012    pos NULL.1 uni10CD9 <20 0 20 0>;\012    pos NULL.1 uni10CE3 <-30 0 -30 0>;\012    pos NULL.1 uni10CE4 <40 0 40 0>;\012    pos NULL.1 uni10CE6 <-60 0 -60 0>;\012    pos NULL.1 uni10CE7 <-80 0 -80 0>;\012    pos NULL.1 uni10CE8 <20 0 20 0>;\012    pos NULL.1 uni10CE9 <20 0 20 0>;\012    pos NULL.1 uni10CEC <10 0 10 0>;\012    pos NULL.1 uni10CED <-40 0 -40 0>;\012    pos NULL.1 uni10CF0 <-60 0 -60 0>;\012    pos NULL.1 uni10CF2 <-10 0 -10 0>;\012    pos NULL.1 uni10CC0.ltr <-40 0 -40 0>;\012    pos NULL.1 uni10CC2.ltr <20 0 20 0>;\012    pos NULL.1 uni10CCC.ltr <-10 0 -10 0>;\012    pos NULL.1 uni10CCD.ltr <40 0 40 0>;\012    pos NULL.1 uni10CD6.ltr <40 0 40 0>;\012    pos NULL.1 uni10CD7.ltr <-10 0 -10 0>;\012    pos NULL.1 uni10CE4.ltr <40 0 40 0>;\012    pos NULL.1 uni10CE6.ltr <-60 0 -60 0>;\012    pos NULL.1 uni10CE8.ltr <20 0 20 0>;\012    pos NULL.1 uni10CE9.ltr <20 0 20 0>;\012    pos NULL.1 uni10CF0.ltr <-60 0 -60 0>;\012    pos NULL.1 uni10CF2.ltr <-10 0 -10 0>;\012    pos CR.1 uni10CC0 <-40 0 -40 0>;\012    pos CR.1 uni10CC1 <-30 0 -30 0>;\012    pos CR.1 uni10CC2 <20 0 20 0>;\012    pos CR.1 uni10CC4 <-30 0 -30 0>;\012    pos CR.1 uni10CC7 <-10 0 -10 0>;\012    pos CR.1 uni10CC9 <-20 0 -20 0>;\012    pos CR.1 uni10CCB <10 0 10 0>;\012    pos CR.1 uni10CCC <-10 0 -10 0>;\012    pos CR.1 uni10CCD <40 0 40 0>;\012    pos CR.1 uni10CCE <20 0 20 0>;\012    pos CR.1 uni10CD0 <-30 0 -30 0>;\012    pos CR.1 uni10CD1 <-50 0 -50 0>;\012    pos CR.1 uni10CD2 <-30 0 -30 0>;\012    pos CR.1 uni10CD4 <-40 0 -40 0>;\012    pos CR.1 uni10CD6 <40 0 40 0>;\012    pos CR.1 uni10CD7 <-10 0 -10 0>;\012    pos CR.1 uni10CD9 <20 0 20 0>;\012    pos CR.1 uni10CE3 <-30 0 -30 0>;\012    pos CR.1 uni10CE4 <40 0 40 0>;\012    pos CR.1 uni10CE6 <-60 0 -60 0>;\012    pos CR.1 uni10CE7 <-80 0 -80 0>;\012    pos CR.1 uni10CE8 <20 0 20 0>;\012    pos CR.1 uni10CE9 <20 0 20 0>;\012    pos CR.1 uni10CEC <10 0 10 0>;\012    pos CR.1 uni10CED <-40 0 -40 0>;\012    pos CR.1 uni10CF0 <-60 0 -60 0>;\012    pos CR.1 uni10CF2 <-10 0 -10 0>;\012    pos CR.1 uni10CC0.ltr <-40 0 -40 0>;\012    pos CR.1 uni10CC2.ltr <20 0 20 0>;\012    pos CR.1 uni10CCC.ltr <-10 0 -10 0>;\012    pos CR.1 uni10CCD.ltr <40 0 40 0>;\012    pos CR.1 uni10CD6.ltr <40 0 40 0>;\012    pos CR.1 uni10CD7.ltr <-10 0 -10 0>;\012    pos CR.1 uni10CE4.ltr <40 0 40 0>;\012    pos CR.1 uni10CE6.ltr <-60 0 -60 0>;\012    pos CR.1 uni10CE8.ltr <20 0 20 0>;\012    pos CR.1 uni10CE9.ltr <20 0 20 0>;\012    pos CR.1 uni10CF0.ltr <-60 0 -60 0>;\012    pos CR.1 uni10CF2.ltr <-10 0 -10 0>;\012    pos space uni10CC0 <-40 0 -40 0>;\012    pos space uni10CC1 <-30 0 -30 0>;\012    pos space uni10CC2 <20 0 20 0>;\012    pos space uni10CC4 <-30 0 -30 0>;\012    pos space uni10CC7 <-10 0 -10 0>;\012    pos space uni10CC9 <-20 0 -20 0>;\012    pos space uni10CCB <10 0 10 0>;\012    pos space uni10CCC <-10 0 -10 0>;\012    pos space uni10CCD <40 0 40 0>;\012    pos space uni10CCE <20 0 20 0>;\012    pos space uni10CD0 <-30 0 -30 0>;\012    pos space uni10CD1 <-50 0 -50 0>;\012    pos space uni10CD2 <-30 0 -30 0>;\012    pos space uni10CD4 <-40 0 -40 0>;\012    pos space uni10CD6 <40 0 40 0>;\012    pos space uni10CD7 <-10 0 -10 0>;\012    pos space uni10CD9 <20 0 20 0>;\012    pos space uni10CE3 <-30 0 -30 0>;\012    pos space uni10CE4 <40 0 40 0>;\012    pos space uni10CE6 <-60 0 -60 0>;\012    pos space uni10CE7 <-80 0 -80 0>;\012    pos space uni10CE8 <20 0 20 0>;\012    pos space uni10CE9 <20 0 20 0>;\012    pos space uni10CEC <10 0 10 0>;\012    pos space uni10CED <-40 0 -40 0>;\012    pos space uni10CF0 <-60 0 -60 0>;\012    pos space uni10CF2 <-10 0 -10 0>;\012    pos space uni10CC0.ltr <-40 0 -40 0>;\012    pos space uni10CC2.ltr <20 0 20 0>;\012    pos space uni10CCC.ltr <-10 0 -10 0>;\012    pos space uni10CCD.ltr <40 0 40 0>;\012    pos space uni10CD6.ltr <40 0 40 0>;\012    pos space uni10CD7.ltr <-10 0 -10 0>;\012    pos space uni10CE4.ltr <40 0 40 0>;\012    pos space uni10CE6.ltr <-60 0 -60 0>;\012    pos space uni10CE8.ltr <20
+ 0 20 0>;\012    pos space uni10CE9.ltr <20 0 20 0>;\012    pos space uni10CF0.ltr <-60 0 -60 0>;\012    pos space uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C80 uni10CC0 <-40 0 -40 0>;\012    pos uni10C80 uni10CC1 <-30 0 -30 0>;\012    pos uni10C80 uni10CC2 <20 0 20 0>;\012    pos uni10C80 uni10CC4 <-30 0 -30 0>;\012    pos uni10C80 uni10CC7 <-10 0 -10 0>;\012    pos uni10C80 uni10CC9 <-20 0 -20 0>;\012    pos uni10C80 uni10CCB <10 0 10 0>;\012    pos uni10C80 uni10CCC <-10 0 -10 0>;\012    pos uni10C80 uni10CCD <40 0 40 0>;\012    pos uni10C80 uni10CCE <20 0 20 0>;\012    pos uni10C80 uni10CD0 <-30 0 -30 0>;\012    pos uni10C80 uni10CD1 <-50 0 -50 0>;\012    pos uni10C80 uni10CD2 <-30 0 -30 0>;\012    pos uni10C80 uni10CD4 <-40 0 -40 0>;\012    pos uni10C80 uni10CD6 <40 0 40 0>;\012    pos uni10C80 uni10CD7 <-10 0 -10 0>;\012    pos uni10C80 uni10CD9 <20 0 20 0>;\012    pos uni10C80 uni10CE3 <-30 0 -30 0>;\012    pos uni10C80 uni10CE4 <40 0 40 0>;\012    pos uni10C80 uni10CE6 <-60 0 -60 0>;\012    pos uni10C80 uni10CE7 <-80 0 -80 0>;\012    pos uni10C80 uni10CE8 <20 0 20 0>;\012    pos uni10C80 uni10CE9 <20 0 20 0>;\012    pos uni10C80 uni10CEC <10 0 10 0>;\012    pos uni10C80 uni10CED <-40 0 -40 0>;\012    pos uni10C80 uni10CF0 <-60 0 -60 0>;\012    pos uni10C80 uni10CF2 <-10 0 -10 0>;\012    pos uni10C80 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C80 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C80 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C80 uni10CCD.ltr <40 0 40 0>;\012    pos uni10C80 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C80 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C80 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C80 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C80 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C80 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C80 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C80 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C81 uni10CC0 <-40 0 -40 0>;\012    pos uni10C81 uni10CC1 <-30 0 -30 0>;\012    pos uni10C81 uni10CC2 <20 0 20 0>;\012    pos uni10C81 uni10CC4 <-30 0 -30 0>;\012    pos uni10C81 uni10CC7 <-10 0 -10 0>;\012    pos uni10C81 uni10CC9 <-20 0 -20 0>;\012    pos uni10C81 uni10CCB <10 0 10 0>;\012    pos uni10C81 uni10CCC <-10 0 -10 0>;\012    pos uni10C81 uni10CCD <40 0 40 0>;\012    pos uni10C81 uni10CCE <20 0 20 0>;\012    pos uni10C81 uni10CD0 <-30 0 -30 0>;\012    pos uni10C81 uni10CD1 <-50 0 -50 0>;\012    pos uni10C81 uni10CD2 <-30 0 -30 0>;\012    pos uni10C81 uni10CD4 <-40 0 -40 0>;\012    pos uni10C81 uni10CD6 <40 0 40 0>;\012    pos uni10C81 uni10CD7 <-10 0 -10 0>;\012    pos uni10C81 uni10CD9 <20 0 20 0>;\012    pos uni10C81 uni10CE3 <-30 0 -30 0>;\012    pos uni10C81 uni10CE4 <40 0 40 0>;\012    pos uni10C81 uni10CE6 <-60 0 -60 0>;\012    pos uni10C81 uni10CE7 <-80 0 -80 0>;\012    pos uni10C81 uni10CE8 <20 0 20 0>;\012    pos uni10C81 uni10CE9 <20 0 20 0>;\012    pos uni10C81 uni10CEC <10 0 10 0>;\012    pos uni10C81 uni10CED <-40 0 -40 0>;\012    pos uni10C81 uni10CF0 <-60 0 -60 0>;\012    pos uni10C81 uni10CF2 <-10 0 -10 0>;\012    pos uni10C81 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C81 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C81 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C81 uni10CCD.ltr <40 0 40 0>;\012    pos uni10C81 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C81 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C81 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C81 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C81 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C81 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C81 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C81 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C82 uni10CC0 <-40 0 -40 0>;\012    pos uni10C82 uni10CC1 <-30 0 -30 0>;\012    pos uni10C82 uni10CC2 <20 0 20 0>;\012    pos uni10C82 uni10CC4 <-30 0 -30 0>;\012    pos uni10C82 uni10CC7 <-10 0 -10 0>;\012    pos uni10C82 uni10CC9 <-20 0 -20 0>;\012    pos uni10C82 uni10CCB <10 0 10 0>;\012    pos uni10C82 uni10CCC <-10 0 -10 0>;\012    pos uni10C82 uni10CCD <40 0 40 0>;\012    pos uni10C82 uni10CCE <20 0 20 0>;\012    pos uni10C82 uni10CD0 <-30 0 -30 0>;\012    pos uni10C82 uni10CD1 <-50 0 -50 0>;\012    pos uni10C82 uni10CD2 <-30 0 -30 0>;\012    pos uni10C82 uni10CD4 <-40 0 -40 0>;\012    pos uni10C82 uni10CD6 <40 0 40 0>;\012    pos uni10C82 uni10CD7 <-10 0 -10 0>;\012    pos uni10C82 uni10CD9 <20 0 20 0>;\012    pos uni10C82 uni10CE3 <-30 0 -30 0>;\012    pos uni10C82 uni10CE4 <40 0 40 0>;\012    pos uni10C82 uni10CE6 <-60 0 -60 0>;\012    pos uni10C82 uni10CE7 <-80 0 -80 0>;\012    pos uni10C82 uni10CE8 <20 0 20 0>;\012    pos uni10C82 uni10CE9 <20 0 20 0>;\012    pos uni10C82 uni10CEC <10 0 10 0>;\012    pos uni10C82 uni10CED <-40 0 -40 0>;\012    pos uni10C82 uni10CF0 <-60 0 -60 0>;\012    pos uni10C82 uni10CF2 <-10 0 -10 0>;\012    pos uni10C82 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C82 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C82 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C82 uni10CCD.ltr <40 0 40 0>;\012    pos uni10C82 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C82 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C82 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C82 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C82 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C82 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C82 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C82 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C83 uni10CC0 <-40 0 -40 0>;\012    pos uni10C83 uni10CC1 <-30 0 -30 0>;\012    pos uni10C83 uni10CC2 <20 0 20 0>;\012    pos uni10C83 uni10CC4 <-30 0 -30 0>;\012    pos uni10C83 uni10CC7 <-10 0 -10 0>;\012    pos uni10C83 uni10CC9 <-20 0 -20 0>;\012    pos uni10C83 uni10CCB <10 0 10 0>;\012    pos uni10C83 uni10CCC <-10 0 -10 0>;\012    pos uni10C83 uni10CCD <40 0 40 0>;\012    pos uni10C83 uni10CCE <20 0 20 0>;\012    pos uni10C83 uni10CD0 <-30 0 -30 0>;\012    pos uni10C83 uni10CD1 <-50 0 -50 0>;\012    pos uni10C83 uni10CD2 <-30 0 -30 0>;\012    pos uni10C83 uni10CD4 <-40 0 -40 0>;\012    pos uni10C83 uni10CD6 <40 0 40 0>;\012    pos uni10C83 uni10CD7 <-10 0 -10 0>;\012    pos uni10C83 uni10CD9 <20 0 20 0>;\012    pos uni10C83 uni10CE3 <-30 0 -30 0>;\012    pos uni10C83 uni10CE4 <40 0 40 0>;\012    pos uni10C83 uni10CE6 <-60 0 -60 0>;\012    pos uni10C83 uni10CE7 <-80 0 -80 0>;\012    pos uni10C83 uni10CE8 <20 0 20 0>;\012    pos uni10C83 uni10CE9 <20 0 20 0>;\012    pos uni10C83 uni10CEC <10 0 10 0>;\012    pos uni10C83 uni10CED <-40 0 -40 0>;\012    pos uni10C83 uni10CF0 <-60 0 -60 0>;\012    pos uni10C83 uni10CF2 <-10 0 -10 0>;\012    pos uni10C83 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C83 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C83 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C83 uni10CCD.ltr <40 0 40 0>;\012    pos uni10C83 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C83 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C83 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C83 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C83 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C83 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C83 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C83 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C84 uni10CC0 <-40 0 -40 0>;\012    pos uni10C84 uni10CC1 <-30 0 -30 0>;\012    pos uni10C84 uni10CC2 <20 0 20 0>;\012    pos uni10C84 uni10CC4 <-30 0 -30 0>;\012    pos uni10C84 uni10CC7 <-10 0 -10 0>;\012    pos uni10C84 uni10CC9 <-20 0 -20 0>;\012    pos uni10C84 uni10CCB <10 0 10 0>;\012    pos uni10C84 uni10CCC <-10 0 -10 0>;\012    pos uni10C84 uni10CCD <40 0 40 0>;\012    pos uni10C84 uni10CCE <20 0 20 0>;\012    pos uni10C84 uni10CD0 <-30 0 -30 0>;\012    pos uni10C84 uni10CD1 <-50 0 -50 0>;\012    pos uni10C84 uni10CD2 <-30 0 -30 0>;\012    pos uni10C84 uni10CD4 <-40 0 -40 0>;\012    pos uni10C84 uni10CD6 <40 0 40 0>;\012    pos uni10C84 uni10CD7 <-10 0 -10 0>;\012    pos uni10C84 uni10CD9 <20 0 20 0>;\012    pos uni10C84 uni10CE3 <-30 0 -30 0>;\012    pos uni10C84 uni10CE4 <40 0 40 0>;\012    pos uni10C84 uni10CE6 <-60 0 -60 0>;\012    pos uni10C84 uni10CE7 <-80 0 -80 0>;\012    pos uni10C84 uni10CE8 <20 0 20 0>;\012    pos uni10C84 uni10CE9 <20 0 20 0>;\012    pos uni10C84 uni10CEC <10 0 10 0>;\012    pos uni10C84 uni10CED <-40 0 -40 0>;\012    pos uni10C84 uni10CF0 <-60 0 -60 0>;\012    pos uni10C84 uni10CF2 <-10 0 -10 0>;\012    pos uni10C84 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C84 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C84 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C84 uni10CCD.ltr <40 0 40 0>;\012    pos uni10C84 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C84 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C84 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C84 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C84 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C84 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C84 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C84 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C85 uni10CC0 <-40 0 -40 0>;\012    pos uni10C85 uni10CC1 <-30 0 -30 0>;\012    pos uni10C85 uni10CC2 <20 0 20 0>;\012    pos uni10C85 uni10CC4 <-30 0 -30 0>;\012    pos uni10C85 uni10CC7 <-10 0 -10 0>;\012    pos uni10C85 uni10CC9 <-20 0 -20 0>;\012    pos uni10C85 uni10CCB <10 0 10 0>;\012    pos uni10C85 uni10CCC <-10 0 -10 0>;\012    pos uni10C85 uni10CCD <40 0 40 0>;\012    pos uni10C85 uni10CCE <20 0 20 0>;\012    pos uni10C85 uni10CD0 <-30 0 -30 0>;\012    pos uni10C85 uni10CD1 <-50 0 -50 0>;\012    pos uni10C85 uni10CD2 <-30 0 -30 0>;\012    pos uni10C85 uni10CD4 <-40 0 -40 0>;\012    pos uni10C85 uni10CD6 <40 0 40 0>;\012    pos uni10C85 uni10CD7 <-10 0 -10 0>;\012    pos uni10C85 uni10CD9 <20 0 20 0>;\012    pos uni10C85 uni10CE3 <-30 0 -30 0>;\012    pos uni10C85 uni10CE4 <40 0 40 0>;\012    pos uni10C85 uni10CE6 <-60 0 -60 0>;\012    pos uni10C85 uni10CE7 <-80 0 -80 0>;\012    pos uni10C85 uni10CE8 <20 0 20 0>;\012    pos uni10C85 uni10CE9 <20 0 20 0>;\012    pos uni10C85 uni10CEC <10 0 10 0>;\012    pos uni10C85 uni10CED <-40 0 -40 0>;\012    pos uni10C85
+ uni10CF0 <-60 0 -60 0>;\012    pos uni10C85 uni10CF2 <-10 0 -10 0>;\012    pos uni10C85 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C85 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C85 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C85 uni10CCD.ltr <40 0 40 0>;\012    pos uni10C85 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C85 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C85 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C85 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C85 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C85 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C85 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C85 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C86 uni10CC0 <-40 0 -40 0>;\012    pos uni10C86 uni10CC1 <-30 0 -30 0>;\012    pos uni10C86 uni10CC2 <20 0 20 0>;\012    pos uni10C86 uni10CC4 <-30 0 -30 0>;\012    pos uni10C86 uni10CC7 <-10 0 -10 0>;\012    pos uni10C86 uni10CC9 <-20 0 -20 0>;\012    pos uni10C86 uni10CCB <10 0 10 0>;\012    pos uni10C86 uni10CCC <-10 0 -10 0>;\012    pos uni10C86 uni10CCD <40 0 40 0>;\012    pos uni10C86 uni10CCE <20 0 20 0>;\012    pos uni10C86 uni10CD0 <-30 0 -30 0>;\012    pos uni10C86 uni10CD1 <-50 0 -50 0>;\012    pos uni10C86 uni10CD2 <-30 0 -30 0>;\012    pos uni10C86 uni10CD4 <-40 0 -40 0>;\012    pos uni10C86 uni10CD6 <40 0 40 0>;\012    pos uni10C86 uni10CD7 <-10 0 -10 0>;\012    pos uni10C86 uni10CD9 <20 0 20 0>;\012    pos uni10C86 uni10CE3 <-30 0 -30 0>;\012    pos uni10C86 uni10CE4 <40 0 40 0>;\012    pos uni10C86 uni10CE6 <-60 0 -60 0>;\012    pos uni10C86 uni10CE7 <-80 0 -80 0>;\012    pos uni10C86 uni10CE8 <20 0 20 0>;\012    pos uni10C86 uni10CE9 <20 0 20 0>;\012    pos uni10C86 uni10CEC <10 0 10 0>;\012    pos uni10C86 uni10CED <-40 0 -40 0>;\012    pos uni10C86 uni10CF0 <-60 0 -60 0>;\012    pos uni10C86 uni10CF2 <-10 0 -10 0>;\012    pos uni10C86 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C86 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C86 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C86 uni10CCD.ltr <40 0 40 0>;\012    pos uni10C86 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C86 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C86 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C86 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C86 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C86 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C86 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C86 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C87 uni10CC0 <-40 0 -40 0>;\012    pos uni10C87 uni10CC1 <-30 0 -30 0>;\012    pos uni10C87 uni10CC2 <20 0 20 0>;\012    pos uni10C87 uni10CC4 <-30 0 -30 0>;\012    pos uni10C87 uni10CC7 <-10 0 -10 0>;\012    pos uni10C87 uni10CC9 <-20 0 -20 0>;\012    pos uni10C87 uni10CCB <10 0 10 0>;\012    pos uni10C87 uni10CCC <-10 0 -10 0>;\012    pos uni10C87 uni10CCD <40 0 40 0>;\012    pos uni10C87 uni10CCE <20 0 20 0>;\012    pos uni10C87 uni10CD0 <-30 0 -30 0>;\012    pos uni10C87 uni10CD1 <-50 0 -50 0>;\012    pos uni10C87 uni10CD2 <-30 0 -30 0>;\012    pos uni10C87 uni10CD4 <-40 0 -40 0>;\012    pos uni10C87 uni10CD6 <40 0 40 0>;\012    pos uni10C87 uni10CD7 <-10 0 -10 0>;\012    pos uni10C87 uni10CD9 <20 0 20 0>;\012    pos uni10C87 uni10CE3 <-30 0 -30 0>;\012    pos uni10C87 uni10CE4 <40 0 40 0>;\012    pos uni10C87 uni10CE6 <-60 0 -60 0>;\012    pos uni10C87 uni10CE7 <-80 0 -80 0>;\012    pos uni10C87 uni10CE8 <20 0 20 0>;\012    pos uni10C87 uni10CE9 <20 0 20 0>;\012    pos uni10C87 uni10CEC <10 0 10 0>;\012    pos uni10C87 uni10CED <-40 0 -40 0>;\012    pos uni10C87 uni10CF0 <-60 0 -60 0>;\012    pos uni10C87 uni10CF2 <-10 0 -10 0>;\012    pos uni10C87 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C87 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C87 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C87 uni10CCD.ltr <40 0 40 0>;\012    pos uni10C87 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C87 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C87 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C87 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C87 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C87 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C87 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C87 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C88 uni10CC0 <-40 0 -40 0>;\012    pos uni10C88 uni10CC1 <-30 0 -30 0>;\012    pos uni10C88 uni10CC2 <20 0 20 0>;\012    pos uni10C88 uni10CC4 <-30 0 -30 0>;\012    pos uni10C88 uni10CC7 <-10 0 -10 0>;\012    pos uni10C88 uni10CC9 <-20 0 -20 0>;\012    pos uni10C88 uni10CCB <10 0 10 0>;\012    pos uni10C88 uni10CCC <-10 0 -10 0>;\012    pos uni10C88 uni10CCD <40 0 40 0>;\012    pos uni10C88 uni10CCE <20 0 20 0>;\012    pos uni10C88 uni10CD0 <-30 0 -30 0>;\012    pos uni10C88 uni10CD1 <-50 0 -50 0>;\012    pos uni10C88 uni10CD2 <-30 0 -30 0>;\012    pos uni10C88 uni10CD4 <-40 0 -40 0>;\012    pos uni10C88 uni10CD6 <40 0 40 0>;\012    pos uni10C88 uni10CD7 <-10 0 -10 0>;\012    pos uni10C88 uni10CD9 <20 0 20 0>;\012    pos uni10C88 uni10CE3 <-30 0 -30 0>;\012    pos uni10C88 uni10CE4 <40 0 40 0>;\012    pos uni10C88 uni10CE6 <-60 0 -60 0>;\012    pos uni10C88 uni10CE7 <-80 0 -80 0>;\012    pos uni10C88 uni10CE8 <20 0 20 0>;\012    pos uni10C88 uni10CE9 <20 0 20 0>;\012    pos uni10C88 uni10CEC <10 0 10 0>;\012    pos uni10C88 uni10CED <-40 0 -40 0>;\012    pos uni10C88 uni10CF0 <-60 0 -60 0>;\012    pos uni10C88 uni10CF2 <-10 0 -10 0>;\012    pos uni10C88 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C88 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C88 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C88 uni10CCD.ltr <40 0 40 0>;\012    pos uni10C88 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C88 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C88 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C88 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C88 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C88 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C88 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C88 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C89 uni10CC0 <-40 0 -40 0>;\012    pos uni10C89 uni10CC1 <-30 0 -30 0>;\012    pos uni10C89 uni10CC2 <20 0 20 0>;\012    pos uni10C89 uni10CC4 <-30 0 -30 0>;\012    pos uni10C89 uni10CC7 <-10 0 -10 0>;\012    pos uni10C89 uni10CC9 <-20 0 -20 0>;\012    pos uni10C89 uni10CCB <10 0 10 0>;\012    pos uni10C89 uni10CCC <-10 0 -10 0>;\012    pos uni10C89 uni10CCD <40 0 40 0>;\012    pos uni10C89 uni10CCE <20 0 20 0>;\012    pos uni10C89 uni10CD0 <-30 0 -30 0>;\012    pos uni10C89 uni10CD1 <-50 0 -50 0>;\012    pos uni10C89 uni10CD2 <-30 0 -30 0>;\012    pos uni10C89 uni10CD4 <-40 0 -40 0>;\012    pos uni10C89 uni10CD6 <40 0 40 0>;\012    pos uni10C89 uni10CD7 <-10 0 -10 0>;\012    pos uni10C89 uni10CD9 <20 0 20 0>;\012    pos uni10C89 uni10CE3 <-30 0 -30 0>;\012    pos uni10C89 uni10CE4 <40 0 40 0>;\012    pos uni10C89 uni10CE6 <-60 0 -60 0>;\012    pos uni10C89 uni10CE7 <-80 0 -80 0>;\012    pos uni10C89 uni10CE8 <20 0 20 0>;\012    pos uni10C89 uni10CE9 <20 0 20 0>;\012    pos uni10C89 uni10CEC <10 0 10 0>;\012    pos uni10C89 uni10CED <-40 0 -40 0>;\012    pos uni10C89 uni10CF0 <-60 0 -60 0>;\012    pos uni10C89 uni10CF2 <-10 0 -10 0>;\012    pos uni10C89 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C89 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C89 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C89 uni10CCD.ltr <40 0 40 0>;\012    pos uni10C89 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C89 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C89 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C89 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C89 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C89 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C89 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C89 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C8A uni10CC0 <-40 0 -40 0>;\012    pos uni10C8A uni10CC1 <-30 0 -30 0>;\012    pos uni10C8A uni10CC2 <20 0 20 0>;\012    pos uni10C8A uni10CC4 <-30 0 -30 0>;\012    pos uni10C8A uni10CC7 <-10 0 -10 0>;\012    pos uni10C8A uni10CC9 <-20 0 -20 0>;\012    pos uni10C8A uni10CCB <10 0 10 0>;\012    pos uni10C8A uni10CCC <-10 0 -10 0>;\012    pos uni10C8A uni10CCD <40 0 40 0>;\012    pos uni10C8A uni10CCE <20 0 20 0>;\012    pos uni10C8A uni10CD0 <-30 0 -30 0>;\012    pos uni10C8A uni10CD1 <-50 0 -50 0>;\012    pos uni10C8A uni10CD2 <-30 0 -30 0>;\012    pos uni10C8A uni10CD4 <-40 0 -40 0>;\012    pos uni10C8A uni10CD6 <40 0 40 0>;\012    pos uni10C8A uni10CD7 <-10 0 -10 0>;\012    pos uni10C8A uni10CD9 <20 0 20 0>;\012    pos uni10C8A uni10CE3 <-30 0 -30 0>;\012    pos uni10C8A uni10CE4 <40 0 40 0>;\012    pos uni10C8A uni10CE6 <-60 0 -60 0>;\012    pos uni10C8A uni10CE7 <-80 0 -80 0>;\012    pos uni10C8A uni10CE8 <20 0 20 0>;\012    pos uni10C8A uni10CE9 <20 0 20 0>;\012    pos uni10C8A uni10CEC <10 0 10 0>;\012    pos uni10C8A uni10CED <-40 0 -40 0>;\012    pos uni10C8A uni10CF0 <-60 0 -60 0>;\012    pos uni10C8A uni10CF2 <-10 0 -10 0>;\012    pos uni10C8A uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C8A uni10CC2.ltr <20 0 20 0>;\012    pos uni10C8A uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C8A uni10CCD.ltr <40 0 40 0>;\012    pos uni10C8A uni10CD6.ltr <40 0 40 0>;\012    pos uni10C8A uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C8A uni10CE4.ltr <40 0 40 0>;\012    pos uni10C8A uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C8A uni10CE8.ltr <20 0 20 0>;\012    pos uni10C8A uni10CE9.ltr <20 0 20 0>;\012    pos uni10C8A uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C8A uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C8B uni10CC0 <-40 0 -40 0>;\012    pos uni10C8B uni10CC1 <-30 0 -30 0>;\012    pos uni10C8B uni10CC2 <20 0 20 0>;\012    pos uni10C8B uni10CC4 <-30 0 -30 0>;\012    pos uni10C8B uni10CC7 <-10 0 -10 0>;\012    pos uni10C8B uni10CC9 <-20 0 -20 0>;\012    pos uni10C8B uni10CCB <10 0 10 0>;\012    pos uni10C8B uni10CCC <-10 0 -10 0>;\012    pos uni10C8B uni10CCD <40 0 40 0>;\012    pos uni10C8B uni10CCE <20 0 20 0>;\012    pos uni10C8B uni10CD0 <-30 0 -30 0>;\012    pos uni10C8B uni10CD1 <-50 0 -50 0>;\012    pos uni10C8B uni10CD2 <-30 0 -30 0>;\012    pos uni10C8B uni10CD4 <-40 0 -40 0>;\012
+    pos uni10C8B uni10CD6 <40 0 40 0>;\012    pos uni10C8B uni10CD7 <-10 0 -10 0>;\012    pos uni10C8B uni10CD9 <20 0 20 0>;\012    pos uni10C8B uni10CE3 <-30 0 -30 0>;\012    pos uni10C8B uni10CE4 <40 0 40 0>;\012    pos uni10C8B uni10CE6 <-60 0 -60 0>;\012    pos uni10C8B uni10CE7 <-80 0 -80 0>;\012    pos uni10C8B uni10CE8 <20 0 20 0>;\012    pos uni10C8B uni10CE9 <20 0 20 0>;\012    pos uni10C8B uni10CEC <10 0 10 0>;\012    pos uni10C8B uni10CED <-40 0 -40 0>;\012    pos uni10C8B uni10CF0 <-60 0 -60 0>;\012    pos uni10C8B uni10CF2 <-10 0 -10 0>;\012    pos uni10C8B uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C8B uni10CC2.ltr <20 0 20 0>;\012    pos uni10C8B uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C8B uni10CCD.ltr <40 0 40 0>;\012    pos uni10C8B uni10CD6.ltr <40 0 40 0>;\012    pos uni10C8B uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C8B uni10CE4.ltr <40 0 40 0>;\012    pos uni10C8B uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C8B uni10CE8.ltr <20 0 20 0>;\012    pos uni10C8B uni10CE9.ltr <20 0 20 0>;\012    pos uni10C8B uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C8B uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C8C uni10CC0 <-40 0 -40 0>;\012    pos uni10C8C uni10CC1 <-30 0 -30 0>;\012    pos uni10C8C uni10CC2 <20 0 20 0>;\012    pos uni10C8C uni10CC4 <-30 0 -30 0>;\012    pos uni10C8C uni10CC7 <-10 0 -10 0>;\012    pos uni10C8C uni10CC9 <-20 0 -20 0>;\012    pos uni10C8C uni10CCB <10 0 10 0>;\012    pos uni10C8C uni10CCC <-10 0 -10 0>;\012    pos uni10C8C uni10CCD <40 0 40 0>;\012    pos uni10C8C uni10CCE <20 0 20 0>;\012    pos uni10C8C uni10CD0 <-30 0 -30 0>;\012    pos uni10C8C uni10CD1 <-50 0 -50 0>;\012    pos uni10C8C uni10CD2 <-30 0 -30 0>;\012    pos uni10C8C uni10CD4 <-40 0 -40 0>;\012    pos uni10C8C uni10CD6 <40 0 40 0>;\012    pos uni10C8C uni10CD7 <-10 0 -10 0>;\012    pos uni10C8C uni10CD9 <20 0 20 0>;\012    pos uni10C8C uni10CE3 <-30 0 -30 0>;\012    pos uni10C8C uni10CE4 <40 0 40 0>;\012    pos uni10C8C uni10CE6 <-60 0 -60 0>;\012    pos uni10C8C uni10CE7 <-80 0 -80 0>;\012    pos uni10C8C uni10CE8 <20 0 20 0>;\012    pos uni10C8C uni10CE9 <20 0 20 0>;\012    pos uni10C8C uni10CEC <10 0 10 0>;\012    pos uni10C8C uni10CED <-40 0 -40 0>;\012    pos uni10C8C uni10CF0 <-60 0 -60 0>;\012    pos uni10C8C uni10CF2 <-10 0 -10 0>;\012    pos uni10C8C uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C8C uni10CC2.ltr <20 0 20 0>;\012    pos uni10C8C uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C8C uni10CCD.ltr <40 0 40 0>;\012    pos uni10C8C uni10CD6.ltr <40 0 40 0>;\012    pos uni10C8C uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C8C uni10CE4.ltr <40 0 40 0>;\012    pos uni10C8C uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C8C uni10CE8.ltr <20 0 20 0>;\012    pos uni10C8C uni10CE9.ltr <20 0 20 0>;\012    pos uni10C8C uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C8C uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C8D uni10CC0 <-40 0 -40 0>;\012    pos uni10C8D uni10CC1 <-30 0 -30 0>;\012    pos uni10C8D uni10CC2 <20 0 20 0>;\012    pos uni10C8D uni10CC4 <-30 0 -30 0>;\012    pos uni10C8D uni10CC7 <-10 0 -10 0>;\012    pos uni10C8D uni10CC9 <-20 0 -20 0>;\012    pos uni10C8D uni10CCB <10 0 10 0>;\012    pos uni10C8D uni10CCC <-10 0 -10 0>;\012    pos uni10C8D uni10CCD <40 0 40 0>;\012    pos uni10C8D uni10CCE <20 0 20 0>;\012    pos uni10C8D uni10CD0 <-30 0 -30 0>;\012    pos uni10C8D uni10CD1 <-50 0 -50 0>;\012    pos uni10C8D uni10CD2 <-30 0 -30 0>;\012    pos uni10C8D uni10CD4 <-40 0 -40 0>;\012    pos uni10C8D uni10CD6 <40 0 40 0>;\012    pos uni10C8D uni10CD7 <-10 0 -10 0>;\012    pos uni10C8D uni10CD9 <20 0 20 0>;\012    pos uni10C8D uni10CE3 <-30 0 -30 0>;\012    pos uni10C8D uni10CE4 <40 0 40 0>;\012    pos uni10C8D uni10CE6 <-60 0 -60 0>;\012    pos uni10C8D uni10CE7 <-80 0 -80 0>;\012    pos uni10C8D uni10CE8 <20 0 20 0>;\012    pos uni10C8D uni10CE9 <20 0 20 0>;\012    pos uni10C8D uni10CEC <10 0 10 0>;\012    pos uni10C8D uni10CED <-40 0 -40 0>;\012    pos uni10C8D uni10CF0 <-60 0 -60 0>;\012    pos uni10C8D uni10CF2 <-10 0 -10 0>;\012    pos uni10C8D uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C8D uni10CC2.ltr <20 0 20 0>;\012    pos uni10C8D uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C8D uni10CCD.ltr <40 0 40 0>;\012    pos uni10C8D uni10CD6.ltr <40 0 40 0>;\012    pos uni10C8D uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C8D uni10CE4.ltr <40 0 40 0>;\012    pos uni10C8D uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C8D uni10CE8.ltr <20 0 20 0>;\012    pos uni10C8D uni10CE9.ltr <20 0 20 0>;\012    pos uni10C8D uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C8D uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C8E uni10CC0 <-40 0 -40 0>;\012    pos uni10C8E uni10CC1 <-30 0 -30 0>;\012    pos uni10C8E uni10CC2 <20 0 20 0>;\012    pos uni10C8E uni10CC4 <-30 0 -30 0>;\012    pos uni10C8E uni10CC7 <-10 0 -10 0>;\012    pos uni10C8E uni10CC9 <-20 0 -20 0>;\012    pos uni10C8E uni10CCB <10 0 10 0>;\012    pos uni10C8E uni10CCC <-10 0 -10 0>;\012    pos uni10C8E uni10CCD <40 0 40 0>;\012    pos uni10C8E uni10CCE <20 0 20 0>;\012    pos uni10C8E uni10CD0 <-30 0 -30 0>;\012    pos uni10C8E uni10CD1 <-50 0 -50 0>;\012    pos uni10C8E uni10CD2 <-30 0 -30 0>;\012    pos uni10C8E uni10CD4 <-40 0 -40 0>;\012    pos uni10C8E uni10CD6 <40 0 40 0>;\012    pos uni10C8E uni10CD7 <-10 0 -10 0>;\012    pos uni10C8E uni10CD9 <20 0 20 0>;\012    pos uni10C8E uni10CE3 <-30 0 -30 0>;\012    pos uni10C8E uni10CE4 <40 0 40 0>;\012    pos uni10C8E uni10CE6 <-60 0 -60 0>;\012    pos uni10C8E uni10CE7 <-80 0 -80 0>;\012    pos uni10C8E uni10CE8 <20 0 20 0>;\012    pos uni10C8E uni10CE9 <20 0 20 0>;\012    pos uni10C8E uni10CEC <10 0 10 0>;\012    pos uni10C8E uni10CED <-40 0 -40 0>;\012    pos uni10C8E uni10CF0 <-60 0 -60 0>;\012    pos uni10C8E uni10CF2 <-10 0 -10 0>;\012    pos uni10C8E uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C8E uni10CC2.ltr <20 0 20 0>;\012    pos uni10C8E uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C8E uni10CCD.ltr <40 0 40 0>;\012    pos uni10C8E uni10CD6.ltr <40 0 40 0>;\012    pos uni10C8E uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C8E uni10CE4.ltr <40 0 40 0>;\012    pos uni10C8E uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C8E uni10CE8.ltr <20 0 20 0>;\012    pos uni10C8E uni10CE9.ltr <20 0 20 0>;\012    pos uni10C8E uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C8E uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C8F uni10CC0 <-40 0 -40 0>;\012    pos uni10C8F uni10CC1 <-30 0 -30 0>;\012    pos uni10C8F uni10CC2 <20 0 20 0>;\012    pos uni10C8F uni10CC4 <-30 0 -30 0>;\012    pos uni10C8F uni10CC7 <-10 0 -10 0>;\012    pos uni10C8F uni10CC9 <-20 0 -20 0>;\012    pos uni10C8F uni10CCB <10 0 10 0>;\012    pos uni10C8F uni10CCC <-10 0 -10 0>;\012    pos uni10C8F uni10CCD <40 0 40 0>;\012    pos uni10C8F uni10CCE <20 0 20 0>;\012    pos uni10C8F uni10CD0 <-30 0 -30 0>;\012    pos uni10C8F uni10CD1 <-50 0 -50 0>;\012    pos uni10C8F uni10CD2 <-30 0 -30 0>;\012    pos uni10C8F uni10CD4 <-40 0 -40 0>;\012    pos uni10C8F uni10CD6 <40 0 40 0>;\012    pos uni10C8F uni10CD7 <-10 0 -10 0>;\012    pos uni10C8F uni10CD9 <20 0 20 0>;\012    pos uni10C8F uni10CE3 <-30 0 -30 0>;\012    pos uni10C8F uni10CE4 <40 0 40 0>;\012    pos uni10C8F uni10CE6 <-60 0 -60 0>;\012    pos uni10C8F uni10CE7 <-80 0 -80 0>;\012    pos uni10C8F uni10CE8 <20 0 20 0>;\012    pos uni10C8F uni10CE9 <20 0 20 0>;\012    pos uni10C8F uni10CEC <10 0 10 0>;\012    pos uni10C8F uni10CED <-40 0 -40 0>;\012    pos uni10C8F uni10CF0 <-60 0 -60 0>;\012    pos uni10C8F uni10CF2 <-10 0 -10 0>;\012    pos uni10C8F uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C8F uni10CC2.ltr <20 0 20 0>;\012    pos uni10C8F uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C8F uni10CCD.ltr <40 0 40 0>;\012    pos uni10C8F uni10CD6.ltr <40 0 40 0>;\012    pos uni10C8F uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C8F uni10CE4.ltr <40 0 40 0>;\012    pos uni10C8F uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C8F uni10CE8.ltr <20 0 20 0>;\012    pos uni10C8F uni10CE9.ltr <20 0 20 0>;\012    pos uni10C8F uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C8F uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C90 uni10CC0 <-40 0 -40 0>;\012    pos uni10C90 uni10CC1 <-30 0 -30 0>;\012    pos uni10C90 uni10CC2 <20 0 20 0>;\012    pos uni10C90 uni10CC4 <-30 0 -30 0>;\012    pos uni10C90 uni10CC7 <-10 0 -10 0>;\012    pos uni10C90 uni10CC9 <-20 0 -20 0>;\012    pos uni10C90 uni10CCB <10 0 10 0>;\012    pos uni10C90 uni10CCC <-10 0 -10 0>;\012    pos uni10C90 uni10CCD <40 0 40 0>;\012    pos uni10C90 uni10CCE <20 0 20 0>;\012    pos uni10C90 uni10CD0 <-30 0 -30 0>;\012    pos uni10C90 uni10CD1 <-50 0 -50 0>;\012    pos uni10C90 uni10CD2 <-30 0 -30 0>;\012    pos uni10C90 uni10CD4 <-40 0 -40 0>;\012    pos uni10C90 uni10CD6 <40 0 40 0>;\012    pos uni10C90 uni10CD7 <-10 0 -10 0>;\012    pos uni10C90 uni10CD9 <20 0 20 0>;\012    pos uni10C90 uni10CE3 <-30 0 -30 0>;\012    pos uni10C90 uni10CE4 <40 0 40 0>;\012    pos uni10C90 uni10CE6 <-60 0 -60 0>;\012    pos uni10C90 uni10CE7 <-80 0 -80 0>;\012    pos uni10C90 uni10CE8 <20 0 20 0>;\012    pos uni10C90 uni10CE9 <20 0 20 0>;\012    pos uni10C90 uni10CEC <10 0 10 0>;\012    pos uni10C90 uni10CED <-40 0 -40 0>;\012    pos uni10C90 uni10CF0 <-60 0 -60 0>;\012    pos uni10C90 uni10CF2 <-10 0 -10 0>;\012    pos uni10C90 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C90 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C90 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C90 uni10CCD.ltr <40 0 40 0>;\012    pos uni10C90 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C90 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C90 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C90 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C90 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C90 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C90 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C90 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C91 uni10CC0 <-40 0 -40 0>;\012    pos uni10C91 uni10CC1 <-30 0 -30 0>;\012    pos uni10C91 uni10CC2 <20
+ 0 20 0>;\012    pos uni10C91 uni10CC4 <-30 0 -30 0>;\012    pos uni10C91 uni10CC7 <-10 0 -10 0>;\012    pos uni10C91 uni10CC9 <-20 0 -20 0>;\012    pos uni10C91 uni10CCB <10 0 10 0>;\012    pos uni10C91 uni10CCC <-10 0 -10 0>;\012    pos uni10C91 uni10CCD <40 0 40 0>;\012    pos uni10C91 uni10CCE <20 0 20 0>;\012    pos uni10C91 uni10CD0 <-30 0 -30 0>;\012    pos uni10C91 uni10CD1 <-50 0 -50 0>;\012    pos uni10C91 uni10CD2 <-30 0 -30 0>;\012    pos uni10C91 uni10CD4 <-40 0 -40 0>;\012    pos uni10C91 uni10CD6 <40 0 40 0>;\012    pos uni10C91 uni10CD7 <-10 0 -10 0>;\012    pos uni10C91 uni10CD9 <20 0 20 0>;\012    pos uni10C91 uni10CE3 <-30 0 -30 0>;\012    pos uni10C91 uni10CE4 <40 0 40 0>;\012    pos uni10C91 uni10CE6 <-60 0 -60 0>;\012    pos uni10C91 uni10CE7 <-80 0 -80 0>;\012    pos uni10C91 uni10CE8 <20 0 20 0>;\012    pos uni10C91 uni10CE9 <20 0 20 0>;\012    pos uni10C91 uni10CEC <10 0 10 0>;\012    pos uni10C91 uni10CED <-40 0 -40 0>;\012    pos uni10C91 uni10CF0 <-60 0 -60 0>;\012    pos uni10C91 uni10CF2 <-10 0 -10 0>;\012    pos uni10C91 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C91 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C91 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C91 uni10CCD.ltr <40 0 40 0>;\012    pos uni10C91 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C91 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C91 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C91 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C91 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C91 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C91 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C91 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C92 uni10CC0 <-40 0 -40 0>;\012    pos uni10C92 uni10CC1 <-30 0 -30 0>;\012    pos uni10C92 uni10CC2 <20 0 20 0>;\012    pos uni10C92 uni10CC4 <-30 0 -30 0>;\012    pos uni10C92 uni10CC7 <-10 0 -10 0>;\012    pos uni10C92 uni10CC9 <-20 0 -20 0>;\012    pos uni10C92 uni10CCB <10 0 10 0>;\012    pos uni10C92 uni10CCC <-10 0 -10 0>;\012    pos uni10C92 uni10CCD <40 0 40 0>;\012    pos uni10C92 uni10CCE <20 0 20 0>;\012    pos uni10C92 uni10CD0 <-30 0 -30 0>;\012    pos uni10C92 uni10CD1 <-50 0 -50 0>;\012    pos uni10C92 uni10CD2 <-30 0 -30 0>;\012    pos uni10C92 uni10CD4 <-40 0 -40 0>;\012    pos uni10C92 uni10CD6 <40 0 40 0>;\012    pos uni10C92 uni10CD7 <-10 0 -10 0>;\012    pos uni10C92 uni10CD9 <20 0 20 0>;\012    pos uni10C92 uni10CE3 <-30 0 -30 0>;\012    pos uni10C92 uni10CE4 <40 0 40 0>;\012    pos uni10C92 uni10CE6 <-60 0 -60 0>;\012    pos uni10C92 uni10CE7 <-80 0 -80 0>;\012    pos uni10C92 uni10CE8 <20 0 20 0>;\012    pos uni10C92 uni10CE9 <20 0 20 0>;\012    pos uni10C92 uni10CEC <10 0 10 0>;\012    pos uni10C92 uni10CED <-40 0 -40 0>;\012    pos uni10C92 uni10CF0 <-60 0 -60 0>;\012    pos uni10C92 uni10CF2 <-10 0 -10 0>;\012    pos uni10C92 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C92 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C92 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C92 uni10CCD.ltr <40 0 40 0>;\012    pos uni10C92 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C92 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C92 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C92 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C92 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C92 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C92 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C92 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C93 uni10CC0 <-40 0 -40 0>;\012    pos uni10C93 uni10CC1 <-30 0 -30 0>;\012    pos uni10C93 uni10CC2 <20 0 20 0>;\012    pos uni10C93 uni10CC4 <-30 0 -30 0>;\012    pos uni10C93 uni10CC7 <-10 0 -10 0>;\012    pos uni10C93 uni10CC9 <-20 0 -20 0>;\012    pos uni10C93 uni10CCB <10 0 10 0>;\012    pos uni10C93 uni10CCC <-10 0 -10 0>;\012    pos uni10C93 uni10CCD <40 0 40 0>;\012    pos uni10C93 uni10CCE <20 0 20 0>;\012    pos uni10C93 uni10CD0 <-30 0 -30 0>;\012    pos uni10C93 uni10CD1 <-50 0 -50 0>;\012    pos uni10C93 uni10CD2 <-30 0 -30 0>;\012    pos uni10C93 uni10CD4 <-40 0 -40 0>;\012    pos uni10C93 uni10CD6 <40 0 40 0>;\012    pos uni10C93 uni10CD7 <-10 0 -10 0>;\012    pos uni10C93 uni10CD9 <20 0 20 0>;\012    pos uni10C93 uni10CE3 <-30 0 -30 0>;\012    pos uni10C93 uni10CE4 <40 0 40 0>;\012    pos uni10C93 uni10CE6 <-60 0 -60 0>;\012    pos uni10C93 uni10CE7 <-80 0 -80 0>;\012    pos uni10C93 uni10CE8 <20 0 20 0>;\012    pos uni10C93 uni10CE9 <20 0 20 0>;\012    pos uni10C93 uni10CEC <10 0 10 0>;\012    pos uni10C93 uni10CED <-40 0 -40 0>;\012    pos uni10C93 uni10CF0 <-60 0 -60 0>;\012    pos uni10C93 uni10CF2 <-10 0 -10 0>;\012    pos uni10C93 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C93 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C93 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C93 uni10CCD.ltr <40 0 40 0>;\012    pos uni10C93 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C93 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C93 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C93 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C93 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C93 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C93 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C93 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C94 uni10CC0 <-40 0 -40 0>;\012    pos uni10C94 uni10CC1 <-30 0 -30 0>;\012    pos uni10C94 uni10CC2 <20 0 20 0>;\012    pos uni10C94 uni10CC4 <-30 0 -30 0>;\012    pos uni10C94 uni10CC7 <-10 0 -10 0>;\012    pos uni10C94 uni10CC9 <-20 0 -20 0>;\012    pos uni10C94 uni10CCB <10 0 10 0>;\012    pos uni10C94 uni10CCC <-10 0 -10 0>;\012    pos uni10C94 uni10CCD <40 0 40 0>;\012    pos uni10C94 uni10CCE <20 0 20 0>;\012    pos uni10C94 uni10CD0 <-30 0 -30 0>;\012    pos uni10C94 uni10CD1 <-50 0 -50 0>;\012    pos uni10C94 uni10CD2 <-30 0 -30 0>;\012    pos uni10C94 uni10CD4 <-40 0 -40 0>;\012    pos uni10C94 uni10CD6 <40 0 40 0>;\012    pos uni10C94 uni10CD7 <-10 0 -10 0>;\012    pos uni10C94 uni10CD9 <20 0 20 0>;\012    pos uni10C94 uni10CE3 <-30 0 -30 0>;\012    pos uni10C94 uni10CE4 <40 0 40 0>;\012    pos uni10C94 uni10CE6 <-60 0 -60 0>;\012    pos uni10C94 uni10CE7 <-80 0 -80 0>;\012    pos uni10C94 uni10CE8 <20 0 20 0>;\012    pos uni10C94 uni10CE9 <20 0 20 0>;\012    pos uni10C94 uni10CEC <10 0 10 0>;\012    pos uni10C94 uni10CED <-40 0 -40 0>;\012    pos uni10C94 uni10CF0 <-60 0 -60 0>;\012    pos uni10C94 uni10CF2 <-10 0 -10 0>;\012    pos uni10C94 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C94 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C94 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C94 uni10CCD.ltr <40 0 40 0>;\012    pos uni10C94 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C94 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C94 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C94 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C94 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C94 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C94 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C94 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C95 uni10CC0 <-40 0 -40 0>;\012    pos uni10C95 uni10CC1 <-30 0 -30 0>;\012    pos uni10C95 uni10CC2 <20 0 20 0>;\012    pos uni10C95 uni10CC4 <-30 0 -30 0>;\012    pos uni10C95 uni10CC7 <-10 0 -10 0>;\012    pos uni10C95 uni10CC9 <-20 0 -20 0>;\012    pos uni10C95 uni10CCB <10 0 10 0>;\012    pos uni10C95 uni10CCC <-10 0 -10 0>;\012    pos uni10C95 uni10CCD <40 0 40 0>;\012    pos uni10C95 uni10CCE <20 0 20 0>;\012    pos uni10C95 uni10CD0 <-30 0 -30 0>;\012    pos uni10C95 uni10CD1 <-50 0 -50 0>;\012    pos uni10C95 uni10CD2 <-30 0 -30 0>;\012    pos uni10C95 uni10CD4 <-40 0 -40 0>;\012    pos uni10C95 uni10CD6 <40 0 40 0>;\012    pos uni10C95 uni10CD7 <-10 0 -10 0>;\012    pos uni10C95 uni10CD9 <20 0 20 0>;\012    pos uni10C95 uni10CE3 <-30 0 -30 0>;\012    pos uni10C95 uni10CE4 <40 0 40 0>;\012    pos uni10C95 uni10CE6 <-60 0 -60 0>;\012    pos uni10C95 uni10CE7 <-80 0 -80 0>;\012    pos uni10C95 uni10CE8 <20 0 20 0>;\012    pos uni10C95 uni10CE9 <20 0 20 0>;\012    pos uni10C95 uni10CEC <10 0 10 0>;\012    pos uni10C95 uni10CED <-40 0 -40 0>;\012    pos uni10C95 uni10CF0 <-60 0 -60 0>;\012    pos uni10C95 uni10CF2 <-10 0 -10 0>;\012    pos uni10C95 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C95 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C95 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C95 uni10CCD.ltr <40 0 40 0>;\012    pos uni10C95 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C95 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C95 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C95 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C95 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C95 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C95 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C95 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C96 uni10CC0 <-40 0 -40 0>;\012    pos uni10C96 uni10CC1 <-30 0 -30 0>;\012    pos uni10C96 uni10CC2 <20 0 20 0>;\012    pos uni10C96 uni10CC4 <-30 0 -30 0>;\012    pos uni10C96 uni10CC7 <-10 0 -10 0>;\012    pos uni10C96 uni10CC9 <-20 0 -20 0>;\012    pos uni10C96 uni10CCB <10 0 10 0>;\012    pos uni10C96 uni10CCC <-10 0 -10 0>;\012    pos uni10C96 uni10CCD <40 0 40 0>;\012    pos uni10C96 uni10CCE <20 0 20 0>;\012    pos uni10C96 uni10CD0 <-30 0 -30 0>;\012    pos uni10C96 uni10CD1 <-50 0 -50 0>;\012    pos uni10C96 uni10CD2 <-30 0 -30 0>;\012    pos uni10C96 uni10CD4 <-40 0 -40 0>;\012    pos uni10C96 uni10CD6 <40 0 40 0>;\012    pos uni10C96 uni10CD7 <-10 0 -10 0>;\012    pos uni10C96 uni10CD9 <20 0 20 0>;\012    pos uni10C96 uni10CE3 <-30 0 -30 0>;\012    pos uni10C96 uni10CE4 <40 0 40 0>;\012    pos uni10C96 uni10CE6 <-60 0 -60 0>;\012    pos uni10C96 uni10CE7 <-80 0 -80 0>;\012    pos uni10C96 uni10CE8 <20 0 20 0>;\012    pos uni10C96 uni10CE9 <20 0 20 0>;\012    pos uni10C96 uni10CEC <10 0 10 0>;\012    pos uni10C96 uni10CED <-40 0 -40 0>;\012    pos uni10C96 uni10CF0 <-60 0 -60 0>;\012    pos uni10C96 uni10CF2 <-10 0 -10 0>;\012    pos uni10C96 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C96 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C96 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C96 uni10CCD.ltr <40 0 40 0>;\012 
+   pos uni10C96 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C96 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C96 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C96 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C96 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C96 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C96 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C96 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C97 uni10CC0 <-40 0 -40 0>;\012    pos uni10C97 uni10CC1 <-30 0 -30 0>;\012    pos uni10C97 uni10CC2 <20 0 20 0>;\012    pos uni10C97 uni10CC4 <-30 0 -30 0>;\012    pos uni10C97 uni10CC7 <-10 0 -10 0>;\012    pos uni10C97 uni10CC9 <-20 0 -20 0>;\012    pos uni10C97 uni10CCB <10 0 10 0>;\012    pos uni10C97 uni10CCC <-10 0 -10 0>;\012    pos uni10C97 uni10CCD <40 0 40 0>;\012    pos uni10C97 uni10CCE <20 0 20 0>;\012    pos uni10C97 uni10CD0 <-30 0 -30 0>;\012    pos uni10C97 uni10CD1 <-50 0 -50 0>;\012    pos uni10C97 uni10CD2 <-30 0 -30 0>;\012    pos uni10C97 uni10CD4 <-40 0 -40 0>;\012    pos uni10C97 uni10CD6 <40 0 40 0>;\012    pos uni10C97 uni10CD7 <-10 0 -10 0>;\012    pos uni10C97 uni10CD9 <20 0 20 0>;\012    pos uni10C97 uni10CE3 <-30 0 -30 0>;\012    pos uni10C97 uni10CE4 <40 0 40 0>;\012    pos uni10C97 uni10CE6 <-60 0 -60 0>;\012    pos uni10C97 uni10CE7 <-80 0 -80 0>;\012    pos uni10C97 uni10CE8 <20 0 20 0>;\012    pos uni10C97 uni10CE9 <20 0 20 0>;\012    pos uni10C97 uni10CEC <10 0 10 0>;\012    pos uni10C97 uni10CED <-40 0 -40 0>;\012    pos uni10C97 uni10CF0 <-60 0 -60 0>;\012    pos uni10C97 uni10CF2 <-10 0 -10 0>;\012    pos uni10C97 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C97 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C97 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C97 uni10CCD.ltr <40 0 40 0>;\012    pos uni10C97 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C97 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C97 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C97 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C97 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C97 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C97 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C97 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C98 uni10CC0 <-40 0 -40 0>;\012    pos uni10C98 uni10CC1 <-30 0 -30 0>;\012    pos uni10C98 uni10CC2 <20 0 20 0>;\012    pos uni10C98 uni10CC4 <-30 0 -30 0>;\012    pos uni10C98 uni10CC7 <-10 0 -10 0>;\012    pos uni10C98 uni10CC9 <-20 0 -20 0>;\012    pos uni10C98 uni10CCB <10 0 10 0>;\012    pos uni10C98 uni10CCC <-10 0 -10 0>;\012    pos uni10C98 uni10CCD <40 0 40 0>;\012    pos uni10C98 uni10CCE <20 0 20 0>;\012    pos uni10C98 uni10CD0 <-30 0 -30 0>;\012    pos uni10C98 uni10CD1 <-50 0 -50 0>;\012    pos uni10C98 uni10CD2 <-30 0 -30 0>;\012    pos uni10C98 uni10CD4 <-40 0 -40 0>;\012    pos uni10C98 uni10CD6 <40 0 40 0>;\012    pos uni10C98 uni10CD7 <-10 0 -10 0>;\012    pos uni10C98 uni10CD9 <20 0 20 0>;\012    pos uni10C98 uni10CE3 <-30 0 -30 0>;\012    pos uni10C98 uni10CE4 <40 0 40 0>;\012    pos uni10C98 uni10CE6 <-60 0 -60 0>;\012    pos uni10C98 uni10CE7 <-80 0 -80 0>;\012    pos uni10C98 uni10CE8 <20 0 20 0>;\012    pos uni10C98 uni10CE9 <20 0 20 0>;\012    pos uni10C98 uni10CEC <10 0 10 0>;\012    pos uni10C98 uni10CED <-40 0 -40 0>;\012    pos uni10C98 uni10CF0 <-60 0 -60 0>;\012    pos uni10C98 uni10CF2 <-10 0 -10 0>;\012    pos uni10C98 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C98 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C98 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C98 uni10CCD.ltr <40 0 40 0>;\012    pos uni10C98 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C98 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C98 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C98 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C98 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C98 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C98 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C98 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C99 uni10CC0 <-40 0 -40 0>;\012    pos uni10C99 uni10CC1 <-30 0 -30 0>;\012    pos uni10C99 uni10CC2 <20 0 20 0>;\012    pos uni10C99 uni10CC4 <-30 0 -30 0>;\012    pos uni10C99 uni10CC7 <-10 0 -10 0>;\012    pos uni10C99 uni10CC9 <-20 0 -20 0>;\012    pos uni10C99 uni10CCB <10 0 10 0>;\012    pos uni10C99 uni10CCC <-10 0 -10 0>;\012    pos uni10C99 uni10CCD <40 0 40 0>;\012    pos uni10C99 uni10CCE <20 0 20 0>;\012    pos uni10C99 uni10CD0 <-30 0 -30 0>;\012    pos uni10C99 uni10CD1 <-50 0 -50 0>;\012    pos uni10C99 uni10CD2 <-30 0 -30 0>;\012    pos uni10C99 uni10CD4 <-40 0 -40 0>;\012    pos uni10C99 uni10CD6 <40 0 40 0>;\012    pos uni10C99 uni10CD7 <-10 0 -10 0>;\012    pos uni10C99 uni10CD9 <20 0 20 0>;\012    pos uni10C99 uni10CE3 <-30 0 -30 0>;\012    pos uni10C99 uni10CE4 <40 0 40 0>;\012    pos uni10C99 uni10CE6 <-60 0 -60 0>;\012    pos uni10C99 uni10CE7 <-80 0 -80 0>;\012    pos uni10C99 uni10CE8 <20 0 20 0>;\012    pos uni10C99 uni10CE9 <20 0 20 0>;\012    pos uni10C99 uni10CEC <10 0 10 0>;\012    pos uni10C99 uni10CED <-40 0 -40 0>;\012    pos uni10C99 uni10CF0 <-60 0 -60 0>;\012    pos uni10C99 uni10CF2 <-10 0 -10 0>;\012    pos uni10C99 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C99 uni10CC2.ltr <20 0 20 0>;\012    pos uni10C99 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C99 uni10CCD.ltr <40 0 40 0>;\012    pos uni10C99 uni10CD6.ltr <40 0 40 0>;\012    pos uni10C99 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C99 uni10CE4.ltr <40 0 40 0>;\012    pos uni10C99 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C99 uni10CE8.ltr <20 0 20 0>;\012    pos uni10C99 uni10CE9.ltr <20 0 20 0>;\012    pos uni10C99 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C99 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C9A uni10CC0 <-40 0 -40 0>;\012    pos uni10C9A uni10CC1 <-30 0 -30 0>;\012    pos uni10C9A uni10CC2 <20 0 20 0>;\012    pos uni10C9A uni10CC4 <-30 0 -30 0>;\012    pos uni10C9A uni10CC7 <-10 0 -10 0>;\012    pos uni10C9A uni10CC9 <-20 0 -20 0>;\012    pos uni10C9A uni10CCB <10 0 10 0>;\012    pos uni10C9A uni10CCC <-10 0 -10 0>;\012    pos uni10C9A uni10CCD <40 0 40 0>;\012    pos uni10C9A uni10CCE <20 0 20 0>;\012    pos uni10C9A uni10CD0 <-30 0 -30 0>;\012    pos uni10C9A uni10CD1 <-50 0 -50 0>;\012    pos uni10C9A uni10CD2 <-30 0 -30 0>;\012    pos uni10C9A uni10CD4 <-40 0 -40 0>;\012    pos uni10C9A uni10CD6 <40 0 40 0>;\012    pos uni10C9A uni10CD7 <-10 0 -10 0>;\012    pos uni10C9A uni10CD9 <20 0 20 0>;\012    pos uni10C9A uni10CE3 <-30 0 -30 0>;\012    pos uni10C9A uni10CE4 <40 0 40 0>;\012    pos uni10C9A uni10CE6 <-60 0 -60 0>;\012    pos uni10C9A uni10CE7 <-80 0 -80 0>;\012    pos uni10C9A uni10CE8 <20 0 20 0>;\012    pos uni10C9A uni10CE9 <20 0 20 0>;\012    pos uni10C9A uni10CEC <10 0 10 0>;\012    pos uni10C9A uni10CED <-40 0 -40 0>;\012    pos uni10C9A uni10CF0 <-60 0 -60 0>;\012    pos uni10C9A uni10CF2 <-10 0 -10 0>;\012    pos uni10C9A uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C9A uni10CC2.ltr <20 0 20 0>;\012    pos uni10C9A uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C9A uni10CCD.ltr <40 0 40 0>;\012    pos uni10C9A uni10CD6.ltr <40 0 40 0>;\012    pos uni10C9A uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C9A uni10CE4.ltr <40 0 40 0>;\012    pos uni10C9A uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C9A uni10CE8.ltr <20 0 20 0>;\012    pos uni10C9A uni10CE9.ltr <20 0 20 0>;\012    pos uni10C9A uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C9A uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C9B uni10CC0 <-40 0 -40 0>;\012    pos uni10C9B uni10CC1 <-30 0 -30 0>;\012    pos uni10C9B uni10CC2 <20 0 20 0>;\012    pos uni10C9B uni10CC4 <-30 0 -30 0>;\012    pos uni10C9B uni10CC7 <-10 0 -10 0>;\012    pos uni10C9B uni10CC9 <-20 0 -20 0>;\012    pos uni10C9B uni10CCB <10 0 10 0>;\012    pos uni10C9B uni10CCC <-10 0 -10 0>;\012    pos uni10C9B uni10CCD <40 0 40 0>;\012    pos uni10C9B uni10CCE <20 0 20 0>;\012    pos uni10C9B uni10CD0 <-30 0 -30 0>;\012    pos uni10C9B uni10CD1 <-50 0 -50 0>;\012    pos uni10C9B uni10CD2 <-30 0 -30 0>;\012    pos uni10C9B uni10CD4 <-40 0 -40 0>;\012    pos uni10C9B uni10CD6 <40 0 40 0>;\012    pos uni10C9B uni10CD7 <-10 0 -10 0>;\012    pos uni10C9B uni10CD9 <20 0 20 0>;\012    pos uni10C9B uni10CE3 <-30 0 -30 0>;\012    pos uni10C9B uni10CE4 <40 0 40 0>;\012    pos uni10C9B uni10CE6 <-60 0 -60 0>;\012    pos uni10C9B uni10CE7 <-80 0 -80 0>;\012    pos uni10C9B uni10CE8 <20 0 20 0>;\012    pos uni10C9B uni10CE9 <20 0 20 0>;\012    pos uni10C9B uni10CEC <10 0 10 0>;\012    pos uni10C9B uni10CED <-40 0 -40 0>;\012    pos uni10C9B uni10CF0 <-60 0 -60 0>;\012    pos uni10C9B uni10CF2 <-10 0 -10 0>;\012    pos uni10C9B uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C9B uni10CC2.ltr <20 0 20 0>;\012    pos uni10C9B uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C9B uni10CCD.ltr <40 0 40 0>;\012    pos uni10C9B uni10CD6.ltr <40 0 40 0>;\012    pos uni10C9B uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C9B uni10CE4.ltr <40 0 40 0>;\012    pos uni10C9B uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C9B uni10CE8.ltr <20 0 20 0>;\012    pos uni10C9B uni10CE9.ltr <20 0 20 0>;\012    pos uni10C9B uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C9B uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C9C uni10CC0 <-40 0 -40 0>;\012    pos uni10C9C uni10CC1 <-30 0 -30 0>;\012    pos uni10C9C uni10CC2 <20 0 20 0>;\012    pos uni10C9C uni10CC4 <-30 0 -30 0>;\012    pos uni10C9C uni10CC7 <-10 0 -10 0>;\012    pos uni10C9C uni10CC9 <-20 0 -20 0>;\012    pos uni10C9C uni10CCB <10 0 10 0>;\012    pos uni10C9C uni10CCC <-10 0 -10 0>;\012    pos uni10C9C uni10CCD <40 0 40 0>;\012    pos uni10C9C uni10CCE <20 0 20 0>;\012    pos uni10C9C uni10CD0 <-30 0 -30 0>;\012    pos uni10C9C uni10CD1 <-50 0 -50 0>;\012    pos uni10C9C uni10CD2 <-30 0 -30 0>;\012    pos uni10C9C uni10CD4 <-40 0 -40 0>;\012    pos uni10C9C uni10CD6 <40 0 40 0>;\012    pos uni10C9C uni10CD7 <-10 0 -10 0>;\012    pos uni10C9C uni10CD9 <20 0 20 0>;\012    pos uni10C9C uni10CE3 <-30 0 -30 0>;\012    pos uni10C9C uni10CE4 <40 0 40 0>;\012    pos uni10C9C uni10CE6 <-60 0 -60 0>;\012
+    pos uni10C9C uni10CE7 <-80 0 -80 0>;\012    pos uni10C9C uni10CE8 <20 0 20 0>;\012    pos uni10C9C uni10CE9 <20 0 20 0>;\012    pos uni10C9C uni10CEC <10 0 10 0>;\012    pos uni10C9C uni10CED <-40 0 -40 0>;\012    pos uni10C9C uni10CF0 <-60 0 -60 0>;\012    pos uni10C9C uni10CF2 <-10 0 -10 0>;\012    pos uni10C9C uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C9C uni10CC2.ltr <20 0 20 0>;\012    pos uni10C9C uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C9C uni10CCD.ltr <40 0 40 0>;\012    pos uni10C9C uni10CD6.ltr <40 0 40 0>;\012    pos uni10C9C uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C9C uni10CE4.ltr <40 0 40 0>;\012    pos uni10C9C uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C9C uni10CE8.ltr <20 0 20 0>;\012    pos uni10C9C uni10CE9.ltr <20 0 20 0>;\012    pos uni10C9C uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C9C uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C9D uni10CC0 <-40 0 -40 0>;\012    pos uni10C9D uni10CC1 <-30 0 -30 0>;\012    pos uni10C9D uni10CC2 <20 0 20 0>;\012    pos uni10C9D uni10CC4 <-30 0 -30 0>;\012    pos uni10C9D uni10CC7 <-10 0 -10 0>;\012    pos uni10C9D uni10CC9 <-20 0 -20 0>;\012    pos uni10C9D uni10CCB <10 0 10 0>;\012    pos uni10C9D uni10CCC <-10 0 -10 0>;\012    pos uni10C9D uni10CCD <40 0 40 0>;\012    pos uni10C9D uni10CCE <20 0 20 0>;\012    pos uni10C9D uni10CD0 <-30 0 -30 0>;\012    pos uni10C9D uni10CD1 <-50 0 -50 0>;\012    pos uni10C9D uni10CD2 <-30 0 -30 0>;\012    pos uni10C9D uni10CD4 <-40 0 -40 0>;\012    pos uni10C9D uni10CD6 <40 0 40 0>;\012    pos uni10C9D uni10CD7 <-10 0 -10 0>;\012    pos uni10C9D uni10CD9 <20 0 20 0>;\012    pos uni10C9D uni10CE3 <-30 0 -30 0>;\012    pos uni10C9D uni10CE4 <40 0 40 0>;\012    pos uni10C9D uni10CE6 <-60 0 -60 0>;\012    pos uni10C9D uni10CE7 <-80 0 -80 0>;\012    pos uni10C9D uni10CE8 <20 0 20 0>;\012    pos uni10C9D uni10CE9 <20 0 20 0>;\012    pos uni10C9D uni10CEC <10 0 10 0>;\012    pos uni10C9D uni10CED <-40 0 -40 0>;\012    pos uni10C9D uni10CF0 <-60 0 -60 0>;\012    pos uni10C9D uni10CF2 <-10 0 -10 0>;\012    pos uni10C9D uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C9D uni10CC2.ltr <20 0 20 0>;\012    pos uni10C9D uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C9D uni10CCD.ltr <40 0 40 0>;\012    pos uni10C9D uni10CD6.ltr <40 0 40 0>;\012    pos uni10C9D uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C9D uni10CE4.ltr <40 0 40 0>;\012    pos uni10C9D uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C9D uni10CE8.ltr <20 0 20 0>;\012    pos uni10C9D uni10CE9.ltr <20 0 20 0>;\012    pos uni10C9D uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C9D uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C9E uni10CC0 <-40 0 -40 0>;\012    pos uni10C9E uni10CC1 <-30 0 -30 0>;\012    pos uni10C9E uni10CC2 <20 0 20 0>;\012    pos uni10C9E uni10CC4 <-30 0 -30 0>;\012    pos uni10C9E uni10CC7 <-10 0 -10 0>;\012    pos uni10C9E uni10CC9 <-20 0 -20 0>;\012    pos uni10C9E uni10CCB <10 0 10 0>;\012    pos uni10C9E uni10CCC <-10 0 -10 0>;\012    pos uni10C9E uni10CCD <40 0 40 0>;\012    pos uni10C9E uni10CCE <20 0 20 0>;\012    pos uni10C9E uni10CD0 <-30 0 -30 0>;\012    pos uni10C9E uni10CD1 <-50 0 -50 0>;\012    pos uni10C9E uni10CD2 <-30 0 -30 0>;\012    pos uni10C9E uni10CD4 <-40 0 -40 0>;\012    pos uni10C9E uni10CD6 <40 0 40 0>;\012    pos uni10C9E uni10CD7 <-10 0 -10 0>;\012    pos uni10C9E uni10CD9 <20 0 20 0>;\012    pos uni10C9E uni10CE3 <-30 0 -30 0>;\012    pos uni10C9E uni10CE4 <40 0 40 0>;\012    pos uni10C9E uni10CE6 <-60 0 -60 0>;\012    pos uni10C9E uni10CE7 <-80 0 -80 0>;\012    pos uni10C9E uni10CE8 <20 0 20 0>;\012    pos uni10C9E uni10CE9 <20 0 20 0>;\012    pos uni10C9E uni10CEC <10 0 10 0>;\012    pos uni10C9E uni10CED <-40 0 -40 0>;\012    pos uni10C9E uni10CF0 <-60 0 -60 0>;\012    pos uni10C9E uni10CF2 <-10 0 -10 0>;\012    pos uni10C9E uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C9E uni10CC2.ltr <20 0 20 0>;\012    pos uni10C9E uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C9E uni10CCD.ltr <40 0 40 0>;\012    pos uni10C9E uni10CD6.ltr <40 0 40 0>;\012    pos uni10C9E uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C9E uni10CE4.ltr <40 0 40 0>;\012    pos uni10C9E uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C9E uni10CE8.ltr <20 0 20 0>;\012    pos uni10C9E uni10CE9.ltr <20 0 20 0>;\012    pos uni10C9E uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C9E uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C9F uni10CC0 <-40 0 -40 0>;\012    pos uni10C9F uni10CC1 <-30 0 -30 0>;\012    pos uni10C9F uni10CC2 <20 0 20 0>;\012    pos uni10C9F uni10CC4 <-30 0 -30 0>;\012    pos uni10C9F uni10CC7 <-10 0 -10 0>;\012    pos uni10C9F uni10CC9 <-20 0 -20 0>;\012    pos uni10C9F uni10CCB <10 0 10 0>;\012    pos uni10C9F uni10CCC <-10 0 -10 0>;\012    pos uni10C9F uni10CCD <40 0 40 0>;\012    pos uni10C9F uni10CCE <20 0 20 0>;\012    pos uni10C9F uni10CD0 <-30 0 -30 0>;\012    pos uni10C9F uni10CD1 <-50 0 -50 0>;\012    pos uni10C9F uni10CD2 <-30 0 -30 0>;\012    pos uni10C9F uni10CD4 <-40 0 -40 0>;\012    pos uni10C9F uni10CD6 <40 0 40 0>;\012    pos uni10C9F uni10CD7 <-10 0 -10 0>;\012    pos uni10C9F uni10CD9 <20 0 20 0>;\012    pos uni10C9F uni10CE3 <-30 0 -30 0>;\012    pos uni10C9F uni10CE4 <40 0 40 0>;\012    pos uni10C9F uni10CE6 <-60 0 -60 0>;\012    pos uni10C9F uni10CE7 <-80 0 -80 0>;\012    pos uni10C9F uni10CE8 <20 0 20 0>;\012    pos uni10C9F uni10CE9 <20 0 20 0>;\012    pos uni10C9F uni10CEC <10 0 10 0>;\012    pos uni10C9F uni10CED <-40 0 -40 0>;\012    pos uni10C9F uni10CF0 <-60 0 -60 0>;\012    pos uni10C9F uni10CF2 <-10 0 -10 0>;\012    pos uni10C9F uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C9F uni10CC2.ltr <20 0 20 0>;\012    pos uni10C9F uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C9F uni10CCD.ltr <40 0 40 0>;\012    pos uni10C9F uni10CD6.ltr <40 0 40 0>;\012    pos uni10C9F uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C9F uni10CE4.ltr <40 0 40 0>;\012    pos uni10C9F uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C9F uni10CE8.ltr <20 0 20 0>;\012    pos uni10C9F uni10CE9.ltr <20 0 20 0>;\012    pos uni10C9F uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C9F uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA0 uni10CC0 <-40 0 -40 0>;\012    pos uni10CA0 uni10CC1 <-30 0 -30 0>;\012    pos uni10CA0 uni10CC2 <20 0 20 0>;\012    pos uni10CA0 uni10CC4 <-30 0 -30 0>;\012    pos uni10CA0 uni10CC7 <-10 0 -10 0>;\012    pos uni10CA0 uni10CC9 <-20 0 -20 0>;\012    pos uni10CA0 uni10CCB <10 0 10 0>;\012    pos uni10CA0 uni10CCC <-10 0 -10 0>;\012    pos uni10CA0 uni10CCD <40 0 40 0>;\012    pos uni10CA0 uni10CCE <20 0 20 0>;\012    pos uni10CA0 uni10CD0 <-30 0 -30 0>;\012    pos uni10CA0 uni10CD1 <-50 0 -50 0>;\012    pos uni10CA0 uni10CD2 <-30 0 -30 0>;\012    pos uni10CA0 uni10CD4 <-40 0 -40 0>;\012    pos uni10CA0 uni10CD6 <40 0 40 0>;\012    pos uni10CA0 uni10CD7 <-10 0 -10 0>;\012    pos uni10CA0 uni10CD9 <20 0 20 0>;\012    pos uni10CA0 uni10CE3 <-30 0 -30 0>;\012    pos uni10CA0 uni10CE4 <40 0 40 0>;\012    pos uni10CA0 uni10CE6 <-60 0 -60 0>;\012    pos uni10CA0 uni10CE7 <-80 0 -80 0>;\012    pos uni10CA0 uni10CE8 <20 0 20 0>;\012    pos uni10CA0 uni10CE9 <20 0 20 0>;\012    pos uni10CA0 uni10CEC <10 0 10 0>;\012    pos uni10CA0 uni10CED <-40 0 -40 0>;\012    pos uni10CA0 uni10CF0 <-60 0 -60 0>;\012    pos uni10CA0 uni10CF2 <-10 0 -10 0>;\012    pos uni10CA0 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA0 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA0 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA0 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA0 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA0 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA0 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA0 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA0 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA0 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CA0 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA0 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA1 uni10CC0 <-40 0 -40 0>;\012    pos uni10CA1 uni10CC1 <-30 0 -30 0>;\012    pos uni10CA1 uni10CC2 <20 0 20 0>;\012    pos uni10CA1 uni10CC4 <-30 0 -30 0>;\012    pos uni10CA1 uni10CC7 <-10 0 -10 0>;\012    pos uni10CA1 uni10CC9 <-20 0 -20 0>;\012    pos uni10CA1 uni10CCB <10 0 10 0>;\012    pos uni10CA1 uni10CCC <-10 0 -10 0>;\012    pos uni10CA1 uni10CCD <40 0 40 0>;\012    pos uni10CA1 uni10CCE <20 0 20 0>;\012    pos uni10CA1 uni10CD0 <-30 0 -30 0>;\012    pos uni10CA1 uni10CD1 <-50 0 -50 0>;\012    pos uni10CA1 uni10CD2 <-30 0 -30 0>;\012    pos uni10CA1 uni10CD4 <-40 0 -40 0>;\012    pos uni10CA1 uni10CD6 <40 0 40 0>;\012    pos uni10CA1 uni10CD7 <-10 0 -10 0>;\012    pos uni10CA1 uni10CD9 <20 0 20 0>;\012    pos uni10CA1 uni10CE3 <-30 0 -30 0>;\012    pos uni10CA1 uni10CE4 <40 0 40 0>;\012    pos uni10CA1 uni10CE6 <-60 0 -60 0>;\012    pos uni10CA1 uni10CE7 <-80 0 -80 0>;\012    pos uni10CA1 uni10CE8 <20 0 20 0>;\012    pos uni10CA1 uni10CE9 <20 0 20 0>;\012    pos uni10CA1 uni10CEC <10 0 10 0>;\012    pos uni10CA1 uni10CED <-40 0 -40 0>;\012    pos uni10CA1 uni10CF0 <-60 0 -60 0>;\012    pos uni10CA1 uni10CF2 <-10 0 -10 0>;\012    pos uni10CA1 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA1 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA1 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA1 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA1 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA1 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA1 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA1 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA1 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA1 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CA1 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA1 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA2 uni10CC0 <-40 0 -40 0>;\012    pos uni10CA2 uni10CC1 <-30 0 -30 0>;\012    pos uni10CA2 uni10CC2 <20 0 20 0>;\012    pos uni10CA2 uni10CC4 <-30 0 -30 0>;\012    pos uni10CA2 uni10CC7 <-10 0 -10 0>;\012    pos uni10CA2 uni10CC9 <-20 0 -20 0>;\012    pos uni10CA2 uni10CCB <10 0 10 0>;\012    pos uni10CA2 uni10CCC <-10 0 -10 0>;\012    pos uni10CA2 uni10CCD <40
+ 0 40 0>;\012    pos uni10CA2 uni10CCE <20 0 20 0>;\012    pos uni10CA2 uni10CD0 <-30 0 -30 0>;\012    pos uni10CA2 uni10CD1 <-50 0 -50 0>;\012    pos uni10CA2 uni10CD2 <-30 0 -30 0>;\012    pos uni10CA2 uni10CD4 <-40 0 -40 0>;\012    pos uni10CA2 uni10CD6 <40 0 40 0>;\012    pos uni10CA2 uni10CD7 <-10 0 -10 0>;\012    pos uni10CA2 uni10CD9 <20 0 20 0>;\012    pos uni10CA2 uni10CE3 <-30 0 -30 0>;\012    pos uni10CA2 uni10CE4 <40 0 40 0>;\012    pos uni10CA2 uni10CE6 <-60 0 -60 0>;\012    pos uni10CA2 uni10CE7 <-80 0 -80 0>;\012    pos uni10CA2 uni10CE8 <20 0 20 0>;\012    pos uni10CA2 uni10CE9 <20 0 20 0>;\012    pos uni10CA2 uni10CEC <10 0 10 0>;\012    pos uni10CA2 uni10CED <-40 0 -40 0>;\012    pos uni10CA2 uni10CF0 <-60 0 -60 0>;\012    pos uni10CA2 uni10CF2 <-10 0 -10 0>;\012    pos uni10CA2 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA2 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA2 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA2 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA2 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA2 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA2 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA2 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA2 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA2 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CA2 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA2 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA3 uni10CC0 <-40 0 -40 0>;\012    pos uni10CA3 uni10CC1 <-30 0 -30 0>;\012    pos uni10CA3 uni10CC2 <20 0 20 0>;\012    pos uni10CA3 uni10CC4 <-30 0 -30 0>;\012    pos uni10CA3 uni10CC7 <-10 0 -10 0>;\012    pos uni10CA3 uni10CC9 <-20 0 -20 0>;\012    pos uni10CA3 uni10CCB <10 0 10 0>;\012    pos uni10CA3 uni10CCC <-10 0 -10 0>;\012    pos uni10CA3 uni10CCD <40 0 40 0>;\012    pos uni10CA3 uni10CCE <20 0 20 0>;\012    pos uni10CA3 uni10CD0 <-30 0 -30 0>;\012    pos uni10CA3 uni10CD1 <-50 0 -50 0>;\012    pos uni10CA3 uni10CD2 <-30 0 -30 0>;\012    pos uni10CA3 uni10CD4 <-40 0 -40 0>;\012    pos uni10CA3 uni10CD6 <40 0 40 0>;\012    pos uni10CA3 uni10CD7 <-10 0 -10 0>;\012    pos uni10CA3 uni10CD9 <20 0 20 0>;\012    pos uni10CA3 uni10CE3 <-30 0 -30 0>;\012    pos uni10CA3 uni10CE4 <40 0 40 0>;\012    pos uni10CA3 uni10CE6 <-60 0 -60 0>;\012    pos uni10CA3 uni10CE7 <-80 0 -80 0>;\012    pos uni10CA3 uni10CE8 <20 0 20 0>;\012    pos uni10CA3 uni10CE9 <20 0 20 0>;\012    pos uni10CA3 uni10CEC <10 0 10 0>;\012    pos uni10CA3 uni10CED <-40 0 -40 0>;\012    pos uni10CA3 uni10CF0 <-60 0 -60 0>;\012    pos uni10CA3 uni10CF2 <-10 0 -10 0>;\012    pos uni10CA3 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA3 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA3 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA3 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA3 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA3 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA3 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA3 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA3 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA3 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CA3 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA3 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA4 uni10CC0 <-40 0 -40 0>;\012    pos uni10CA4 uni10CC1 <-30 0 -30 0>;\012    pos uni10CA4 uni10CC2 <20 0 20 0>;\012    pos uni10CA4 uni10CC4 <-30 0 -30 0>;\012    pos uni10CA4 uni10CC7 <-10 0 -10 0>;\012    pos uni10CA4 uni10CC9 <-20 0 -20 0>;\012    pos uni10CA4 uni10CCB <10 0 10 0>;\012    pos uni10CA4 uni10CCC <-10 0 -10 0>;\012    pos uni10CA4 uni10CCD <40 0 40 0>;\012    pos uni10CA4 uni10CCE <20 0 20 0>;\012    pos uni10CA4 uni10CD0 <-30 0 -30 0>;\012    pos uni10CA4 uni10CD1 <-50 0 -50 0>;\012    pos uni10CA4 uni10CD2 <-30 0 -30 0>;\012    pos uni10CA4 uni10CD4 <-40 0 -40 0>;\012    pos uni10CA4 uni10CD6 <40 0 40 0>;\012    pos uni10CA4 uni10CD7 <-10 0 -10 0>;\012    pos uni10CA4 uni10CD9 <20 0 20 0>;\012    pos uni10CA4 uni10CE3 <-30 0 -30 0>;\012    pos uni10CA4 uni10CE4 <40 0 40 0>;\012    pos uni10CA4 uni10CE6 <-60 0 -60 0>;\012    pos uni10CA4 uni10CE7 <-80 0 -80 0>;\012    pos uni10CA4 uni10CE8 <20 0 20 0>;\012    pos uni10CA4 uni10CE9 <20 0 20 0>;\012    pos uni10CA4 uni10CEC <10 0 10 0>;\012    pos uni10CA4 uni10CED <-40 0 -40 0>;\012    pos uni10CA4 uni10CF0 <-60 0 -60 0>;\012    pos uni10CA4 uni10CF2 <-10 0 -10 0>;\012    pos uni10CA4 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA4 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA4 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA4 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA4 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA4 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA4 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA4 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA4 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA4 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CA4 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA4 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA5 uni10CC0 <-40 0 -40 0>;\012    pos uni10CA5 uni10CC1 <-30 0 -30 0>;\012    pos uni10CA5 uni10CC2 <20 0 20 0>;\012    pos uni10CA5 uni10CC4 <-30 0 -30 0>;\012    pos uni10CA5 uni10CC7 <-10 0 -10 0>;\012    pos uni10CA5 uni10CC9 <-20 0 -20 0>;\012    pos uni10CA5 uni10CCB <10 0 10 0>;\012    pos uni10CA5 uni10CCC <-10 0 -10 0>;\012    pos uni10CA5 uni10CCD <40 0 40 0>;\012    pos uni10CA5 uni10CCE <20 0 20 0>;\012    pos uni10CA5 uni10CD0 <-30 0 -30 0>;\012    pos uni10CA5 uni10CD1 <-50 0 -50 0>;\012    pos uni10CA5 uni10CD2 <-30 0 -30 0>;\012    pos uni10CA5 uni10CD4 <-40 0 -40 0>;\012    pos uni10CA5 uni10CD6 <40 0 40 0>;\012    pos uni10CA5 uni10CD7 <-10 0 -10 0>;\012    pos uni10CA5 uni10CD9 <20 0 20 0>;\012    pos uni10CA5 uni10CE3 <-30 0 -30 0>;\012    pos uni10CA5 uni10CE4 <40 0 40 0>;\012    pos uni10CA5 uni10CE6 <-60 0 -60 0>;\012    pos uni10CA5 uni10CE7 <-80 0 -80 0>;\012    pos uni10CA5 uni10CE8 <20 0 20 0>;\012    pos uni10CA5 uni10CE9 <20 0 20 0>;\012    pos uni10CA5 uni10CEC <10 0 10 0>;\012    pos uni10CA5 uni10CED <-40 0 -40 0>;\012    pos uni10CA5 uni10CF0 <-60 0 -60 0>;\012    pos uni10CA5 uni10CF2 <-10 0 -10 0>;\012    pos uni10CA5 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA5 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA5 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA5 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA5 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA5 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA5 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA5 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA5 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA5 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CA5 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA5 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA6 uni10CC0 <-40 0 -40 0>;\012    pos uni10CA6 uni10CC1 <-30 0 -30 0>;\012    pos uni10CA6 uni10CC2 <20 0 20 0>;\012    pos uni10CA6 uni10CC4 <-30 0 -30 0>;\012    pos uni10CA6 uni10CC7 <-10 0 -10 0>;\012    pos uni10CA6 uni10CC9 <-20 0 -20 0>;\012    pos uni10CA6 uni10CCB <10 0 10 0>;\012    pos uni10CA6 uni10CCC <-10 0 -10 0>;\012    pos uni10CA6 uni10CCD <40 0 40 0>;\012    pos uni10CA6 uni10CCE <20 0 20 0>;\012    pos uni10CA6 uni10CD0 <-30 0 -30 0>;\012    pos uni10CA6 uni10CD1 <-50 0 -50 0>;\012    pos uni10CA6 uni10CD2 <-30 0 -30 0>;\012    pos uni10CA6 uni10CD4 <-40 0 -40 0>;\012    pos uni10CA6 uni10CD6 <40 0 40 0>;\012    pos uni10CA6 uni10CD7 <-10 0 -10 0>;\012    pos uni10CA6 uni10CD9 <20 0 20 0>;\012    pos uni10CA6 uni10CE3 <-30 0 -30 0>;\012    pos uni10CA6 uni10CE4 <40 0 40 0>;\012    pos uni10CA6 uni10CE6 <-60 0 -60 0>;\012    pos uni10CA6 uni10CE7 <-80 0 -80 0>;\012    pos uni10CA6 uni10CE8 <20 0 20 0>;\012    pos uni10CA6 uni10CE9 <20 0 20 0>;\012    pos uni10CA6 uni10CEC <10 0 10 0>;\012    pos uni10CA6 uni10CED <-40 0 -40 0>;\012    pos uni10CA6 uni10CF0 <-60 0 -60 0>;\012    pos uni10CA6 uni10CF2 <-10 0 -10 0>;\012    pos uni10CA6 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA6 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA6 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA6 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA6 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA6 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA6 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA6 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA6 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA6 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CA6 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA6 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA7 uni10CC0 <-40 0 -40 0>;\012    pos uni10CA7 uni10CC1 <-30 0 -30 0>;\012    pos uni10CA7 uni10CC2 <20 0 20 0>;\012    pos uni10CA7 uni10CC4 <-30 0 -30 0>;\012    pos uni10CA7 uni10CC7 <-10 0 -10 0>;\012    pos uni10CA7 uni10CC9 <-20 0 -20 0>;\012    pos uni10CA7 uni10CCB <10 0 10 0>;\012    pos uni10CA7 uni10CCC <-10 0 -10 0>;\012    pos uni10CA7 uni10CCD <40 0 40 0>;\012    pos uni10CA7 uni10CCE <20 0 20 0>;\012    pos uni10CA7 uni10CD0 <-30 0 -30 0>;\012    pos uni10CA7 uni10CD1 <-50 0 -50 0>;\012    pos uni10CA7 uni10CD2 <-30 0 -30 0>;\012    pos uni10CA7 uni10CD4 <-40 0 -40 0>;\012    pos uni10CA7 uni10CD6 <40 0 40 0>;\012    pos uni10CA7 uni10CD7 <-10 0 -10 0>;\012    pos uni10CA7 uni10CD9 <20 0 20 0>;\012    pos uni10CA7 uni10CE3 <-30 0 -30 0>;\012    pos uni10CA7 uni10CE4 <40 0 40 0>;\012    pos uni10CA7 uni10CE6 <-60 0 -60 0>;\012    pos uni10CA7 uni10CE7 <-80 0 -80 0>;\012    pos uni10CA7 uni10CE8 <20 0 20 0>;\012    pos uni10CA7 uni10CE9 <20 0 20 0>;\012    pos uni10CA7 uni10CEC <10 0 10 0>;\012    pos uni10CA7 uni10CED <-40 0 -40 0>;\012    pos uni10CA7 uni10CF0 <-60 0 -60 0>;\012    pos uni10CA7 uni10CF2 <-10 0 -10 0>;\012    pos uni10CA7 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA7 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA7 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA7 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA7 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA7 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA7 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA7 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA7 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA7 uni10CE9.ltr
+ <20 0 20 0>;\012    pos uni10CA7 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA7 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA8 uni10CC0 <-40 0 -40 0>;\012    pos uni10CA8 uni10CC1 <-30 0 -30 0>;\012    pos uni10CA8 uni10CC2 <20 0 20 0>;\012    pos uni10CA8 uni10CC4 <-30 0 -30 0>;\012    pos uni10CA8 uni10CC7 <-10 0 -10 0>;\012    pos uni10CA8 uni10CC9 <-20 0 -20 0>;\012    pos uni10CA8 uni10CCB <10 0 10 0>;\012    pos uni10CA8 uni10CCC <-10 0 -10 0>;\012    pos uni10CA8 uni10CCD <40 0 40 0>;\012    pos uni10CA8 uni10CCE <20 0 20 0>;\012    pos uni10CA8 uni10CD0 <-30 0 -30 0>;\012    pos uni10CA8 uni10CD1 <-50 0 -50 0>;\012    pos uni10CA8 uni10CD2 <-30 0 -30 0>;\012    pos uni10CA8 uni10CD4 <-40 0 -40 0>;\012    pos uni10CA8 uni10CD6 <40 0 40 0>;\012    pos uni10CA8 uni10CD7 <-10 0 -10 0>;\012    pos uni10CA8 uni10CD9 <20 0 20 0>;\012    pos uni10CA8 uni10CE3 <-30 0 -30 0>;\012    pos uni10CA8 uni10CE4 <40 0 40 0>;\012    pos uni10CA8 uni10CE6 <-60 0 -60 0>;\012    pos uni10CA8 uni10CE7 <-80 0 -80 0>;\012    pos uni10CA8 uni10CE8 <20 0 20 0>;\012    pos uni10CA8 uni10CE9 <20 0 20 0>;\012    pos uni10CA8 uni10CEC <10 0 10 0>;\012    pos uni10CA8 uni10CED <-40 0 -40 0>;\012    pos uni10CA8 uni10CF0 <-60 0 -60 0>;\012    pos uni10CA8 uni10CF2 <-10 0 -10 0>;\012    pos uni10CA8 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA8 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA8 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA8 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA8 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA8 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA8 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA8 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA8 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA8 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CA8 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA8 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA9 uni10CC0 <-40 0 -40 0>;\012    pos uni10CA9 uni10CC1 <-30 0 -30 0>;\012    pos uni10CA9 uni10CC2 <20 0 20 0>;\012    pos uni10CA9 uni10CC4 <-30 0 -30 0>;\012    pos uni10CA9 uni10CC7 <-10 0 -10 0>;\012    pos uni10CA9 uni10CC9 <-20 0 -20 0>;\012    pos uni10CA9 uni10CCB <10 0 10 0>;\012    pos uni10CA9 uni10CCC <-10 0 -10 0>;\012    pos uni10CA9 uni10CCD <40 0 40 0>;\012    pos uni10CA9 uni10CCE <20 0 20 0>;\012    pos uni10CA9 uni10CD0 <-30 0 -30 0>;\012    pos uni10CA9 uni10CD1 <-50 0 -50 0>;\012    pos uni10CA9 uni10CD2 <-30 0 -30 0>;\012    pos uni10CA9 uni10CD4 <-40 0 -40 0>;\012    pos uni10CA9 uni10CD6 <40 0 40 0>;\012    pos uni10CA9 uni10CD7 <-10 0 -10 0>;\012    pos uni10CA9 uni10CD9 <20 0 20 0>;\012    pos uni10CA9 uni10CE3 <-30 0 -30 0>;\012    pos uni10CA9 uni10CE4 <40 0 40 0>;\012    pos uni10CA9 uni10CE6 <-60 0 -60 0>;\012    pos uni10CA9 uni10CE7 <-80 0 -80 0>;\012    pos uni10CA9 uni10CE8 <20 0 20 0>;\012    pos uni10CA9 uni10CE9 <20 0 20 0>;\012    pos uni10CA9 uni10CEC <10 0 10 0>;\012    pos uni10CA9 uni10CED <-40 0 -40 0>;\012    pos uni10CA9 uni10CF0 <-60 0 -60 0>;\012    pos uni10CA9 uni10CF2 <-10 0 -10 0>;\012    pos uni10CA9 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA9 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA9 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA9 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA9 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA9 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA9 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA9 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA9 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA9 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CA9 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA9 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CAA uni10CC0 <-40 0 -40 0>;\012    pos uni10CAA uni10CC1 <-30 0 -30 0>;\012    pos uni10CAA uni10CC2 <20 0 20 0>;\012    pos uni10CAA uni10CC4 <-30 0 -30 0>;\012    pos uni10CAA uni10CC7 <-10 0 -10 0>;\012    pos uni10CAA uni10CC9 <-20 0 -20 0>;\012    pos uni10CAA uni10CCB <10 0 10 0>;\012    pos uni10CAA uni10CCC <-10 0 -10 0>;\012    pos uni10CAA uni10CCD <40 0 40 0>;\012    pos uni10CAA uni10CCE <20 0 20 0>;\012    pos uni10CAA uni10CD0 <-30 0 -30 0>;\012    pos uni10CAA uni10CD1 <-50 0 -50 0>;\012    pos uni10CAA uni10CD2 <-30 0 -30 0>;\012    pos uni10CAA uni10CD4 <-40 0 -40 0>;\012    pos uni10CAA uni10CD6 <40 0 40 0>;\012    pos uni10CAA uni10CD7 <-10 0 -10 0>;\012    pos uni10CAA uni10CD9 <20 0 20 0>;\012    pos uni10CAA uni10CE3 <-30 0 -30 0>;\012    pos uni10CAA uni10CE4 <40 0 40 0>;\012    pos uni10CAA uni10CE6 <-60 0 -60 0>;\012    pos uni10CAA uni10CE7 <-80 0 -80 0>;\012    pos uni10CAA uni10CE8 <20 0 20 0>;\012    pos uni10CAA uni10CE9 <20 0 20 0>;\012    pos uni10CAA uni10CEC <10 0 10 0>;\012    pos uni10CAA uni10CED <-40 0 -40 0>;\012    pos uni10CAA uni10CF0 <-60 0 -60 0>;\012    pos uni10CAA uni10CF2 <-10 0 -10 0>;\012    pos uni10CAA uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CAA uni10CC2.ltr <20 0 20 0>;\012    pos uni10CAA uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CAA uni10CCD.ltr <40 0 40 0>;\012    pos uni10CAA uni10CD6.ltr <40 0 40 0>;\012    pos uni10CAA uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CAA uni10CE4.ltr <40 0 40 0>;\012    pos uni10CAA uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CAA uni10CE8.ltr <20 0 20 0>;\012    pos uni10CAA uni10CE9.ltr <20 0 20 0>;\012    pos uni10CAA uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CAA uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CAB uni10CC0 <-40 0 -40 0>;\012    pos uni10CAB uni10CC1 <-30 0 -30 0>;\012    pos uni10CAB uni10CC2 <20 0 20 0>;\012    pos uni10CAB uni10CC4 <-30 0 -30 0>;\012    pos uni10CAB uni10CC7 <-10 0 -10 0>;\012    pos uni10CAB uni10CC9 <-20 0 -20 0>;\012    pos uni10CAB uni10CCB <10 0 10 0>;\012    pos uni10CAB uni10CCC <-10 0 -10 0>;\012    pos uni10CAB uni10CCD <40 0 40 0>;\012    pos uni10CAB uni10CCE <20 0 20 0>;\012    pos uni10CAB uni10CD0 <-30 0 -30 0>;\012    pos uni10CAB uni10CD1 <-50 0 -50 0>;\012    pos uni10CAB uni10CD2 <-30 0 -30 0>;\012    pos uni10CAB uni10CD4 <-40 0 -40 0>;\012    pos uni10CAB uni10CD6 <40 0 40 0>;\012    pos uni10CAB uni10CD7 <-10 0 -10 0>;\012    pos uni10CAB uni10CD9 <20 0 20 0>;\012    pos uni10CAB uni10CE3 <-30 0 -30 0>;\012    pos uni10CAB uni10CE4 <40 0 40 0>;\012    pos uni10CAB uni10CE6 <-60 0 -60 0>;\012    pos uni10CAB uni10CE7 <-80 0 -80 0>;\012    pos uni10CAB uni10CE8 <20 0 20 0>;\012    pos uni10CAB uni10CE9 <20 0 20 0>;\012    pos uni10CAB uni10CEC <10 0 10 0>;\012    pos uni10CAB uni10CED <-40 0 -40 0>;\012    pos uni10CAB uni10CF0 <-60 0 -60 0>;\012    pos uni10CAB uni10CF2 <-10 0 -10 0>;\012    pos uni10CAB uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CAB uni10CC2.ltr <20 0 20 0>;\012    pos uni10CAB uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CAB uni10CCD.ltr <40 0 40 0>;\012    pos uni10CAB uni10CD6.ltr <40 0 40 0>;\012    pos uni10CAB uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CAB uni10CE4.ltr <40 0 40 0>;\012    pos uni10CAB uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CAB uni10CE8.ltr <20 0 20 0>;\012    pos uni10CAB uni10CE9.ltr <20 0 20 0>;\012    pos uni10CAB uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CAB uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CAC uni10CC0 <-40 0 -40 0>;\012    pos uni10CAC uni10CC1 <-30 0 -30 0>;\012    pos uni10CAC uni10CC2 <20 0 20 0>;\012    pos uni10CAC uni10CC4 <-30 0 -30 0>;\012    pos uni10CAC uni10CC7 <-10 0 -10 0>;\012    pos uni10CAC uni10CC9 <-20 0 -20 0>;\012    pos uni10CAC uni10CCB <10 0 10 0>;\012    pos uni10CAC uni10CCC <-10 0 -10 0>;\012    pos uni10CAC uni10CCD <40 0 40 0>;\012    pos uni10CAC uni10CCE <20 0 20 0>;\012    pos uni10CAC uni10CD0 <-30 0 -30 0>;\012    pos uni10CAC uni10CD1 <-50 0 -50 0>;\012    pos uni10CAC uni10CD2 <-30 0 -30 0>;\012    pos uni10CAC uni10CD4 <-40 0 -40 0>;\012    pos uni10CAC uni10CD6 <40 0 40 0>;\012    pos uni10CAC uni10CD7 <-10 0 -10 0>;\012    pos uni10CAC uni10CD9 <20 0 20 0>;\012    pos uni10CAC uni10CE3 <-30 0 -30 0>;\012    pos uni10CAC uni10CE4 <40 0 40 0>;\012    pos uni10CAC uni10CE6 <-60 0 -60 0>;\012    pos uni10CAC uni10CE7 <-80 0 -80 0>;\012    pos uni10CAC uni10CE8 <20 0 20 0>;\012    pos uni10CAC uni10CE9 <20 0 20 0>;\012    pos uni10CAC uni10CEC <10 0 10 0>;\012    pos uni10CAC uni10CED <-40 0 -40 0>;\012    pos uni10CAC uni10CF0 <-60 0 -60 0>;\012    pos uni10CAC uni10CF2 <-10 0 -10 0>;\012    pos uni10CAC uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CAC uni10CC2.ltr <20 0 20 0>;\012    pos uni10CAC uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CAC uni10CCD.ltr <40 0 40 0>;\012    pos uni10CAC uni10CD6.ltr <40 0 40 0>;\012    pos uni10CAC uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CAC uni10CE4.ltr <40 0 40 0>;\012    pos uni10CAC uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CAC uni10CE8.ltr <20 0 20 0>;\012    pos uni10CAC uni10CE9.ltr <20 0 20 0>;\012    pos uni10CAC uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CAC uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CAD uni10CC0 <-40 0 -40 0>;\012    pos uni10CAD uni10CC1 <-30 0 -30 0>;\012    pos uni10CAD uni10CC2 <20 0 20 0>;\012    pos uni10CAD uni10CC4 <-30 0 -30 0>;\012    pos uni10CAD uni10CC7 <-10 0 -10 0>;\012    pos uni10CAD uni10CC9 <-20 0 -20 0>;\012    pos uni10CAD uni10CCB <10 0 10 0>;\012    pos uni10CAD uni10CCC <-10 0 -10 0>;\012    pos uni10CAD uni10CCD <40 0 40 0>;\012    pos uni10CAD uni10CCE <20 0 20 0>;\012    pos uni10CAD uni10CD0 <-30 0 -30 0>;\012    pos uni10CAD uni10CD1 <-50 0 -50 0>;\012    pos uni10CAD uni10CD2 <-30 0 -30 0>;\012    pos uni10CAD uni10CD4 <-40 0 -40 0>;\012    pos uni10CAD uni10CD6 <40 0 40 0>;\012    pos uni10CAD uni10CD7 <-10 0 -10 0>;\012    pos uni10CAD uni10CD9 <20 0 20 0>;\012    pos uni10CAD uni10CE3 <-30 0 -30 0>;\012    pos uni10CAD uni10CE4 <40 0 40 0>;\012    pos uni10CAD uni10CE6 <-60 0 -60 0>;\012    pos uni10CAD uni10CE7 <-80 0 -80 0>;\012    pos uni10CAD uni10CE8 <20 0 20 0>;\012    pos uni10CAD uni10CE9 <20 0 20 0>;\012    pos uni10CAD uni10CEC <10 0 10 0>;\012    pos uni10CAD uni10CED <-40 0 -40 0>;\012    pos uni10CAD uni10CF0 <-60 0 -60 0>;\012   
+ pos uni10CAD uni10CF2 <-10 0 -10 0>;\012    pos uni10CAD uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CAD uni10CC2.ltr <20 0 20 0>;\012    pos uni10CAD uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CAD uni10CCD.ltr <40 0 40 0>;\012    pos uni10CAD uni10CD6.ltr <40 0 40 0>;\012    pos uni10CAD uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CAD uni10CE4.ltr <40 0 40 0>;\012    pos uni10CAD uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CAD uni10CE8.ltr <20 0 20 0>;\012    pos uni10CAD uni10CE9.ltr <20 0 20 0>;\012    pos uni10CAD uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CAD uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CAE uni10CC0 <-40 0 -40 0>;\012    pos uni10CAE uni10CC1 <-30 0 -30 0>;\012    pos uni10CAE uni10CC2 <20 0 20 0>;\012    pos uni10CAE uni10CC4 <-30 0 -30 0>;\012    pos uni10CAE uni10CC7 <-10 0 -10 0>;\012    pos uni10CAE uni10CC9 <-20 0 -20 0>;\012    pos uni10CAE uni10CCB <10 0 10 0>;\012    pos uni10CAE uni10CCC <-10 0 -10 0>;\012    pos uni10CAE uni10CCD <40 0 40 0>;\012    pos uni10CAE uni10CCE <20 0 20 0>;\012    pos uni10CAE uni10CD0 <-30 0 -30 0>;\012    pos uni10CAE uni10CD1 <-50 0 -50 0>;\012    pos uni10CAE uni10CD2 <-30 0 -30 0>;\012    pos uni10CAE uni10CD4 <-40 0 -40 0>;\012    pos uni10CAE uni10CD6 <40 0 40 0>;\012    pos uni10CAE uni10CD7 <-10 0 -10 0>;\012    pos uni10CAE uni10CD9 <20 0 20 0>;\012    pos uni10CAE uni10CE3 <-30 0 -30 0>;\012    pos uni10CAE uni10CE4 <40 0 40 0>;\012    pos uni10CAE uni10CE6 <-60 0 -60 0>;\012    pos uni10CAE uni10CE7 <-80 0 -80 0>;\012    pos uni10CAE uni10CE8 <20 0 20 0>;\012    pos uni10CAE uni10CE9 <20 0 20 0>;\012    pos uni10CAE uni10CEC <10 0 10 0>;\012    pos uni10CAE uni10CED <-40 0 -40 0>;\012    pos uni10CAE uni10CF0 <-60 0 -60 0>;\012    pos uni10CAE uni10CF2 <-10 0 -10 0>;\012    pos uni10CAE uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CAE uni10CC2.ltr <20 0 20 0>;\012    pos uni10CAE uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CAE uni10CCD.ltr <40 0 40 0>;\012    pos uni10CAE uni10CD6.ltr <40 0 40 0>;\012    pos uni10CAE uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CAE uni10CE4.ltr <40 0 40 0>;\012    pos uni10CAE uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CAE uni10CE8.ltr <20 0 20 0>;\012    pos uni10CAE uni10CE9.ltr <20 0 20 0>;\012    pos uni10CAE uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CAE uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CAF uni10CC0 <-40 0 -40 0>;\012    pos uni10CAF uni10CC1 <-30 0 -30 0>;\012    pos uni10CAF uni10CC2 <20 0 20 0>;\012    pos uni10CAF uni10CC4 <-30 0 -30 0>;\012    pos uni10CAF uni10CC7 <-10 0 -10 0>;\012    pos uni10CAF uni10CC9 <-20 0 -20 0>;\012    pos uni10CAF uni10CCB <10 0 10 0>;\012    pos uni10CAF uni10CCC <-10 0 -10 0>;\012    pos uni10CAF uni10CCD <40 0 40 0>;\012    pos uni10CAF uni10CCE <20 0 20 0>;\012    pos uni10CAF uni10CD0 <-30 0 -30 0>;\012    pos uni10CAF uni10CD1 <-50 0 -50 0>;\012    pos uni10CAF uni10CD2 <-30 0 -30 0>;\012    pos uni10CAF uni10CD4 <-40 0 -40 0>;\012    pos uni10CAF uni10CD6 <40 0 40 0>;\012    pos uni10CAF uni10CD7 <-10 0 -10 0>;\012    pos uni10CAF uni10CD9 <20 0 20 0>;\012    pos uni10CAF uni10CE3 <-30 0 -30 0>;\012    pos uni10CAF uni10CE4 <40 0 40 0>;\012    pos uni10CAF uni10CE6 <-60 0 -60 0>;\012    pos uni10CAF uni10CE7 <-80 0 -80 0>;\012    pos uni10CAF uni10CE8 <20 0 20 0>;\012    pos uni10CAF uni10CE9 <20 0 20 0>;\012    pos uni10CAF uni10CEC <10 0 10 0>;\012    pos uni10CAF uni10CED <-40 0 -40 0>;\012    pos uni10CAF uni10CF0 <-60 0 -60 0>;\012    pos uni10CAF uni10CF2 <-10 0 -10 0>;\012    pos uni10CAF uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CAF uni10CC2.ltr <20 0 20 0>;\012    pos uni10CAF uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CAF uni10CCD.ltr <40 0 40 0>;\012    pos uni10CAF uni10CD6.ltr <40 0 40 0>;\012    pos uni10CAF uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CAF uni10CE4.ltr <40 0 40 0>;\012    pos uni10CAF uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CAF uni10CE8.ltr <20 0 20 0>;\012    pos uni10CAF uni10CE9.ltr <20 0 20 0>;\012    pos uni10CAF uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CAF uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CB0 uni10CC0 <-40 0 -40 0>;\012    pos uni10CB0 uni10CC1 <-30 0 -30 0>;\012    pos uni10CB0 uni10CC2 <20 0 20 0>;\012    pos uni10CB0 uni10CC4 <-30 0 -30 0>;\012    pos uni10CB0 uni10CC7 <-10 0 -10 0>;\012    pos uni10CB0 uni10CC9 <-20 0 -20 0>;\012    pos uni10CB0 uni10CCB <10 0 10 0>;\012    pos uni10CB0 uni10CCC <-10 0 -10 0>;\012    pos uni10CB0 uni10CCD <40 0 40 0>;\012    pos uni10CB0 uni10CCE <20 0 20 0>;\012    pos uni10CB0 uni10CD0 <-30 0 -30 0>;\012    pos uni10CB0 uni10CD1 <-50 0 -50 0>;\012    pos uni10CB0 uni10CD2 <-30 0 -30 0>;\012    pos uni10CB0 uni10CD4 <-40 0 -40 0>;\012    pos uni10CB0 uni10CD6 <40 0 40 0>;\012    pos uni10CB0 uni10CD7 <-10 0 -10 0>;\012    pos uni10CB0 uni10CD9 <20 0 20 0>;\012    pos uni10CB0 uni10CE3 <-30 0 -30 0>;\012    pos uni10CB0 uni10CE4 <40 0 40 0>;\012    pos uni10CB0 uni10CE6 <-60 0 -60 0>;\012    pos uni10CB0 uni10CE7 <-80 0 -80 0>;\012    pos uni10CB0 uni10CE8 <20 0 20 0>;\012    pos uni10CB0 uni10CE9 <20 0 20 0>;\012    pos uni10CB0 uni10CEC <10 0 10 0>;\012    pos uni10CB0 uni10CED <-40 0 -40 0>;\012    pos uni10CB0 uni10CF0 <-60 0 -60 0>;\012    pos uni10CB0 uni10CF2 <-10 0 -10 0>;\012    pos uni10CB0 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CB0 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CB0 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CB0 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CB0 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CB0 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CB0 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CB0 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CB0 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CB0 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CB0 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CB0 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CB1 uni10CC0 <-40 0 -40 0>;\012    pos uni10CB1 uni10CC1 <-30 0 -30 0>;\012    pos uni10CB1 uni10CC2 <20 0 20 0>;\012    pos uni10CB1 uni10CC4 <-30 0 -30 0>;\012    pos uni10CB1 uni10CC7 <-10 0 -10 0>;\012    pos uni10CB1 uni10CC9 <-20 0 -20 0>;\012    pos uni10CB1 uni10CCB <10 0 10 0>;\012    pos uni10CB1 uni10CCC <-10 0 -10 0>;\012    pos uni10CB1 uni10CCD <40 0 40 0>;\012    pos uni10CB1 uni10CCE <20 0 20 0>;\012    pos uni10CB1 uni10CD0 <-30 0 -30 0>;\012    pos uni10CB1 uni10CD1 <-50 0 -50 0>;\012    pos uni10CB1 uni10CD2 <-30 0 -30 0>;\012    pos uni10CB1 uni10CD4 <-40 0 -40 0>;\012    pos uni10CB1 uni10CD6 <40 0 40 0>;\012    pos uni10CB1 uni10CD7 <-10 0 -10 0>;\012    pos uni10CB1 uni10CD9 <20 0 20 0>;\012    pos uni10CB1 uni10CE3 <-30 0 -30 0>;\012    pos uni10CB1 uni10CE4 <40 0 40 0>;\012    pos uni10CB1 uni10CE6 <-60 0 -60 0>;\012    pos uni10CB1 uni10CE7 <-80 0 -80 0>;\012    pos uni10CB1 uni10CE8 <20 0 20 0>;\012    pos uni10CB1 uni10CE9 <20 0 20 0>;\012    pos uni10CB1 uni10CEC <10 0 10 0>;\012    pos uni10CB1 uni10CED <-40 0 -40 0>;\012    pos uni10CB1 uni10CF0 <-60 0 -60 0>;\012    pos uni10CB1 uni10CF2 <-10 0 -10 0>;\012    pos uni10CB1 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CB1 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CB1 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CB1 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CB1 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CB1 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CB1 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CB1 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CB1 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CB1 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CB1 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CB1 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CB2 uni10CC0 <-40 0 -40 0>;\012    pos uni10CB2 uni10CC1 <-30 0 -30 0>;\012    pos uni10CB2 uni10CC2 <20 0 20 0>;\012    pos uni10CB2 uni10CC4 <-30 0 -30 0>;\012    pos uni10CB2 uni10CC7 <-10 0 -10 0>;\012    pos uni10CB2 uni10CC9 <-20 0 -20 0>;\012    pos uni10CB2 uni10CCB <10 0 10 0>;\012    pos uni10CB2 uni10CCC <-10 0 -10 0>;\012    pos uni10CB2 uni10CCD <40 0 40 0>;\012    pos uni10CB2 uni10CCE <20 0 20 0>;\012    pos uni10CB2 uni10CD0 <-30 0 -30 0>;\012    pos uni10CB2 uni10CD1 <-50 0 -50 0>;\012    pos uni10CB2 uni10CD2 <-30 0 -30 0>;\012    pos uni10CB2 uni10CD4 <-40 0 -40 0>;\012    pos uni10CB2 uni10CD6 <40 0 40 0>;\012    pos uni10CB2 uni10CD7 <-10 0 -10 0>;\012    pos uni10CB2 uni10CD9 <20 0 20 0>;\012    pos uni10CB2 uni10CE3 <-30 0 -30 0>;\012    pos uni10CB2 uni10CE4 <40 0 40 0>;\012    pos uni10CB2 uni10CE6 <-60 0 -60 0>;\012    pos uni10CB2 uni10CE7 <-80 0 -80 0>;\012    pos uni10CB2 uni10CE8 <20 0 20 0>;\012    pos uni10CB2 uni10CE9 <20 0 20 0>;\012    pos uni10CB2 uni10CEC <10 0 10 0>;\012    pos uni10CB2 uni10CED <-40 0 -40 0>;\012    pos uni10CB2 uni10CF0 <-60 0 -60 0>;\012    pos uni10CB2 uni10CF2 <-10 0 -10 0>;\012    pos uni10CB2 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CB2 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CB2 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CB2 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CB2 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CB2 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CB2 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CB2 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CB2 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CB2 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CB2 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CB2 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CC0 uni10CC0 <-40 0 -40 0>;\012    pos uni10CC0 uni10CC1 <-30 0 -30 0>;\012    pos uni10CC0 uni10CC2 <20 0 20 0>;\012    pos uni10CC0 uni10CC4 <-30 0 -30 0>;\012    pos uni10CC0 uni10CC7 <-10 0 -10 0>;\012    pos uni10CC0 uni10CC9 <-20 0 -20 0>;\012    pos uni10CC0 uni10CCB <10 0 10 0>;\012    pos uni10CC0 uni10CCC <-10 0 -10 0>;\012    pos uni10CC0 uni10CCD <40 0 40 0>;\012    pos uni10CC0 uni10CCE <20 0 20 0>;\012    pos uni10CC0 uni10CD0 <-30 0 -30 0>;\012    pos uni10CC0 uni10CD1 <-50 0 -50 0>;\012    pos uni10CC0 uni10CD2 <-30 0 -30 0>;\012    pos uni10CC0 uni10CD4 <-40 0 -40 0>;\012    pos uni10CC0 uni10CD6 <40
+ 0 40 0>;\012    pos uni10CC0 uni10CD7 <-10 0 -10 0>;\012    pos uni10CC0 uni10CD9 <20 0 20 0>;\012    pos uni10CC0 uni10CE3 <-30 0 -30 0>;\012    pos uni10CC0 uni10CE4 <40 0 40 0>;\012    pos uni10CC0 uni10CE6 <-60 0 -60 0>;\012    pos uni10CC0 uni10CE7 <-80 0 -80 0>;\012    pos uni10CC0 uni10CE8 <20 0 20 0>;\012    pos uni10CC0 uni10CE9 <20 0 20 0>;\012    pos uni10CC0 uni10CEC <10 0 10 0>;\012    pos uni10CC0 uni10CED <-40 0 -40 0>;\012    pos uni10CC0 uni10CF0 <-60 0 -60 0>;\012    pos uni10CC0 uni10CF2 <-10 0 -10 0>;\012    pos uni10CC0 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CC0 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CC0 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CC0 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CC0 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CC0 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CC0 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CC0 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CC0 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CC0 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CC0 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CC0 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CC1 uni10CC0 <-40 0 -40 0>;\012    pos uni10CC1 uni10CC1 <-30 0 -30 0>;\012    pos uni10CC1 uni10CC2 <20 0 20 0>;\012    pos uni10CC1 uni10CC4 <-30 0 -30 0>;\012    pos uni10CC1 uni10CC7 <-10 0 -10 0>;\012    pos uni10CC1 uni10CC9 <-20 0 -20 0>;\012    pos uni10CC1 uni10CCB <10 0 10 0>;\012    pos uni10CC1 uni10CCC <-10 0 -10 0>;\012    pos uni10CC1 uni10CCD <40 0 40 0>;\012    pos uni10CC1 uni10CCE <20 0 20 0>;\012    pos uni10CC1 uni10CD0 <-30 0 -30 0>;\012    pos uni10CC1 uni10CD1 <-50 0 -50 0>;\012    pos uni10CC1 uni10CD2 <-30 0 -30 0>;\012    pos uni10CC1 uni10CD4 <-40 0 -40 0>;\012    pos uni10CC1 uni10CD6 <40 0 40 0>;\012    pos uni10CC1 uni10CD7 <-10 0 -10 0>;\012    pos uni10CC1 uni10CD9 <20 0 20 0>;\012    pos uni10CC1 uni10CE3 <-30 0 -30 0>;\012    pos uni10CC1 uni10CE4 <40 0 40 0>;\012    pos uni10CC1 uni10CE6 <-60 0 -60 0>;\012    pos uni10CC1 uni10CE7 <-80 0 -80 0>;\012    pos uni10CC1 uni10CE8 <20 0 20 0>;\012    pos uni10CC1 uni10CE9 <20 0 20 0>;\012    pos uni10CC1 uni10CEC <10 0 10 0>;\012    pos uni10CC1 uni10CED <-40 0 -40 0>;\012    pos uni10CC1 uni10CF0 <-60 0 -60 0>;\012    pos uni10CC1 uni10CF2 <-10 0 -10 0>;\012    pos uni10CC1 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CC1 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CC1 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CC1 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CC1 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CC1 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CC1 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CC1 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CC1 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CC1 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CC1 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CC1 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CC2 uni10CC0 <-10 0 -10 0>;\012    pos uni10CC2 uni10CC1 <-30 0 -30 0>;\012    pos uni10CC2 uni10CC2 <20 0 20 0>;\012    pos uni10CC2 uni10CC3 <10 0 10 0>;\012    pos uni10CC2 uni10CCC <-20 0 -20 0>;\012    pos uni10CC2 uni10CD2 <-10 0 -10 0>;\012    pos uni10CC2 uni10CD7 <-20 0 -20 0>;\012    pos uni10CC2 uni10CD9 <20 0 20 0>;\012    pos uni10CC2 uni10CE3 <-40 0 -40 0>;\012    pos uni10CC2 uni10CE8 <20 0 20 0>;\012    pos uni10CC2 uni10CE9 <20 0 20 0>;\012    pos uni10CC2 uni10CEC <20 0 20 0>;\012    pos uni10CC2 uni10CF2 <-20 0 -20 0>;\012    pos uni10CC2 uni10CC0.ltr <-10 0 -10 0>;\012    pos uni10CC2 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CC2 uni10CCC.ltr <-20 0 -20 0>;\012    pos uni10CC2 uni10CD7.ltr <-20 0 -20 0>;\012    pos uni10CC2 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CC2 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CC2 uni10CF2.ltr <-20 0 -20 0>;\012    pos uni10CC3 uni10CC0 <-40 0 -40 0>;\012    pos uni10CC3 uni10CC1 <-30 0 -30 0>;\012    pos uni10CC3 uni10CC2 <20 0 20 0>;\012    pos uni10CC3 uni10CC4 <-30 0 -30 0>;\012    pos uni10CC3 uni10CC7 <-10 0 -10 0>;\012    pos uni10CC3 uni10CC9 <-20 0 -20 0>;\012    pos uni10CC3 uni10CCB <10 0 10 0>;\012    pos uni10CC3 uni10CCC <-10 0 -10 0>;\012    pos uni10CC3 uni10CCD <40 0 40 0>;\012    pos uni10CC3 uni10CCE <20 0 20 0>;\012    pos uni10CC3 uni10CD0 <-30 0 -30 0>;\012    pos uni10CC3 uni10CD1 <-50 0 -50 0>;\012    pos uni10CC3 uni10CD2 <-30 0 -30 0>;\012    pos uni10CC3 uni10CD4 <-40 0 -40 0>;\012    pos uni10CC3 uni10CD6 <40 0 40 0>;\012    pos uni10CC3 uni10CD7 <-10 0 -10 0>;\012    pos uni10CC3 uni10CD9 <20 0 20 0>;\012    pos uni10CC3 uni10CE3 <-30 0 -30 0>;\012    pos uni10CC3 uni10CE4 <40 0 40 0>;\012    pos uni10CC3 uni10CE6 <-60 0 -60 0>;\012    pos uni10CC3 uni10CE7 <-80 0 -80 0>;\012    pos uni10CC3 uni10CE8 <20 0 20 0>;\012    pos uni10CC3 uni10CE9 <20 0 20 0>;\012    pos uni10CC3 uni10CEC <10 0 10 0>;\012    pos uni10CC3 uni10CED <-40 0 -40 0>;\012    pos uni10CC3 uni10CF0 <-60 0 -60 0>;\012    pos uni10CC3 uni10CF2 <-10 0 -10 0>;\012    pos uni10CC3 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CC3 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CC3 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CC3 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CC3 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CC3 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CC3 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CC3 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CC3 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CC3 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CC3 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CC3 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CC4 uni10CE3 <-20 0 -20 0>;\012    pos uni10CC5 uni10CC0 <-40 0 -40 0>;\012    pos uni10CC5 uni10CC1 <-30 0 -30 0>;\012    pos uni10CC5 uni10CC2 <20 0 20 0>;\012    pos uni10CC5 uni10CC4 <-30 0 -30 0>;\012    pos uni10CC5 uni10CC7 <-10 0 -10 0>;\012    pos uni10CC5 uni10CC9 <-20 0 -20 0>;\012    pos uni10CC5 uni10CCB <10 0 10 0>;\012    pos uni10CC5 uni10CCC <-10 0 -10 0>;\012    pos uni10CC5 uni10CCD <40 0 40 0>;\012    pos uni10CC5 uni10CCE <20 0 20 0>;\012    pos uni10CC5 uni10CD0 <-30 0 -30 0>;\012    pos uni10CC5 uni10CD1 <-50 0 -50 0>;\012    pos uni10CC5 uni10CD2 <-30 0 -30 0>;\012    pos uni10CC5 uni10CD4 <-40 0 -40 0>;\012    pos uni10CC5 uni10CD6 <40 0 40 0>;\012    pos uni10CC5 uni10CD7 <-10 0 -10 0>;\012    pos uni10CC5 uni10CD9 <20 0 20 0>;\012    pos uni10CC5 uni10CE3 <-30 0 -30 0>;\012    pos uni10CC5 uni10CE4 <40 0 40 0>;\012    pos uni10CC5 uni10CE6 <-60 0 -60 0>;\012    pos uni10CC5 uni10CE7 <-80 0 -80 0>;\012    pos uni10CC5 uni10CE8 <20 0 20 0>;\012    pos uni10CC5 uni10CE9 <20 0 20 0>;\012    pos uni10CC5 uni10CEC <10 0 10 0>;\012    pos uni10CC5 uni10CED <-40 0 -40 0>;\012    pos uni10CC5 uni10CF0 <-60 0 -60 0>;\012    pos uni10CC5 uni10CF2 <-10 0 -10 0>;\012    pos uni10CC5 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CC5 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CC5 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CC5 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CC5 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CC5 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CC5 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CC5 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CC5 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CC5 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CC5 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CC5 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CC6 uni10CC0 <-40 0 -40 0>;\012    pos uni10CC6 uni10CC1 <-30 0 -30 0>;\012    pos uni10CC6 uni10CC2 <20 0 20 0>;\012    pos uni10CC6 uni10CC4 <-30 0 -30 0>;\012    pos uni10CC6 uni10CC7 <-10 0 -10 0>;\012    pos uni10CC6 uni10CC9 <-20 0 -20 0>;\012    pos uni10CC6 uni10CCB <10 0 10 0>;\012    pos uni10CC6 uni10CCC <-10 0 -10 0>;\012    pos uni10CC6 uni10CCD <40 0 40 0>;\012    pos uni10CC6 uni10CCE <20 0 20 0>;\012    pos uni10CC6 uni10CD0 <-30 0 -30 0>;\012    pos uni10CC6 uni10CD1 <-50 0 -50 0>;\012    pos uni10CC6 uni10CD2 <-30 0 -30 0>;\012    pos uni10CC6 uni10CD4 <-40 0 -40 0>;\012    pos uni10CC6 uni10CD6 <40 0 40 0>;\012    pos uni10CC6 uni10CD7 <-10 0 -10 0>;\012    pos uni10CC6 uni10CD9 <20 0 20 0>;\012    pos uni10CC6 uni10CE3 <-30 0 -30 0>;\012    pos uni10CC6 uni10CE4 <40 0 40 0>;\012    pos uni10CC6 uni10CE6 <-60 0 -60 0>;\012    pos uni10CC6 uni10CE7 <-80 0 -80 0>;\012    pos uni10CC6 uni10CE8 <20 0 20 0>;\012    pos uni10CC6 uni10CE9 <20 0 20 0>;\012    pos uni10CC6 uni10CEC <10 0 10 0>;\012    pos uni10CC6 uni10CED <-40 0 -40 0>;\012    pos uni10CC6 uni10CF0 <-60 0 -60 0>;\012    pos uni10CC6 uni10CF2 <-10 0 -10 0>;\012    pos uni10CC6 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CC6 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CC6 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CC6 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CC6 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CC6 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CC6 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CC6 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CC6 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CC6 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CC6 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CC6 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CC7 uni10CCD <-20 0 -20 0>;\012    pos uni10CC7 uni10CD6 <-20 0 -20 0>;\012    pos uni10CC7 uni10CE4 <-20 0 -20 0>;\012    pos uni10CC7 uni10CCD.ltr <-20 0 -20 0>;\012    pos uni10CC7 uni10CD6.ltr <-20 0 -20 0>;\012    pos uni10CC7 uni10CE4.ltr <-20 0 -20 0>;\012    pos uni10CC8 uni10CC0 <-40 0 -40 0>;\012    pos uni10CC8 uni10CC1 <-30 0 -30 0>;\012    pos uni10CC8 uni10CC2 <20 0 20 0>;\012    pos uni10CC8 uni10CC4 <-30 0 -30 0>;\012    pos uni10CC8 uni10CC7 <-10 0 -10 0>;\012    pos uni10CC8 uni10CC9 <-20 0 -20 0>;\012    pos uni10CC8 uni10CCB <10 0 10 0>;\012    pos uni10CC8 uni10CCC <-10 0 -10 0>;\012    pos uni10CC8 uni10CCD <40 0 40 0>;\012    pos uni10CC8 uni10CCE <20 0 20 0>;\012    pos uni10CC8 uni10CD0 <-30 0 -30 0>;\012    pos uni10CC8 uni10CD1 <-50 0 -50 0>;\012    pos uni10CC8 uni10CD2 <-30 0 -30 0>;\012    pos uni10CC8 uni10CD4 <-40 0 -40 0>;\012    pos uni10CC8 uni10CD6 <40 0 40 0>;\012    pos uni10CC8 uni10CD7
+ <-10 0 -10 0>;\012    pos uni10CC8 uni10CD9 <20 0 20 0>;\012    pos uni10CC8 uni10CE3 <-30 0 -30 0>;\012    pos uni10CC8 uni10CE4 <40 0 40 0>;\012    pos uni10CC8 uni10CE6 <-60 0 -60 0>;\012    pos uni10CC8 uni10CE7 <-80 0 -80 0>;\012    pos uni10CC8 uni10CE8 <20 0 20 0>;\012    pos uni10CC8 uni10CE9 <20 0 20 0>;\012    pos uni10CC8 uni10CEC <10 0 10 0>;\012    pos uni10CC8 uni10CED <-40 0 -40 0>;\012    pos uni10CC8 uni10CF0 <-60 0 -60 0>;\012    pos uni10CC8 uni10CF2 <-10 0 -10 0>;\012    pos uni10CC8 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CC8 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CC8 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CC8 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CC8 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CC8 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CC8 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CC8 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CC8 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CC8 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CC8 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CC8 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CC9 uni10CC0 <-40 0 -40 0>;\012    pos uni10CC9 uni10CC1 <-30 0 -30 0>;\012    pos uni10CC9 uni10CC2 <20 0 20 0>;\012    pos uni10CC9 uni10CC4 <-30 0 -30 0>;\012    pos uni10CC9 uni10CC7 <-10 0 -10 0>;\012    pos uni10CC9 uni10CC9 <-20 0 -20 0>;\012    pos uni10CC9 uni10CCB <10 0 10 0>;\012    pos uni10CC9 uni10CCC <-10 0 -10 0>;\012    pos uni10CC9 uni10CCD <40 0 40 0>;\012    pos uni10CC9 uni10CCE <20 0 20 0>;\012    pos uni10CC9 uni10CD0 <-30 0 -30 0>;\012    pos uni10CC9 uni10CD1 <-50 0 -50 0>;\012    pos uni10CC9 uni10CD2 <-30 0 -30 0>;\012    pos uni10CC9 uni10CD4 <-40 0 -40 0>;\012    pos uni10CC9 uni10CD6 <40 0 40 0>;\012    pos uni10CC9 uni10CD7 <-10 0 -10 0>;\012    pos uni10CC9 uni10CD9 <20 0 20 0>;\012    pos uni10CC9 uni10CE3 <-30 0 -30 0>;\012    pos uni10CC9 uni10CE4 <40 0 40 0>;\012    pos uni10CC9 uni10CE6 <-60 0 -60 0>;\012    pos uni10CC9 uni10CE7 <-80 0 -80 0>;\012    pos uni10CC9 uni10CE8 <20 0 20 0>;\012    pos uni10CC9 uni10CE9 <20 0 20 0>;\012    pos uni10CC9 uni10CEC <10 0 10 0>;\012    pos uni10CC9 uni10CED <-40 0 -40 0>;\012    pos uni10CC9 uni10CF0 <-60 0 -60 0>;\012    pos uni10CC9 uni10CF2 <-10 0 -10 0>;\012    pos uni10CC9 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CC9 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CC9 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CC9 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CC9 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CC9 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CC9 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CC9 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CC9 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CC9 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CC9 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CC9 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CCA uni10CC0 <-40 0 -40 0>;\012    pos uni10CCA uni10CC1 <-30 0 -30 0>;\012    pos uni10CCA uni10CC2 <20 0 20 0>;\012    pos uni10CCA uni10CC4 <-30 0 -30 0>;\012    pos uni10CCA uni10CC7 <-10 0 -10 0>;\012    pos uni10CCA uni10CC9 <-20 0 -20 0>;\012    pos uni10CCA uni10CCB <10 0 10 0>;\012    pos uni10CCA uni10CCC <-10 0 -10 0>;\012    pos uni10CCA uni10CCD <40 0 40 0>;\012    pos uni10CCA uni10CCE <20 0 20 0>;\012    pos uni10CCA uni10CD0 <-30 0 -30 0>;\012    pos uni10CCA uni10CD1 <-50 0 -50 0>;\012    pos uni10CCA uni10CD2 <-30 0 -30 0>;\012    pos uni10CCA uni10CD4 <-40 0 -40 0>;\012    pos uni10CCA uni10CD6 <40 0 40 0>;\012    pos uni10CCA uni10CD7 <-10 0 -10 0>;\012    pos uni10CCA uni10CD9 <20 0 20 0>;\012    pos uni10CCA uni10CE3 <-30 0 -30 0>;\012    pos uni10CCA uni10CE4 <40 0 40 0>;\012    pos uni10CCA uni10CE6 <-60 0 -60 0>;\012    pos uni10CCA uni10CE7 <-80 0 -80 0>;\012    pos uni10CCA uni10CE8 <20 0 20 0>;\012    pos uni10CCA uni10CE9 <20 0 20 0>;\012    pos uni10CCA uni10CEC <10 0 10 0>;\012    pos uni10CCA uni10CED <-40 0 -40 0>;\012    pos uni10CCA uni10CF0 <-60 0 -60 0>;\012    pos uni10CCA uni10CF2 <-10 0 -10 0>;\012    pos uni10CCA uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CCA uni10CC2.ltr <20 0 20 0>;\012    pos uni10CCA uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CCA uni10CCD.ltr <40 0 40 0>;\012    pos uni10CCA uni10CD6.ltr <40 0 40 0>;\012    pos uni10CCA uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CCA uni10CE4.ltr <40 0 40 0>;\012    pos uni10CCA uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CCA uni10CE8.ltr <20 0 20 0>;\012    pos uni10CCA uni10CE9.ltr <20 0 20 0>;\012    pos uni10CCA uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CCA uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CCB uni10CC0 <-40 0 -40 0>;\012    pos uni10CCB uni10CC1 <-30 0 -30 0>;\012    pos uni10CCB uni10CC2 <20 0 20 0>;\012    pos uni10CCB uni10CC4 <-30 0 -30 0>;\012    pos uni10CCB uni10CC7 <-10 0 -10 0>;\012    pos uni10CCB uni10CC9 <-20 0 -20 0>;\012    pos uni10CCB uni10CCB <10 0 10 0>;\012    pos uni10CCB uni10CCC <-10 0 -10 0>;\012    pos uni10CCB uni10CCD <40 0 40 0>;\012    pos uni10CCB uni10CCE <20 0 20 0>;\012    pos uni10CCB uni10CD0 <-30 0 -30 0>;\012    pos uni10CCB uni10CD1 <-50 0 -50 0>;\012    pos uni10CCB uni10CD2 <-30 0 -30 0>;\012    pos uni10CCB uni10CD4 <-40 0 -40 0>;\012    pos uni10CCB uni10CD6 <40 0 40 0>;\012    pos uni10CCB uni10CD7 <-10 0 -10 0>;\012    pos uni10CCB uni10CD9 <20 0 20 0>;\012    pos uni10CCB uni10CE3 <-30 0 -30 0>;\012    pos uni10CCB uni10CE4 <40 0 40 0>;\012    pos uni10CCB uni10CE6 <-60 0 -60 0>;\012    pos uni10CCB uni10CE7 <-80 0 -80 0>;\012    pos uni10CCB uni10CE8 <20 0 20 0>;\012    pos uni10CCB uni10CE9 <20 0 20 0>;\012    pos uni10CCB uni10CEC <10 0 10 0>;\012    pos uni10CCB uni10CED <-40 0 -40 0>;\012    pos uni10CCB uni10CF0 <-60 0 -60 0>;\012    pos uni10CCB uni10CF2 <-10 0 -10 0>;\012    pos uni10CCB uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CCB uni10CC2.ltr <20 0 20 0>;\012    pos uni10CCB uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CCB uni10CCD.ltr <40 0 40 0>;\012    pos uni10CCB uni10CD6.ltr <40 0 40 0>;\012    pos uni10CCB uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CCB uni10CE4.ltr <40 0 40 0>;\012    pos uni10CCB uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CCB uni10CE8.ltr <20 0 20 0>;\012    pos uni10CCB uni10CE9.ltr <20 0 20 0>;\012    pos uni10CCB uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CCB uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CCC uni10CC2 <-10 0 -10 0>;\012    pos uni10CCC uni10CE6 <-30 0 -30 0>;\012    pos uni10CCC uni10CE8 <-10 0 -10 0>;\012    pos uni10CCC uni10CE9 <-10 0 -10 0>;\012    pos uni10CCC uni10CF0 <-30 0 -30 0>;\012    pos uni10CCC uni10CC2.ltr <-10 0 -10 0>;\012    pos uni10CCC uni10CE6.ltr <-30 0 -30 0>;\012    pos uni10CCC uni10CE8.ltr <-10 0 -10 0>;\012    pos uni10CCC uni10CE9.ltr <-10 0 -10 0>;\012    pos uni10CCC uni10CF0.ltr <-30 0 -30 0>;\012    pos uni10CCD uni10CC0 <-40 0 -40 0>;\012    pos uni10CCD uni10CC1 <-30 0 -30 0>;\012    pos uni10CCD uni10CC2 <20 0 20 0>;\012    pos uni10CCD uni10CC4 <-30 0 -30 0>;\012    pos uni10CCD uni10CC7 <-10 0 -10 0>;\012    pos uni10CCD uni10CC9 <-20 0 -20 0>;\012    pos uni10CCD uni10CCB <10 0 10 0>;\012    pos uni10CCD uni10CCC <-10 0 -10 0>;\012    pos uni10CCD uni10CCD <40 0 40 0>;\012    pos uni10CCD uni10CCE <20 0 20 0>;\012    pos uni10CCD uni10CD0 <-30 0 -30 0>;\012    pos uni10CCD uni10CD1 <-50 0 -50 0>;\012    pos uni10CCD uni10CD2 <-30 0 -30 0>;\012    pos uni10CCD uni10CD4 <-40 0 -40 0>;\012    pos uni10CCD uni10CD6 <40 0 40 0>;\012    pos uni10CCD uni10CD7 <-10 0 -10 0>;\012    pos uni10CCD uni10CD9 <20 0 20 0>;\012    pos uni10CCD uni10CE3 <-30 0 -30 0>;\012    pos uni10CCD uni10CE4 <40 0 40 0>;\012    pos uni10CCD uni10CE6 <-60 0 -60 0>;\012    pos uni10CCD uni10CE7 <-80 0 -80 0>;\012    pos uni10CCD uni10CE8 <20 0 20 0>;\012    pos uni10CCD uni10CE9 <20 0 20 0>;\012    pos uni10CCD uni10CEC <10 0 10 0>;\012    pos uni10CCD uni10CED <-40 0 -40 0>;\012    pos uni10CCD uni10CF0 <-60 0 -60 0>;\012    pos uni10CCD uni10CF2 <-10 0 -10 0>;\012    pos uni10CCD uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CCD uni10CC2.ltr <20 0 20 0>;\012    pos uni10CCD uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CCD uni10CCD.ltr <40 0 40 0>;\012    pos uni10CCD uni10CD6.ltr <40 0 40 0>;\012    pos uni10CCD uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CCD uni10CE4.ltr <40 0 40 0>;\012    pos uni10CCD uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CCD uni10CE8.ltr <20 0 20 0>;\012    pos uni10CCD uni10CE9.ltr <20 0 20 0>;\012    pos uni10CCD uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CCD uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CCE uni10CCD <-20 0 -20 0>;\012    pos uni10CCE uni10CD6 <-20 0 -20 0>;\012    pos uni10CCE uni10CE4 <-20 0 -20 0>;\012    pos uni10CCE uni10CCD.ltr <-20 0 -20 0>;\012    pos uni10CCE uni10CD6.ltr <-20 0 -20 0>;\012    pos uni10CCE uni10CE4.ltr <-20 0 -20 0>;\012    pos uni10CCF uni10CE6 <-20 0 -20 0>;\012    pos uni10CCF uni10CF0 <-20 0 -20 0>;\012    pos uni10CCF uni10CE6.ltr <-20 0 -20 0>;\012    pos uni10CCF uni10CF0.ltr <-20 0 -20 0>;\012    pos uni10CD0 uni10CCD <-40 0 -40 0>;\012    pos uni10CD0 uni10CD6 <-40 0 -40 0>;\012    pos uni10CD0 uni10CE4 <-40 0 -40 0>;\012    pos uni10CD0 uni10CCD.ltr <-40 0 -40 0>;\012    pos uni10CD0 uni10CD6.ltr <-40 0 -40 0>;\012    pos uni10CD0 uni10CE4.ltr <-40 0 -40 0>;\012    pos uni10CD1 uni10CC0 <-20 0 -20 0>;\012    pos uni10CD1 uni10CCC <-30 0 -30 0>;\012    pos uni10CD1 uni10CCD <-40 0 -40 0>;\012    pos uni10CD1 uni10CD6 <-40 0 -40 0>;\012    pos uni10CD1 uni10CD7 <-30 0 -30 0>;\012    pos uni10CD1 uni10CE4 <-40 0 -40 0>;\012    pos uni10CD1 uni10CF2 <-30 0 -30 0>;\012    pos uni10CD1 uni10CC0.ltr <-20 0 -20 0>;\012    pos uni10CD1 uni10CCC.ltr <-30 0 -30 0>;\012    pos uni10CD1 uni10CCD.ltr <-40 0 -40 0>;\012    pos uni10CD1 uni10CD6.ltr <-40 0 -40 0>;\012    pos uni10CD1 uni10CD7.ltr <-30 0 -30 0>;\012    pos uni10CD1 uni10CE4.ltr <-40 0 -40 0>;\012    pos uni10CD1 uni10CF2.ltr <-30 0 -30 0>;\012    pos uni10CD2 uni10CC0 <-40 0 -40 0>;\012    pos uni10CD2 uni10CC1 <-30 0
+ -30 0>;\012    pos uni10CD2 uni10CC2 <20 0 20 0>;\012    pos uni10CD2 uni10CC4 <-30 0 -30 0>;\012    pos uni10CD2 uni10CC7 <-10 0 -10 0>;\012    pos uni10CD2 uni10CC9 <-20 0 -20 0>;\012    pos uni10CD2 uni10CCB <10 0 10 0>;\012    pos uni10CD2 uni10CCC <-10 0 -10 0>;\012    pos uni10CD2 uni10CCD <40 0 40 0>;\012    pos uni10CD2 uni10CCE <20 0 20 0>;\012    pos uni10CD2 uni10CD0 <-30 0 -30 0>;\012    pos uni10CD2 uni10CD1 <-50 0 -50 0>;\012    pos uni10CD2 uni10CD2 <-30 0 -30 0>;\012    pos uni10CD2 uni10CD4 <-40 0 -40 0>;\012    pos uni10CD2 uni10CD6 <40 0 40 0>;\012    pos uni10CD2 uni10CD7 <-10 0 -10 0>;\012    pos uni10CD2 uni10CD9 <20 0 20 0>;\012    pos uni10CD2 uni10CE3 <-30 0 -30 0>;\012    pos uni10CD2 uni10CE4 <40 0 40 0>;\012    pos uni10CD2 uni10CE6 <-60 0 -60 0>;\012    pos uni10CD2 uni10CE7 <-80 0 -80 0>;\012    pos uni10CD2 uni10CE8 <20 0 20 0>;\012    pos uni10CD2 uni10CE9 <20 0 20 0>;\012    pos uni10CD2 uni10CEC <10 0 10 0>;\012    pos uni10CD2 uni10CED <-40 0 -40 0>;\012    pos uni10CD2 uni10CF0 <-60 0 -60 0>;\012    pos uni10CD2 uni10CF2 <-10 0 -10 0>;\012    pos uni10CD2 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CD2 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CD2 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CD2 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CD2 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CD2 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CD2 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CD2 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CD2 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CD2 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CD2 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CD2 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CD3 uni10CE6 <-40 0 -40 0>;\012    pos uni10CD3 uni10CF0 <-40 0 -40 0>;\012    pos uni10CD3 uni10CE6.ltr <-40 0 -40 0>;\012    pos uni10CD3 uni10CF0.ltr <-40 0 -40 0>;\012    pos uni10CD4 uni10CC0 <-30 0 -30 0>;\012    pos uni10CD4 uni10CE6 <-70 0 -70 0>;\012    pos uni10CD4 uni10CF0 <-70 0 -70 0>;\012    pos uni10CD4 uni10CC0.ltr <-30 0 -30 0>;\012    pos uni10CD4 uni10CE6.ltr <-70 0 -70 0>;\012    pos uni10CD4 uni10CF0.ltr <-70 0 -70 0>;\012    pos uni10CD5 uni10CCC <-30 0 -30 0>;\012    pos uni10CD5 uni10CD7 <-30 0 -30 0>;\012    pos uni10CD5 uni10CF2 <-30 0 -30 0>;\012    pos uni10CD5 uni10CCC.ltr <-30 0 -30 0>;\012    pos uni10CD5 uni10CD7.ltr <-30 0 -30 0>;\012    pos uni10CD5 uni10CF2.ltr <-30 0 -30 0>;\012    pos uni10CD6 uni10CC0 <-40 0 -40 0>;\012    pos uni10CD6 uni10CC1 <-30 0 -30 0>;\012    pos uni10CD6 uni10CC2 <20 0 20 0>;\012    pos uni10CD6 uni10CC4 <-30 0 -30 0>;\012    pos uni10CD6 uni10CC7 <-10 0 -10 0>;\012    pos uni10CD6 uni10CC9 <-20 0 -20 0>;\012    pos uni10CD6 uni10CCB <10 0 10 0>;\012    pos uni10CD6 uni10CCC <-10 0 -10 0>;\012    pos uni10CD6 uni10CCD <40 0 40 0>;\012    pos uni10CD6 uni10CCE <20 0 20 0>;\012    pos uni10CD6 uni10CD0 <-30 0 -30 0>;\012    pos uni10CD6 uni10CD1 <-50 0 -50 0>;\012    pos uni10CD6 uni10CD2 <-30 0 -30 0>;\012    pos uni10CD6 uni10CD4 <-40 0 -40 0>;\012    pos uni10CD6 uni10CD6 <40 0 40 0>;\012    pos uni10CD6 uni10CD7 <-10 0 -10 0>;\012    pos uni10CD6 uni10CD9 <20 0 20 0>;\012    pos uni10CD6 uni10CE3 <-30 0 -30 0>;\012    pos uni10CD6 uni10CE4 <40 0 40 0>;\012    pos uni10CD6 uni10CE6 <-60 0 -60 0>;\012    pos uni10CD6 uni10CE7 <-80 0 -80 0>;\012    pos uni10CD6 uni10CE8 <20 0 20 0>;\012    pos uni10CD6 uni10CE9 <20 0 20 0>;\012    pos uni10CD6 uni10CEC <10 0 10 0>;\012    pos uni10CD6 uni10CED <-40 0 -40 0>;\012    pos uni10CD6 uni10CF0 <-60 0 -60 0>;\012    pos uni10CD6 uni10CF2 <-10 0 -10 0>;\012    pos uni10CD6 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CD6 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CD6 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CD6 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CD6 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CD6 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CD6 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CD6 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CD6 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CD6 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CD6 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CD6 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CD7 uni10CC2 <-30 0 -30 0>;\012    pos uni10CD7 uni10CC4 <-10 0 -10 0>;\012    pos uni10CD7 uni10CC9 <-30 0 -30 0>;\012    pos uni10CD7 uni10CCD <-20 0 -20 0>;\012    pos uni10CD7 uni10CCF <-20 0 -20 0>;\012    pos uni10CD7 uni10CD0 <-30 0 -30 0>;\012    pos uni10CD7 uni10CD1 <-20 0 -20 0>;\012    pos uni10CD7 uni10CD5 <-30 0 -30 0>;\012    pos uni10CD7 uni10CD6 <-20 0 -20 0>;\012    pos uni10CD7 uni10CD9 <-30 0 -30 0>;\012    pos uni10CD7 uni10CE4 <-20 0 -20 0>;\012    pos uni10CD7 uni10CE6 <-40 0 -40 0>;\012    pos uni10CD7 uni10CE7 <-30 0 -30 0>;\012    pos uni10CD7 uni10CE8 <-30 0 -30 0>;\012    pos uni10CD7 uni10CE9 <-30 0 -30 0>;\012    pos uni10CD7 uni10CF0 <-40 0 -40 0>;\012    pos uni10CD7 uni10CC2.ltr <-30 0 -30 0>;\012    pos uni10CD7 uni10CCD.ltr <-20 0 -20 0>;\012    pos uni10CD7 uni10CD6.ltr <-20 0 -20 0>;\012    pos uni10CD7 uni10CE4.ltr <-20 0 -20 0>;\012    pos uni10CD7 uni10CE6.ltr <-40 0 -40 0>;\012    pos uni10CD7 uni10CE8.ltr <-30 0 -30 0>;\012    pos uni10CD7 uni10CE9.ltr <-30 0 -30 0>;\012    pos uni10CD7 uni10CF0.ltr <-40 0 -40 0>;\012    pos uni10CD8 uni10CC0 <-40 0 -40 0>;\012    pos uni10CD8 uni10CC1 <-30 0 -30 0>;\012    pos uni10CD8 uni10CC2 <20 0 20 0>;\012    pos uni10CD8 uni10CC4 <-30 0 -30 0>;\012    pos uni10CD8 uni10CC7 <-10 0 -10 0>;\012    pos uni10CD8 uni10CC9 <-20 0 -20 0>;\012    pos uni10CD8 uni10CCB <10 0 10 0>;\012    pos uni10CD8 uni10CCC <-10 0 -10 0>;\012    pos uni10CD8 uni10CCD <40 0 40 0>;\012    pos uni10CD8 uni10CCE <20 0 20 0>;\012    pos uni10CD8 uni10CD0 <-30 0 -30 0>;\012    pos uni10CD8 uni10CD1 <-50 0 -50 0>;\012    pos uni10CD8 uni10CD2 <-30 0 -30 0>;\012    pos uni10CD8 uni10CD4 <-40 0 -40 0>;\012    pos uni10CD8 uni10CD6 <40 0 40 0>;\012    pos uni10CD8 uni10CD7 <-10 0 -10 0>;\012    pos uni10CD8 uni10CD9 <20 0 20 0>;\012    pos uni10CD8 uni10CE3 <-30 0 -30 0>;\012    pos uni10CD8 uni10CE4 <40 0 40 0>;\012    pos uni10CD8 uni10CE6 <-60 0 -60 0>;\012    pos uni10CD8 uni10CE7 <-80 0 -80 0>;\012    pos uni10CD8 uni10CE8 <20 0 20 0>;\012    pos uni10CD8 uni10CE9 <20 0 20 0>;\012    pos uni10CD8 uni10CEC <10 0 10 0>;\012    pos uni10CD8 uni10CED <-40 0 -40 0>;\012    pos uni10CD8 uni10CF0 <-60 0 -60 0>;\012    pos uni10CD8 uni10CF2 <-10 0 -10 0>;\012    pos uni10CD8 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CD8 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CD8 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CD8 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CD8 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CD8 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CD8 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CD8 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CD8 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CD8 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CD8 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CD8 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CD9 uni10CC2 <-30 0 -30 0>;\012    pos uni10CD9 uni10CC4 <-10 0 -10 0>;\012    pos uni10CD9 uni10CC9 <-30 0 -30 0>;\012    pos uni10CD9 uni10CCD <-20 0 -20 0>;\012    pos uni10CD9 uni10CCF <-20 0 -20 0>;\012    pos uni10CD9 uni10CD0 <-30 0 -30 0>;\012    pos uni10CD9 uni10CD1 <-20 0 -20 0>;\012    pos uni10CD9 uni10CD5 <-30 0 -30 0>;\012    pos uni10CD9 uni10CD6 <-20 0 -20 0>;\012    pos uni10CD9 uni10CD9 <-30 0 -30 0>;\012    pos uni10CD9 uni10CE4 <-20 0 -20 0>;\012    pos uni10CD9 uni10CE6 <-40 0 -40 0>;\012    pos uni10CD9 uni10CE7 <-30 0 -30 0>;\012    pos uni10CD9 uni10CE8 <-30 0 -30 0>;\012    pos uni10CD9 uni10CE9 <-30 0 -30 0>;\012    pos uni10CD9 uni10CF0 <-40 0 -40 0>;\012    pos uni10CD9 uni10CC2.ltr <-30 0 -30 0>;\012    pos uni10CD9 uni10CCD.ltr <-20 0 -20 0>;\012    pos uni10CD9 uni10CD6.ltr <-20 0 -20 0>;\012    pos uni10CD9 uni10CE4.ltr <-20 0 -20 0>;\012    pos uni10CD9 uni10CE6.ltr <-40 0 -40 0>;\012    pos uni10CD9 uni10CE8.ltr <-30 0 -30 0>;\012    pos uni10CD9 uni10CE9.ltr <-30 0 -30 0>;\012    pos uni10CD9 uni10CF0.ltr <-40 0 -40 0>;\012    pos uni10CDA uni10CC2 <-30 0 -30 0>;\012    pos uni10CDA uni10CC4 <-10 0 -10 0>;\012    pos uni10CDA uni10CC9 <-30 0 -30 0>;\012    pos uni10CDA uni10CCD <-20 0 -20 0>;\012    pos uni10CDA uni10CCF <-20 0 -20 0>;\012    pos uni10CDA uni10CD0 <-30 0 -30 0>;\012    pos uni10CDA uni10CD1 <-20 0 -20 0>;\012    pos uni10CDA uni10CD5 <-30 0 -30 0>;\012    pos uni10CDA uni10CD6 <-20 0 -20 0>;\012    pos uni10CDA uni10CD9 <-30 0 -30 0>;\012    pos uni10CDA uni10CE4 <-20 0 -20 0>;\012    pos uni10CDA uni10CE6 <-40 0 -40 0>;\012    pos uni10CDA uni10CE7 <-30 0 -30 0>;\012    pos uni10CDA uni10CE8 <-30 0 -30 0>;\012    pos uni10CDA uni10CE9 <-30 0 -30 0>;\012    pos uni10CDA uni10CF0 <-40 0 -40 0>;\012    pos uni10CDA uni10CC2.ltr <-30 0 -30 0>;\012    pos uni10CDA uni10CCD.ltr <-20 0 -20 0>;\012    pos uni10CDA uni10CD6.ltr <-20 0 -20 0>;\012    pos uni10CDA uni10CE4.ltr <-20 0 -20 0>;\012    pos uni10CDA uni10CE6.ltr <-40 0 -40 0>;\012    pos uni10CDA uni10CE8.ltr <-30 0 -30 0>;\012    pos uni10CDA uni10CE9.ltr <-30 0 -30 0>;\012    pos uni10CDA uni10CF0.ltr <-40 0 -40 0>;\012    pos uni10CDB uni10CC2 <-30 0 -30 0>;\012    pos uni10CDB uni10CC4 <-10 0 -10 0>;\012    pos uni10CDB uni10CC9 <-30 0 -30 0>;\012    pos uni10CDB uni10CCD <-20 0 -20 0>;\012    pos uni10CDB uni10CCF <-20 0 -20 0>;\012    pos uni10CDB uni10CD0 <-30 0 -30 0>;\012    pos uni10CDB uni10CD1 <-20 0 -20 0>;\012    pos uni10CDB uni10CD5 <-30 0 -30 0>;\012    pos uni10CDB uni10CD6 <-20 0 -20 0>;\012    pos uni10CDB uni10CD9 <-30 0 -30 0>;\012    pos uni10CDB uni10CE4 <-20 0 -20 0>;\012    pos uni10CDB uni10CE6 <-40 0 -40 0>;\012    pos uni10CDB uni10CE7 <-30 0 -30 0>;\012    pos uni10CDB uni10CE8 <-30 0 -30 0>;\012    pos uni10CDB uni10CE9 <-30 0 -30 0>;\012    pos uni10CDB uni10CF0 <-40 0 -40 0>;\012    pos uni10CDB uni10CC2.ltr <-30 0 -30 0>;\012    pos uni10CDB uni10CCD.ltr
+ <-20 0 -20 0>;\012    pos uni10CDB uni10CD6.ltr <-20 0 -20 0>;\012    pos uni10CDB uni10CE4.ltr <-20 0 -20 0>;\012    pos uni10CDB uni10CE6.ltr <-40 0 -40 0>;\012    pos uni10CDB uni10CE8.ltr <-30 0 -30 0>;\012    pos uni10CDB uni10CE9.ltr <-30 0 -30 0>;\012    pos uni10CDB uni10CF0.ltr <-40 0 -40 0>;\012    pos uni10CDC uni10CC2 <-30 0 -30 0>;\012    pos uni10CDC uni10CC4 <-10 0 -10 0>;\012    pos uni10CDC uni10CC9 <-30 0 -30 0>;\012    pos uni10CDC uni10CCD <-20 0 -20 0>;\012    pos uni10CDC uni10CCF <-20 0 -20 0>;\012    pos uni10CDC uni10CD0 <-30 0 -30 0>;\012    pos uni10CDC uni10CD1 <-20 0 -20 0>;\012    pos uni10CDC uni10CD5 <-30 0 -30 0>;\012    pos uni10CDC uni10CD6 <-20 0 -20 0>;\012    pos uni10CDC uni10CD9 <-30 0 -30 0>;\012    pos uni10CDC uni10CE4 <-20 0 -20 0>;\012    pos uni10CDC uni10CE6 <-40 0 -40 0>;\012    pos uni10CDC uni10CE7 <-30 0 -30 0>;\012    pos uni10CDC uni10CE8 <-30 0 -30 0>;\012    pos uni10CDC uni10CE9 <-30 0 -30 0>;\012    pos uni10CDC uni10CF0 <-40 0 -40 0>;\012    pos uni10CDC uni10CC2.ltr <-30 0 -30 0>;\012    pos uni10CDC uni10CCD.ltr <-20 0 -20 0>;\012    pos uni10CDC uni10CD6.ltr <-20 0 -20 0>;\012    pos uni10CDC uni10CE4.ltr <-20 0 -20 0>;\012    pos uni10CDC uni10CE6.ltr <-40 0 -40 0>;\012    pos uni10CDC uni10CE8.ltr <-30 0 -30 0>;\012    pos uni10CDC uni10CE9.ltr <-30 0 -30 0>;\012    pos uni10CDC uni10CF0.ltr <-40 0 -40 0>;\012    pos uni10CDD uni10CE6 <-20 0 -20 0>;\012    pos uni10CDD uni10CF0 <-20 0 -20 0>;\012    pos uni10CDD uni10CE6.ltr <-20 0 -20 0>;\012    pos uni10CDD uni10CF0.ltr <-20 0 -20 0>;\012    pos uni10CDE uni10CC0 <-10 0 -10 0>;\012    pos uni10CDE uni10CC1 <-30 0 -30 0>;\012    pos uni10CDE uni10CC2 <20 0 20 0>;\012    pos uni10CDE uni10CC3 <10 0 10 0>;\012    pos uni10CDE uni10CCC <-20 0 -20 0>;\012    pos uni10CDE uni10CD2 <-10 0 -10 0>;\012    pos uni10CDE uni10CD7 <-20 0 -20 0>;\012    pos uni10CDE uni10CD9 <20 0 20 0>;\012    pos uni10CDE uni10CE3 <-40 0 -40 0>;\012    pos uni10CDE uni10CE8 <20 0 20 0>;\012    pos uni10CDE uni10CE9 <20 0 20 0>;\012    pos uni10CDE uni10CEC <20 0 20 0>;\012    pos uni10CDE uni10CF2 <-20 0 -20 0>;\012    pos uni10CDE uni10CC0.ltr <-10 0 -10 0>;\012    pos uni10CDE uni10CC2.ltr <20 0 20 0>;\012    pos uni10CDE uni10CCC.ltr <-20 0 -20 0>;\012    pos uni10CDE uni10CD7.ltr <-20 0 -20 0>;\012    pos uni10CDE uni10CE8.ltr <20 0 20 0>;\012    pos uni10CDE uni10CE9.ltr <20 0 20 0>;\012    pos uni10CDE uni10CF2.ltr <-20 0 -20 0>;\012    pos uni10CDF uni10CC0 <-40 0 -40 0>;\012    pos uni10CDF uni10CC1 <-30 0 -30 0>;\012    pos uni10CDF uni10CC2 <20 0 20 0>;\012    pos uni10CDF uni10CC4 <-30 0 -30 0>;\012    pos uni10CDF uni10CC7 <-10 0 -10 0>;\012    pos uni10CDF uni10CC9 <-20 0 -20 0>;\012    pos uni10CDF uni10CCB <10 0 10 0>;\012    pos uni10CDF uni10CCC <-10 0 -10 0>;\012    pos uni10CDF uni10CCD <40 0 40 0>;\012    pos uni10CDF uni10CCE <20 0 20 0>;\012    pos uni10CDF uni10CD0 <-30 0 -30 0>;\012    pos uni10CDF uni10CD1 <-50 0 -50 0>;\012    pos uni10CDF uni10CD2 <-30 0 -30 0>;\012    pos uni10CDF uni10CD4 <-40 0 -40 0>;\012    pos uni10CDF uni10CD6 <40 0 40 0>;\012    pos uni10CDF uni10CD7 <-10 0 -10 0>;\012    pos uni10CDF uni10CD9 <20 0 20 0>;\012    pos uni10CDF uni10CE3 <-30 0 -30 0>;\012    pos uni10CDF uni10CE4 <40 0 40 0>;\012    pos uni10CDF uni10CE6 <-60 0 -60 0>;\012    pos uni10CDF uni10CE7 <-80 0 -80 0>;\012    pos uni10CDF uni10CE8 <20 0 20 0>;\012    pos uni10CDF uni10CE9 <20 0 20 0>;\012    pos uni10CDF uni10CEC <10 0 10 0>;\012    pos uni10CDF uni10CED <-40 0 -40 0>;\012    pos uni10CDF uni10CF0 <-60 0 -60 0>;\012    pos uni10CDF uni10CF2 <-10 0 -10 0>;\012    pos uni10CDF uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CDF uni10CC2.ltr <20 0 20 0>;\012    pos uni10CDF uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CDF uni10CCD.ltr <40 0 40 0>;\012    pos uni10CDF uni10CD6.ltr <40 0 40 0>;\012    pos uni10CDF uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CDF uni10CE4.ltr <40 0 40 0>;\012    pos uni10CDF uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CDF uni10CE8.ltr <20 0 20 0>;\012    pos uni10CDF uni10CE9.ltr <20 0 20 0>;\012    pos uni10CDF uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CDF uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CE0 uni10CC0 <-40 0 -40 0>;\012    pos uni10CE0 uni10CC1 <-30 0 -30 0>;\012    pos uni10CE0 uni10CC2 <20 0 20 0>;\012    pos uni10CE0 uni10CC4 <-30 0 -30 0>;\012    pos uni10CE0 uni10CC7 <-10 0 -10 0>;\012    pos uni10CE0 uni10CC9 <-20 0 -20 0>;\012    pos uni10CE0 uni10CCB <10 0 10 0>;\012    pos uni10CE0 uni10CCC <-10 0 -10 0>;\012    pos uni10CE0 uni10CCD <40 0 40 0>;\012    pos uni10CE0 uni10CCE <20 0 20 0>;\012    pos uni10CE0 uni10CD0 <-30 0 -30 0>;\012    pos uni10CE0 uni10CD1 <-50 0 -50 0>;\012    pos uni10CE0 uni10CD2 <-30 0 -30 0>;\012    pos uni10CE0 uni10CD4 <-40 0 -40 0>;\012    pos uni10CE0 uni10CD6 <40 0 40 0>;\012    pos uni10CE0 uni10CD7 <-10 0 -10 0>;\012    pos uni10CE0 uni10CD9 <20 0 20 0>;\012    pos uni10CE0 uni10CE3 <-30 0 -30 0>;\012    pos uni10CE0 uni10CE4 <40 0 40 0>;\012    pos uni10CE0 uni10CE6 <-60 0 -60 0>;\012    pos uni10CE0 uni10CE7 <-80 0 -80 0>;\012    pos uni10CE0 uni10CE8 <20 0 20 0>;\012    pos uni10CE0 uni10CE9 <20 0 20 0>;\012    pos uni10CE0 uni10CEC <10 0 10 0>;\012    pos uni10CE0 uni10CED <-40 0 -40 0>;\012    pos uni10CE0 uni10CF0 <-60 0 -60 0>;\012    pos uni10CE0 uni10CF2 <-10 0 -10 0>;\012    pos uni10CE0 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CE0 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CE0 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CE0 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CE0 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CE0 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CE0 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CE0 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CE0 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CE0 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CE0 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CE0 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CE1 uni10CE6 <-20 0 -20 0>;\012    pos uni10CE1 uni10CF0 <-20 0 -20 0>;\012    pos uni10CE1 uni10CE6.ltr <-20 0 -20 0>;\012    pos uni10CE1 uni10CF0.ltr <-20 0 -20 0>;\012    pos uni10CE2 uni10CC0 <-40 0 -40 0>;\012    pos uni10CE2 uni10CC1 <-30 0 -30 0>;\012    pos uni10CE2 uni10CC2 <20 0 20 0>;\012    pos uni10CE2 uni10CC4 <-30 0 -30 0>;\012    pos uni10CE2 uni10CC7 <-10 0 -10 0>;\012    pos uni10CE2 uni10CC9 <-20 0 -20 0>;\012    pos uni10CE2 uni10CCB <10 0 10 0>;\012    pos uni10CE2 uni10CCC <-10 0 -10 0>;\012    pos uni10CE2 uni10CCD <40 0 40 0>;\012    pos uni10CE2 uni10CCE <20 0 20 0>;\012    pos uni10CE2 uni10CD0 <-30 0 -30 0>;\012    pos uni10CE2 uni10CD1 <-50 0 -50 0>;\012    pos uni10CE2 uni10CD2 <-30 0 -30 0>;\012    pos uni10CE2 uni10CD4 <-40 0 -40 0>;\012    pos uni10CE2 uni10CD6 <40 0 40 0>;\012    pos uni10CE2 uni10CD7 <-10 0 -10 0>;\012    pos uni10CE2 uni10CD9 <20 0 20 0>;\012    pos uni10CE2 uni10CE3 <-30 0 -30 0>;\012    pos uni10CE2 uni10CE4 <40 0 40 0>;\012    pos uni10CE2 uni10CE6 <-60 0 -60 0>;\012    pos uni10CE2 uni10CE7 <-80 0 -80 0>;\012    pos uni10CE2 uni10CE8 <20 0 20 0>;\012    pos uni10CE2 uni10CE9 <20 0 20 0>;\012    pos uni10CE2 uni10CEC <10 0 10 0>;\012    pos uni10CE2 uni10CED <-40 0 -40 0>;\012    pos uni10CE2 uni10CF0 <-60 0 -60 0>;\012    pos uni10CE2 uni10CF2 <-10 0 -10 0>;\012    pos uni10CE2 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CE2 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CE2 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CE2 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CE2 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CE2 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CE2 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CE2 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CE2 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CE2 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CE2 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CE2 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CE3 uni10CC2 <-40 0 -40 0>;\012    pos uni10CE3 uni10CCD <-50 0 -50 0>;\012    pos uni10CE3 uni10CD6 <-50 0 -50 0>;\012    pos uni10CE3 uni10CE4 <-50 0 -50 0>;\012    pos uni10CE3 uni10CE6 <-20 0 -20 0>;\012    pos uni10CE3 uni10CE8 <-40 0 -40 0>;\012    pos uni10CE3 uni10CE9 <-40 0 -40 0>;\012    pos uni10CE3 uni10CF0 <-20 0 -20 0>;\012    pos uni10CE3 uni10CC2.ltr <-40 0 -40 0>;\012    pos uni10CE3 uni10CCD.ltr <-50 0 -50 0>;\012    pos uni10CE3 uni10CD6.ltr <-50 0 -50 0>;\012    pos uni10CE3 uni10CE4.ltr <-50 0 -50 0>;\012    pos uni10CE3 uni10CE6.ltr <-20 0 -20 0>;\012    pos uni10CE3 uni10CE8.ltr <-40 0 -40 0>;\012    pos uni10CE3 uni10CE9.ltr <-40 0 -40 0>;\012    pos uni10CE3 uni10CF0.ltr <-20 0 -20 0>;\012    pos uni10CE4 uni10CC0 <-40 0 -40 0>;\012    pos uni10CE4 uni10CC1 <-30 0 -30 0>;\012    pos uni10CE4 uni10CC2 <20 0 20 0>;\012    pos uni10CE4 uni10CC4 <-30 0 -30 0>;\012    pos uni10CE4 uni10CC7 <-10 0 -10 0>;\012    pos uni10CE4 uni10CC9 <-20 0 -20 0>;\012    pos uni10CE4 uni10CCB <10 0 10 0>;\012    pos uni10CE4 uni10CCC <-10 0 -10 0>;\012    pos uni10CE4 uni10CCD <40 0 40 0>;\012    pos uni10CE4 uni10CCE <20 0 20 0>;\012    pos uni10CE4 uni10CD0 <-30 0 -30 0>;\012    pos uni10CE4 uni10CD1 <-50 0 -50 0>;\012    pos uni10CE4 uni10CD2 <-30 0 -30 0>;\012    pos uni10CE4 uni10CD4 <-40 0 -40 0>;\012    pos uni10CE4 uni10CD6 <40 0 40 0>;\012    pos uni10CE4 uni10CD7 <-10 0 -10 0>;\012    pos uni10CE4 uni10CD9 <20 0 20 0>;\012    pos uni10CE4 uni10CE3 <-30 0 -30 0>;\012    pos uni10CE4 uni10CE4 <40 0 40 0>;\012    pos uni10CE4 uni10CE6 <-60 0 -60 0>;\012    pos uni10CE4 uni10CE7 <-80 0 -80 0>;\012    pos uni10CE4 uni10CE8 <20 0 20 0>;\012    pos uni10CE4 uni10CE9 <20 0 20 0>;\012    pos uni10CE4 uni10CEC <10 0 10 0>;\012    pos uni10CE4 uni10CED <-40 0 -40 0>;\012    pos uni10CE4 uni10CF0 <-60 0 -60 0>;\012    pos uni10CE4 uni10CF2 <-10 0 -10 0>;\012    pos uni10CE4 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CE4 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CE4 uni10CCC.ltr <-10 0 -10 0>;\012    pos
+ uni10CE4 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CE4 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CE4 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CE4 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CE4 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CE4 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CE4 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CE4 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CE4 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CE5 uni10CC0 <-40 0 -40 0>;\012    pos uni10CE5 uni10CC1 <-30 0 -30 0>;\012    pos uni10CE5 uni10CC2 <20 0 20 0>;\012    pos uni10CE5 uni10CC4 <-30 0 -30 0>;\012    pos uni10CE5 uni10CC7 <-10 0 -10 0>;\012    pos uni10CE5 uni10CC9 <-20 0 -20 0>;\012    pos uni10CE5 uni10CCB <10 0 10 0>;\012    pos uni10CE5 uni10CCC <-10 0 -10 0>;\012    pos uni10CE5 uni10CCD <40 0 40 0>;\012    pos uni10CE5 uni10CCE <20 0 20 0>;\012    pos uni10CE5 uni10CD0 <-30 0 -30 0>;\012    pos uni10CE5 uni10CD1 <-50 0 -50 0>;\012    pos uni10CE5 uni10CD2 <-30 0 -30 0>;\012    pos uni10CE5 uni10CD4 <-40 0 -40 0>;\012    pos uni10CE5 uni10CD6 <40 0 40 0>;\012    pos uni10CE5 uni10CD7 <-10 0 -10 0>;\012    pos uni10CE5 uni10CD9 <20 0 20 0>;\012    pos uni10CE5 uni10CE3 <-30 0 -30 0>;\012    pos uni10CE5 uni10CE4 <40 0 40 0>;\012    pos uni10CE5 uni10CE6 <-60 0 -60 0>;\012    pos uni10CE5 uni10CE7 <-80 0 -80 0>;\012    pos uni10CE5 uni10CE8 <20 0 20 0>;\012    pos uni10CE5 uni10CE9 <20 0 20 0>;\012    pos uni10CE5 uni10CEC <10 0 10 0>;\012    pos uni10CE5 uni10CED <-40 0 -40 0>;\012    pos uni10CE5 uni10CF0 <-60 0 -60 0>;\012    pos uni10CE5 uni10CF2 <-10 0 -10 0>;\012    pos uni10CE5 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CE5 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CE5 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CE5 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CE5 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CE5 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CE5 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CE5 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CE5 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CE5 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CE5 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CE5 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CE6 uni10CC0 <-40 0 -40 0>;\012    pos uni10CE6 uni10CC1 <-30 0 -30 0>;\012    pos uni10CE6 uni10CC2 <20 0 20 0>;\012    pos uni10CE6 uni10CC4 <-30 0 -30 0>;\012    pos uni10CE6 uni10CC7 <-10 0 -10 0>;\012    pos uni10CE6 uni10CC9 <-20 0 -20 0>;\012    pos uni10CE6 uni10CCB <10 0 10 0>;\012    pos uni10CE6 uni10CCC <-10 0 -10 0>;\012    pos uni10CE6 uni10CCD <40 0 40 0>;\012    pos uni10CE6 uni10CCE <20 0 20 0>;\012    pos uni10CE6 uni10CD0 <-30 0 -30 0>;\012    pos uni10CE6 uni10CD1 <-50 0 -50 0>;\012    pos uni10CE6 uni10CD2 <-30 0 -30 0>;\012    pos uni10CE6 uni10CD4 <-40 0 -40 0>;\012    pos uni10CE6 uni10CD6 <40 0 40 0>;\012    pos uni10CE6 uni10CD7 <-10 0 -10 0>;\012    pos uni10CE6 uni10CD9 <20 0 20 0>;\012    pos uni10CE6 uni10CE3 <-30 0 -30 0>;\012    pos uni10CE6 uni10CE4 <40 0 40 0>;\012    pos uni10CE6 uni10CE6 <-60 0 -60 0>;\012    pos uni10CE6 uni10CE7 <-80 0 -80 0>;\012    pos uni10CE6 uni10CE8 <20 0 20 0>;\012    pos uni10CE6 uni10CE9 <20 0 20 0>;\012    pos uni10CE6 uni10CEC <10 0 10 0>;\012    pos uni10CE6 uni10CED <-40 0 -40 0>;\012    pos uni10CE6 uni10CF0 <-60 0 -60 0>;\012    pos uni10CE6 uni10CF2 <-10 0 -10 0>;\012    pos uni10CE6 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CE6 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CE6 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CE6 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CE6 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CE6 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CE6 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CE6 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CE6 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CE6 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CE6 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CE6 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CE7 uni10CC0 <-20 0 -20 0>;\012    pos uni10CE7 uni10CCC <-30 0 -30 0>;\012    pos uni10CE7 uni10CCD <-70 0 -70 0>;\012    pos uni10CE7 uni10CD6 <-70 0 -70 0>;\012    pos uni10CE7 uni10CD7 <-30 0 -30 0>;\012    pos uni10CE7 uni10CE4 <-70 0 -70 0>;\012    pos uni10CE7 uni10CF2 <-30 0 -30 0>;\012    pos uni10CE7 uni10CC0.ltr <-20 0 -20 0>;\012    pos uni10CE7 uni10CCC.ltr <-30 0 -30 0>;\012    pos uni10CE7 uni10CCD.ltr <-70 0 -70 0>;\012    pos uni10CE7 uni10CD6.ltr <-70 0 -70 0>;\012    pos uni10CE7 uni10CD7.ltr <-30 0 -30 0>;\012    pos uni10CE7 uni10CE4.ltr <-70 0 -70 0>;\012    pos uni10CE7 uni10CF2.ltr <-30 0 -30 0>;\012    pos uni10CE8 uni10CC0 <-10 0 -10 0>;\012    pos uni10CE8 uni10CC1 <-30 0 -30 0>;\012    pos uni10CE8 uni10CC2 <20 0 20 0>;\012    pos uni10CE8 uni10CC3 <10 0 10 0>;\012    pos uni10CE8 uni10CCC <-20 0 -20 0>;\012    pos uni10CE8 uni10CD2 <-10 0 -10 0>;\012    pos uni10CE8 uni10CD7 <-20 0 -20 0>;\012    pos uni10CE8 uni10CD9 <20 0 20 0>;\012    pos uni10CE8 uni10CE3 <-40 0 -40 0>;\012    pos uni10CE8 uni10CE8 <20 0 20 0>;\012    pos uni10CE8 uni10CE9 <20 0 20 0>;\012    pos uni10CE8 uni10CEC <20 0 20 0>;\012    pos uni10CE8 uni10CF2 <-20 0 -20 0>;\012    pos uni10CE8 uni10CC0.ltr <-10 0 -10 0>;\012    pos uni10CE8 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CE8 uni10CCC.ltr <-20 0 -20 0>;\012    pos uni10CE8 uni10CD7.ltr <-20 0 -20 0>;\012    pos uni10CE8 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CE8 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CE8 uni10CF2.ltr <-20 0 -20 0>;\012    pos uni10CE9 uni10CC0 <-10 0 -10 0>;\012    pos uni10CE9 uni10CC1 <-30 0 -30 0>;\012    pos uni10CE9 uni10CC2 <20 0 20 0>;\012    pos uni10CE9 uni10CC3 <10 0 10 0>;\012    pos uni10CE9 uni10CCC <-20 0 -20 0>;\012    pos uni10CE9 uni10CD2 <-10 0 -10 0>;\012    pos uni10CE9 uni10CD7 <-20 0 -20 0>;\012    pos uni10CE9 uni10CD9 <20 0 20 0>;\012    pos uni10CE9 uni10CE3 <-40 0 -40 0>;\012    pos uni10CE9 uni10CE8 <20 0 20 0>;\012    pos uni10CE9 uni10CE9 <20 0 20 0>;\012    pos uni10CE9 uni10CEC <20 0 20 0>;\012    pos uni10CE9 uni10CF2 <-20 0 -20 0>;\012    pos uni10CE9 uni10CC0.ltr <-10 0 -10 0>;\012    pos uni10CE9 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CE9 uni10CCC.ltr <-20 0 -20 0>;\012    pos uni10CE9 uni10CD7.ltr <-20 0 -20 0>;\012    pos uni10CE9 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CE9 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CE9 uni10CF2.ltr <-20 0 -20 0>;\012    pos uni10CEA uni10CC0 <-40 0 -40 0>;\012    pos uni10CEA uni10CC1 <-30 0 -30 0>;\012    pos uni10CEA uni10CC2 <20 0 20 0>;\012    pos uni10CEA uni10CC4 <-30 0 -30 0>;\012    pos uni10CEA uni10CC7 <-10 0 -10 0>;\012    pos uni10CEA uni10CC9 <-20 0 -20 0>;\012    pos uni10CEA uni10CCB <10 0 10 0>;\012    pos uni10CEA uni10CCC <-10 0 -10 0>;\012    pos uni10CEA uni10CCD <40 0 40 0>;\012    pos uni10CEA uni10CCE <20 0 20 0>;\012    pos uni10CEA uni10CD0 <-30 0 -30 0>;\012    pos uni10CEA uni10CD1 <-50 0 -50 0>;\012    pos uni10CEA uni10CD2 <-30 0 -30 0>;\012    pos uni10CEA uni10CD4 <-40 0 -40 0>;\012    pos uni10CEA uni10CD6 <40 0 40 0>;\012    pos uni10CEA uni10CD7 <-10 0 -10 0>;\012    pos uni10CEA uni10CD9 <20 0 20 0>;\012    pos uni10CEA uni10CE3 <-30 0 -30 0>;\012    pos uni10CEA uni10CE4 <40 0 40 0>;\012    pos uni10CEA uni10CE6 <-60 0 -60 0>;\012    pos uni10CEA uni10CE7 <-80 0 -80 0>;\012    pos uni10CEA uni10CE8 <20 0 20 0>;\012    pos uni10CEA uni10CE9 <20 0 20 0>;\012    pos uni10CEA uni10CEC <10 0 10 0>;\012    pos uni10CEA uni10CED <-40 0 -40 0>;\012    pos uni10CEA uni10CF0 <-60 0 -60 0>;\012    pos uni10CEA uni10CF2 <-10 0 -10 0>;\012    pos uni10CEA uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CEA uni10CC2.ltr <20 0 20 0>;\012    pos uni10CEA uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CEA uni10CCD.ltr <40 0 40 0>;\012    pos uni10CEA uni10CD6.ltr <40 0 40 0>;\012    pos uni10CEA uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CEA uni10CE4.ltr <40 0 40 0>;\012    pos uni10CEA uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CEA uni10CE8.ltr <20 0 20 0>;\012    pos uni10CEA uni10CE9.ltr <20 0 20 0>;\012    pos uni10CEA uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CEA uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CEB uni10CC0 <-40 0 -40 0>;\012    pos uni10CEB uni10CC1 <-30 0 -30 0>;\012    pos uni10CEB uni10CC2 <20 0 20 0>;\012    pos uni10CEB uni10CC4 <-30 0 -30 0>;\012    pos uni10CEB uni10CC7 <-10 0 -10 0>;\012    pos uni10CEB uni10CC9 <-20 0 -20 0>;\012    pos uni10CEB uni10CCB <10 0 10 0>;\012    pos uni10CEB uni10CCC <-10 0 -10 0>;\012    pos uni10CEB uni10CCD <40 0 40 0>;\012    pos uni10CEB uni10CCE <20 0 20 0>;\012    pos uni10CEB uni10CD0 <-30 0 -30 0>;\012    pos uni10CEB uni10CD1 <-50 0 -50 0>;\012    pos uni10CEB uni10CD2 <-30 0 -30 0>;\012    pos uni10CEB uni10CD4 <-40 0 -40 0>;\012    pos uni10CEB uni10CD6 <40 0 40 0>;\012    pos uni10CEB uni10CD7 <-10 0 -10 0>;\012    pos uni10CEB uni10CD9 <20 0 20 0>;\012    pos uni10CEB uni10CE3 <-30 0 -30 0>;\012    pos uni10CEB uni10CE4 <40 0 40 0>;\012    pos uni10CEB uni10CE6 <-60 0 -60 0>;\012    pos uni10CEB uni10CE7 <-80 0 -80 0>;\012    pos uni10CEB uni10CE8 <20 0 20 0>;\012    pos uni10CEB uni10CE9 <20 0 20 0>;\012    pos uni10CEB uni10CEC <10 0 10 0>;\012    pos uni10CEB uni10CED <-40 0 -40 0>;\012    pos uni10CEB uni10CF0 <-60 0 -60 0>;\012    pos uni10CEB uni10CF2 <-10 0 -10 0>;\012    pos uni10CEB uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CEB uni10CC2.ltr <20 0 20 0>;\012    pos uni10CEB uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CEB uni10CCD.ltr <40 0 40 0>;\012    pos uni10CEB uni10CD6.ltr <40 0 40 0>;\012    pos uni10CEB uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CEB uni10CE4.ltr <40 0 40 0>;\012    pos uni10CEB uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CEB uni10CE8.ltr <20 0 20 0>;\012    pos uni10CEB uni10CE9.ltr <20 0 20 0>;\012    pos uni10CEB uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CEB uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CEC uni10CC2 <20 0 20 0>;\012    pos uni10CEC uni10CCD <10 0 10 0>;\012    pos uni10CEC uni10CD6 <10 0 10 0>;\012    pos
+ uni10CEC uni10CE4 <10 0 10 0>;\012    pos uni10CEC uni10CE8 <20 0 20 0>;\012    pos uni10CEC uni10CE9 <20 0 20 0>;\012    pos uni10CEC uni10CC2.ltr <20 0 20 0>;\012    pos uni10CEC uni10CCD.ltr <10 0 10 0>;\012    pos uni10CEC uni10CD6.ltr <10 0 10 0>;\012    pos uni10CEC uni10CE4.ltr <10 0 10 0>;\012    pos uni10CEC uni10CE8.ltr <20 0 20 0>;\012    pos uni10CEC uni10CE9.ltr <20 0 20 0>;\012    pos uni10CED uni10CC2 <-20 0 -20 0>;\012    pos uni10CED uni10CE6 <-50 0 -50 0>;\012    pos uni10CED uni10CE8 <-20 0 -20 0>;\012    pos uni10CED uni10CE9 <-20 0 -20 0>;\012    pos uni10CED uni10CF0 <-50 0 -50 0>;\012    pos uni10CED uni10CC2.ltr <-20 0 -20 0>;\012    pos uni10CED uni10CE6.ltr <-50 0 -50 0>;\012    pos uni10CED uni10CE8.ltr <-20 0 -20 0>;\012    pos uni10CED uni10CE9.ltr <-20 0 -20 0>;\012    pos uni10CED uni10CF0.ltr <-50 0 -50 0>;\012    pos uni10CEE uni10CC0 <-40 0 -40 0>;\012    pos uni10CEE uni10CC1 <-30 0 -30 0>;\012    pos uni10CEE uni10CC2 <20 0 20 0>;\012    pos uni10CEE uni10CC4 <-30 0 -30 0>;\012    pos uni10CEE uni10CC7 <-10 0 -10 0>;\012    pos uni10CEE uni10CC9 <-20 0 -20 0>;\012    pos uni10CEE uni10CCB <10 0 10 0>;\012    pos uni10CEE uni10CCC <-10 0 -10 0>;\012    pos uni10CEE uni10CCD <40 0 40 0>;\012    pos uni10CEE uni10CCE <20 0 20 0>;\012    pos uni10CEE uni10CD0 <-30 0 -30 0>;\012    pos uni10CEE uni10CD1 <-50 0 -50 0>;\012    pos uni10CEE uni10CD2 <-30 0 -30 0>;\012    pos uni10CEE uni10CD4 <-40 0 -40 0>;\012    pos uni10CEE uni10CD6 <40 0 40 0>;\012    pos uni10CEE uni10CD7 <-10 0 -10 0>;\012    pos uni10CEE uni10CD9 <20 0 20 0>;\012    pos uni10CEE uni10CE3 <-30 0 -30 0>;\012    pos uni10CEE uni10CE4 <40 0 40 0>;\012    pos uni10CEE uni10CE6 <-60 0 -60 0>;\012    pos uni10CEE uni10CE7 <-80 0 -80 0>;\012    pos uni10CEE uni10CE8 <20 0 20 0>;\012    pos uni10CEE uni10CE9 <20 0 20 0>;\012    pos uni10CEE uni10CEC <10 0 10 0>;\012    pos uni10CEE uni10CED <-40 0 -40 0>;\012    pos uni10CEE uni10CF0 <-60 0 -60 0>;\012    pos uni10CEE uni10CF2 <-10 0 -10 0>;\012    pos uni10CEE uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CEE uni10CC2.ltr <20 0 20 0>;\012    pos uni10CEE uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CEE uni10CCD.ltr <40 0 40 0>;\012    pos uni10CEE uni10CD6.ltr <40 0 40 0>;\012    pos uni10CEE uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CEE uni10CE4.ltr <40 0 40 0>;\012    pos uni10CEE uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CEE uni10CE8.ltr <20 0 20 0>;\012    pos uni10CEE uni10CE9.ltr <20 0 20 0>;\012    pos uni10CEE uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CEE uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CEF uni10CC0 <-40 0 -40 0>;\012    pos uni10CEF uni10CC1 <-30 0 -30 0>;\012    pos uni10CEF uni10CC2 <20 0 20 0>;\012    pos uni10CEF uni10CC4 <-30 0 -30 0>;\012    pos uni10CEF uni10CC7 <-10 0 -10 0>;\012    pos uni10CEF uni10CC9 <-20 0 -20 0>;\012    pos uni10CEF uni10CCB <10 0 10 0>;\012    pos uni10CEF uni10CCC <-10 0 -10 0>;\012    pos uni10CEF uni10CCD <40 0 40 0>;\012    pos uni10CEF uni10CCE <20 0 20 0>;\012    pos uni10CEF uni10CD0 <-30 0 -30 0>;\012    pos uni10CEF uni10CD1 <-50 0 -50 0>;\012    pos uni10CEF uni10CD2 <-30 0 -30 0>;\012    pos uni10CEF uni10CD4 <-40 0 -40 0>;\012    pos uni10CEF uni10CD6 <40 0 40 0>;\012    pos uni10CEF uni10CD7 <-10 0 -10 0>;\012    pos uni10CEF uni10CD9 <20 0 20 0>;\012    pos uni10CEF uni10CE3 <-30 0 -30 0>;\012    pos uni10CEF uni10CE4 <40 0 40 0>;\012    pos uni10CEF uni10CE6 <-60 0 -60 0>;\012    pos uni10CEF uni10CE7 <-80 0 -80 0>;\012    pos uni10CEF uni10CE8 <20 0 20 0>;\012    pos uni10CEF uni10CE9 <20 0 20 0>;\012    pos uni10CEF uni10CEC <10 0 10 0>;\012    pos uni10CEF uni10CED <-40 0 -40 0>;\012    pos uni10CEF uni10CF0 <-60 0 -60 0>;\012    pos uni10CEF uni10CF2 <-10 0 -10 0>;\012    pos uni10CEF uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CEF uni10CC2.ltr <20 0 20 0>;\012    pos uni10CEF uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CEF uni10CCD.ltr <40 0 40 0>;\012    pos uni10CEF uni10CD6.ltr <40 0 40 0>;\012    pos uni10CEF uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CEF uni10CE4.ltr <40 0 40 0>;\012    pos uni10CEF uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CEF uni10CE8.ltr <20 0 20 0>;\012    pos uni10CEF uni10CE9.ltr <20 0 20 0>;\012    pos uni10CEF uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CEF uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CF0 uni10CC2 <20 0 20 0>;\012    pos uni10CF0 uni10CCC <-30 0 -30 0>;\012    pos uni10CF0 uni10CCD <-80 0 -80 0>;\012    pos uni10CF0 uni10CD6 <-80 0 -80 0>;\012    pos uni10CF0 uni10CD7 <-30 0 -30 0>;\012    pos uni10CF0 uni10CE4 <-80 0 -80 0>;\012    pos uni10CF0 uni10CE6 <20 0 20 0>;\012    pos uni10CF0 uni10CE8 <20 0 20 0>;\012    pos uni10CF0 uni10CE9 <20 0 20 0>;\012    pos uni10CF0 uni10CF0 <20 0 20 0>;\012    pos uni10CF0 uni10CF2 <-30 0 -30 0>;\012    pos uni10CF0 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CF0 uni10CCC.ltr <-30 0 -30 0>;\012    pos uni10CF0 uni10CCD.ltr <-80 0 -80 0>;\012    pos uni10CF0 uni10CD6.ltr <-80 0 -80 0>;\012    pos uni10CF0 uni10CD7.ltr <-30 0 -30 0>;\012    pos uni10CF0 uni10CE4.ltr <-80 0 -80 0>;\012    pos uni10CF0 uni10CE6.ltr <20 0 20 0>;\012    pos uni10CF0 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CF0 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CF0 uni10CF0.ltr <20 0 20 0>;\012    pos uni10CF0 uni10CF2.ltr <-30 0 -30 0>;\012    pos uni10CF1 uni10CC0 <-40 0 -40 0>;\012    pos uni10CF1 uni10CC1 <-30 0 -30 0>;\012    pos uni10CF1 uni10CC2 <20 0 20 0>;\012    pos uni10CF1 uni10CC4 <-30 0 -30 0>;\012    pos uni10CF1 uni10CC7 <-10 0 -10 0>;\012    pos uni10CF1 uni10CC9 <-20 0 -20 0>;\012    pos uni10CF1 uni10CCB <10 0 10 0>;\012    pos uni10CF1 uni10CCC <-10 0 -10 0>;\012    pos uni10CF1 uni10CCD <40 0 40 0>;\012    pos uni10CF1 uni10CCE <20 0 20 0>;\012    pos uni10CF1 uni10CD0 <-30 0 -30 0>;\012    pos uni10CF1 uni10CD1 <-50 0 -50 0>;\012    pos uni10CF1 uni10CD2 <-30 0 -30 0>;\012    pos uni10CF1 uni10CD4 <-40 0 -40 0>;\012    pos uni10CF1 uni10CD6 <40 0 40 0>;\012    pos uni10CF1 uni10CD7 <-10 0 -10 0>;\012    pos uni10CF1 uni10CD9 <20 0 20 0>;\012    pos uni10CF1 uni10CE3 <-30 0 -30 0>;\012    pos uni10CF1 uni10CE4 <40 0 40 0>;\012    pos uni10CF1 uni10CE6 <-60 0 -60 0>;\012    pos uni10CF1 uni10CE7 <-80 0 -80 0>;\012    pos uni10CF1 uni10CE8 <20 0 20 0>;\012    pos uni10CF1 uni10CE9 <20 0 20 0>;\012    pos uni10CF1 uni10CEC <10 0 10 0>;\012    pos uni10CF1 uni10CED <-40 0 -40 0>;\012    pos uni10CF1 uni10CF0 <-60 0 -60 0>;\012    pos uni10CF1 uni10CF2 <-10 0 -10 0>;\012    pos uni10CF1 uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CF1 uni10CC2.ltr <20 0 20 0>;\012    pos uni10CF1 uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CF1 uni10CCD.ltr <40 0 40 0>;\012    pos uni10CF1 uni10CD6.ltr <40 0 40 0>;\012    pos uni10CF1 uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CF1 uni10CE4.ltr <40 0 40 0>;\012    pos uni10CF1 uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CF1 uni10CE8.ltr <20 0 20 0>;\012    pos uni10CF1 uni10CE9.ltr <20 0 20 0>;\012    pos uni10CF1 uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CF1 uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CF2 uni10CC2 <-30 0 -30 0>;\012    pos uni10CF2 uni10CC4 <-10 0 -10 0>;\012    pos uni10CF2 uni10CC9 <-30 0 -30 0>;\012    pos uni10CF2 uni10CCD <-20 0 -20 0>;\012    pos uni10CF2 uni10CCF <-20 0 -20 0>;\012    pos uni10CF2 uni10CD0 <-30 0 -30 0>;\012    pos uni10CF2 uni10CD1 <-20 0 -20 0>;\012    pos uni10CF2 uni10CD5 <-30 0 -30 0>;\012    pos uni10CF2 uni10CD6 <-20 0 -20 0>;\012    pos uni10CF2 uni10CD9 <-30 0 -30 0>;\012    pos uni10CF2 uni10CE4 <-20 0 -20 0>;\012    pos uni10CF2 uni10CE6 <-40 0 -40 0>;\012    pos uni10CF2 uni10CE7 <-30 0 -30 0>;\012    pos uni10CF2 uni10CE8 <-30 0 -30 0>;\012    pos uni10CF2 uni10CE9 <-30 0 -30 0>;\012    pos uni10CF2 uni10CF0 <-40 0 -40 0>;\012    pos uni10CF2 uni10CC2.ltr <-30 0 -30 0>;\012    pos uni10CF2 uni10CCD.ltr <-20 0 -20 0>;\012    pos uni10CF2 uni10CD6.ltr <-20 0 -20 0>;\012    pos uni10CF2 uni10CE4.ltr <-20 0 -20 0>;\012    pos uni10CF2 uni10CE6.ltr <-40 0 -40 0>;\012    pos uni10CF2 uni10CE8.ltr <-30 0 -30 0>;\012    pos uni10CF2 uni10CE9.ltr <-30 0 -30 0>;\012    pos uni10CF2 uni10CF0.ltr <-40 0 -40 0>;\012    pos uni10CFA uni10CC0 <-40 0 -40 0>;\012    pos uni10CFA uni10CC1 <-30 0 -30 0>;\012    pos uni10CFA uni10CC2 <20 0 20 0>;\012    pos uni10CFA uni10CC4 <-30 0 -30 0>;\012    pos uni10CFA uni10CC7 <-10 0 -10 0>;\012    pos uni10CFA uni10CC9 <-20 0 -20 0>;\012    pos uni10CFA uni10CCB <10 0 10 0>;\012    pos uni10CFA uni10CCC <-10 0 -10 0>;\012    pos uni10CFA uni10CCD <40 0 40 0>;\012    pos uni10CFA uni10CCE <20 0 20 0>;\012    pos uni10CFA uni10CD0 <-30 0 -30 0>;\012    pos uni10CFA uni10CD1 <-50 0 -50 0>;\012    pos uni10CFA uni10CD2 <-30 0 -30 0>;\012    pos uni10CFA uni10CD4 <-40 0 -40 0>;\012    pos uni10CFA uni10CD6 <40 0 40 0>;\012    pos uni10CFA uni10CD7 <-10 0 -10 0>;\012    pos uni10CFA uni10CD9 <20 0 20 0>;\012    pos uni10CFA uni10CE3 <-30 0 -30 0>;\012    pos uni10CFA uni10CE4 <40 0 40 0>;\012    pos uni10CFA uni10CE6 <-60 0 -60 0>;\012    pos uni10CFA uni10CE7 <-80 0 -80 0>;\012    pos uni10CFA uni10CE8 <20 0 20 0>;\012    pos uni10CFA uni10CE9 <20 0 20 0>;\012    pos uni10CFA uni10CEC <10 0 10 0>;\012    pos uni10CFA uni10CED <-40 0 -40 0>;\012    pos uni10CFA uni10CF0 <-60 0 -60 0>;\012    pos uni10CFA uni10CF2 <-10 0 -10 0>;\012    pos uni10CFA uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CFA uni10CC2.ltr <20 0 20 0>;\012    pos uni10CFA uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CFA uni10CCD.ltr <40 0 40 0>;\012    pos uni10CFA uni10CD6.ltr <40 0 40 0>;\012    pos uni10CFA uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CFA uni10CE4.ltr <40 0 40 0>;\012    pos uni10CFA uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CFA uni10CE8.ltr <20 0 20 0>;\012    pos uni10CFA uni10CE9.ltr <20 0 20 0>;\012    pos uni10CFA uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CFA uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CFB uni10CC0 <-40 0 -40 0>;\012
+    pos uni10CFB uni10CC1 <-30 0 -30 0>;\012    pos uni10CFB uni10CC2 <20 0 20 0>;\012    pos uni10CFB uni10CC4 <-30 0 -30 0>;\012    pos uni10CFB uni10CC7 <-10 0 -10 0>;\012    pos uni10CFB uni10CC9 <-20 0 -20 0>;\012    pos uni10CFB uni10CCB <10 0 10 0>;\012    pos uni10CFB uni10CCC <-10 0 -10 0>;\012    pos uni10CFB uni10CCD <40 0 40 0>;\012    pos uni10CFB uni10CCE <20 0 20 0>;\012    pos uni10CFB uni10CD0 <-30 0 -30 0>;\012    pos uni10CFB uni10CD1 <-50 0 -50 0>;\012    pos uni10CFB uni10CD2 <-30 0 -30 0>;\012    pos uni10CFB uni10CD4 <-40 0 -40 0>;\012    pos uni10CFB uni10CD6 <40 0 40 0>;\012    pos uni10CFB uni10CD7 <-10 0 -10 0>;\012    pos uni10CFB uni10CD9 <20 0 20 0>;\012    pos uni10CFB uni10CE3 <-30 0 -30 0>;\012    pos uni10CFB uni10CE4 <40 0 40 0>;\012    pos uni10CFB uni10CE6 <-60 0 -60 0>;\012    pos uni10CFB uni10CE7 <-80 0 -80 0>;\012    pos uni10CFB uni10CE8 <20 0 20 0>;\012    pos uni10CFB uni10CE9 <20 0 20 0>;\012    pos uni10CFB uni10CEC <10 0 10 0>;\012    pos uni10CFB uni10CED <-40 0 -40 0>;\012    pos uni10CFB uni10CF0 <-60 0 -60 0>;\012    pos uni10CFB uni10CF2 <-10 0 -10 0>;\012    pos uni10CFB uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CFB uni10CC2.ltr <20 0 20 0>;\012    pos uni10CFB uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CFB uni10CCD.ltr <40 0 40 0>;\012    pos uni10CFB uni10CD6.ltr <40 0 40 0>;\012    pos uni10CFB uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CFB uni10CE4.ltr <40 0 40 0>;\012    pos uni10CFB uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CFB uni10CE8.ltr <20 0 20 0>;\012    pos uni10CFB uni10CE9.ltr <20 0 20 0>;\012    pos uni10CFB uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CFB uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CFC uni10CC0 <-40 0 -40 0>;\012    pos uni10CFC uni10CC1 <-30 0 -30 0>;\012    pos uni10CFC uni10CC2 <20 0 20 0>;\012    pos uni10CFC uni10CC4 <-30 0 -30 0>;\012    pos uni10CFC uni10CC7 <-10 0 -10 0>;\012    pos uni10CFC uni10CC9 <-20 0 -20 0>;\012    pos uni10CFC uni10CCB <10 0 10 0>;\012    pos uni10CFC uni10CCC <-10 0 -10 0>;\012    pos uni10CFC uni10CCD <40 0 40 0>;\012    pos uni10CFC uni10CCE <20 0 20 0>;\012    pos uni10CFC uni10CD0 <-30 0 -30 0>;\012    pos uni10CFC uni10CD1 <-50 0 -50 0>;\012    pos uni10CFC uni10CD2 <-30 0 -30 0>;\012    pos uni10CFC uni10CD4 <-40 0 -40 0>;\012    pos uni10CFC uni10CD6 <40 0 40 0>;\012    pos uni10CFC uni10CD7 <-10 0 -10 0>;\012    pos uni10CFC uni10CD9 <20 0 20 0>;\012    pos uni10CFC uni10CE3 <-30 0 -30 0>;\012    pos uni10CFC uni10CE4 <40 0 40 0>;\012    pos uni10CFC uni10CE6 <-60 0 -60 0>;\012    pos uni10CFC uni10CE7 <-80 0 -80 0>;\012    pos uni10CFC uni10CE8 <20 0 20 0>;\012    pos uni10CFC uni10CE9 <20 0 20 0>;\012    pos uni10CFC uni10CEC <10 0 10 0>;\012    pos uni10CFC uni10CED <-40 0 -40 0>;\012    pos uni10CFC uni10CF0 <-60 0 -60 0>;\012    pos uni10CFC uni10CF2 <-10 0 -10 0>;\012    pos uni10CFC uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CFC uni10CC2.ltr <20 0 20 0>;\012    pos uni10CFC uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CFC uni10CCD.ltr <40 0 40 0>;\012    pos uni10CFC uni10CD6.ltr <40 0 40 0>;\012    pos uni10CFC uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CFC uni10CE4.ltr <40 0 40 0>;\012    pos uni10CFC uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CFC uni10CE8.ltr <20 0 20 0>;\012    pos uni10CFC uni10CE9.ltr <20 0 20 0>;\012    pos uni10CFC uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CFC uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CFD uni10CC0 <-40 0 -40 0>;\012    pos uni10CFD uni10CC1 <-30 0 -30 0>;\012    pos uni10CFD uni10CC2 <20 0 20 0>;\012    pos uni10CFD uni10CC4 <-30 0 -30 0>;\012    pos uni10CFD uni10CC7 <-10 0 -10 0>;\012    pos uni10CFD uni10CC9 <-20 0 -20 0>;\012    pos uni10CFD uni10CCB <10 0 10 0>;\012    pos uni10CFD uni10CCC <-10 0 -10 0>;\012    pos uni10CFD uni10CCD <40 0 40 0>;\012    pos uni10CFD uni10CCE <20 0 20 0>;\012    pos uni10CFD uni10CD0 <-30 0 -30 0>;\012    pos uni10CFD uni10CD1 <-50 0 -50 0>;\012    pos uni10CFD uni10CD2 <-30 0 -30 0>;\012    pos uni10CFD uni10CD4 <-40 0 -40 0>;\012    pos uni10CFD uni10CD6 <40 0 40 0>;\012    pos uni10CFD uni10CD7 <-10 0 -10 0>;\012    pos uni10CFD uni10CD9 <20 0 20 0>;\012    pos uni10CFD uni10CE3 <-30 0 -30 0>;\012    pos uni10CFD uni10CE4 <40 0 40 0>;\012    pos uni10CFD uni10CE6 <-60 0 -60 0>;\012    pos uni10CFD uni10CE7 <-80 0 -80 0>;\012    pos uni10CFD uni10CE8 <20 0 20 0>;\012    pos uni10CFD uni10CE9 <20 0 20 0>;\012    pos uni10CFD uni10CEC <10 0 10 0>;\012    pos uni10CFD uni10CED <-40 0 -40 0>;\012    pos uni10CFD uni10CF0 <-60 0 -60 0>;\012    pos uni10CFD uni10CF2 <-10 0 -10 0>;\012    pos uni10CFD uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CFD uni10CC2.ltr <20 0 20 0>;\012    pos uni10CFD uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CFD uni10CCD.ltr <40 0 40 0>;\012    pos uni10CFD uni10CD6.ltr <40 0 40 0>;\012    pos uni10CFD uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CFD uni10CE4.ltr <40 0 40 0>;\012    pos uni10CFD uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CFD uni10CE8.ltr <20 0 20 0>;\012    pos uni10CFD uni10CE9.ltr <20 0 20 0>;\012    pos uni10CFD uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CFD uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CFE uni10CC0 <-40 0 -40 0>;\012    pos uni10CFE uni10CC1 <-30 0 -30 0>;\012    pos uni10CFE uni10CC2 <20 0 20 0>;\012    pos uni10CFE uni10CC4 <-30 0 -30 0>;\012    pos uni10CFE uni10CC7 <-10 0 -10 0>;\012    pos uni10CFE uni10CC9 <-20 0 -20 0>;\012    pos uni10CFE uni10CCB <10 0 10 0>;\012    pos uni10CFE uni10CCC <-10 0 -10 0>;\012    pos uni10CFE uni10CCD <40 0 40 0>;\012    pos uni10CFE uni10CCE <20 0 20 0>;\012    pos uni10CFE uni10CD0 <-30 0 -30 0>;\012    pos uni10CFE uni10CD1 <-50 0 -50 0>;\012    pos uni10CFE uni10CD2 <-30 0 -30 0>;\012    pos uni10CFE uni10CD4 <-40 0 -40 0>;\012    pos uni10CFE uni10CD6 <40 0 40 0>;\012    pos uni10CFE uni10CD7 <-10 0 -10 0>;\012    pos uni10CFE uni10CD9 <20 0 20 0>;\012    pos uni10CFE uni10CE3 <-30 0 -30 0>;\012    pos uni10CFE uni10CE4 <40 0 40 0>;\012    pos uni10CFE uni10CE6 <-60 0 -60 0>;\012    pos uni10CFE uni10CE7 <-80 0 -80 0>;\012    pos uni10CFE uni10CE8 <20 0 20 0>;\012    pos uni10CFE uni10CE9 <20 0 20 0>;\012    pos uni10CFE uni10CEC <10 0 10 0>;\012    pos uni10CFE uni10CED <-40 0 -40 0>;\012    pos uni10CFE uni10CF0 <-60 0 -60 0>;\012    pos uni10CFE uni10CF2 <-10 0 -10 0>;\012    pos uni10CFE uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CFE uni10CC2.ltr <20 0 20 0>;\012    pos uni10CFE uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CFE uni10CCD.ltr <40 0 40 0>;\012    pos uni10CFE uni10CD6.ltr <40 0 40 0>;\012    pos uni10CFE uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CFE uni10CE4.ltr <40 0 40 0>;\012    pos uni10CFE uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CFE uni10CE8.ltr <20 0 20 0>;\012    pos uni10CFE uni10CE9.ltr <20 0 20 0>;\012    pos uni10CFE uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CFE uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CFF uni10CC0 <-40 0 -40 0>;\012    pos uni10CFF uni10CC1 <-30 0 -30 0>;\012    pos uni10CFF uni10CC2 <20 0 20 0>;\012    pos uni10CFF uni10CC4 <-30 0 -30 0>;\012    pos uni10CFF uni10CC7 <-10 0 -10 0>;\012    pos uni10CFF uni10CC9 <-20 0 -20 0>;\012    pos uni10CFF uni10CCB <10 0 10 0>;\012    pos uni10CFF uni10CCC <-10 0 -10 0>;\012    pos uni10CFF uni10CCD <40 0 40 0>;\012    pos uni10CFF uni10CCE <20 0 20 0>;\012    pos uni10CFF uni10CD0 <-30 0 -30 0>;\012    pos uni10CFF uni10CD1 <-50 0 -50 0>;\012    pos uni10CFF uni10CD2 <-30 0 -30 0>;\012    pos uni10CFF uni10CD4 <-40 0 -40 0>;\012    pos uni10CFF uni10CD6 <40 0 40 0>;\012    pos uni10CFF uni10CD7 <-10 0 -10 0>;\012    pos uni10CFF uni10CD9 <20 0 20 0>;\012    pos uni10CFF uni10CE3 <-30 0 -30 0>;\012    pos uni10CFF uni10CE4 <40 0 40 0>;\012    pos uni10CFF uni10CE6 <-60 0 -60 0>;\012    pos uni10CFF uni10CE7 <-80 0 -80 0>;\012    pos uni10CFF uni10CE8 <20 0 20 0>;\012    pos uni10CFF uni10CE9 <20 0 20 0>;\012    pos uni10CFF uni10CEC <10 0 10 0>;\012    pos uni10CFF uni10CED <-40 0 -40 0>;\012    pos uni10CFF uni10CF0 <-60 0 -60 0>;\012    pos uni10CFF uni10CF2 <-10 0 -10 0>;\012    pos uni10CFF uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CFF uni10CC2.ltr <20 0 20 0>;\012    pos uni10CFF uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CFF uni10CCD.ltr <40 0 40 0>;\012    pos uni10CFF uni10CD6.ltr <40 0 40 0>;\012    pos uni10CFF uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CFF uni10CE4.ltr <40 0 40 0>;\012    pos uni10CFF uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CFF uni10CE8.ltr <20 0 20 0>;\012    pos uni10CFF uni10CE9.ltr <20 0 20 0>;\012    pos uni10CFF uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CFF uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C80.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C80.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C80.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C80.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C80.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C80.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C80.ltr uni10CCB <10 0 10 0>;\012    pos uni10C80.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C80.ltr uni10CCD <40 0 40 0>;\012    pos uni10C80.ltr uni10CCE <20 0 20 0>;\012    pos uni10C80.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C80.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C80.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C80.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C80.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C80.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C80.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C80.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C80.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C80.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C80.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C80.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C80.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C80.ltr uni10CEC <10 0 10 0>;\012    pos uni10C80.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C80.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C80.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C80.ltr
+ uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C80.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C80.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C80.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C80.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C80.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C80.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C80.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C80.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C80.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C80.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C80.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C81.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C81.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C81.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C81.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C81.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C81.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C81.ltr uni10CCB <10 0 10 0>;\012    pos uni10C81.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C81.ltr uni10CCD <40 0 40 0>;\012    pos uni10C81.ltr uni10CCE <20 0 20 0>;\012    pos uni10C81.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C81.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C81.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C81.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C81.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C81.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C81.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C81.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C81.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C81.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C81.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C81.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C81.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C81.ltr uni10CEC <10 0 10 0>;\012    pos uni10C81.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C81.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C81.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C81.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C81.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C81.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C81.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C81.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C81.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C81.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C81.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C81.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C81.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C81.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C81.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C82.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C82.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C82.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C82.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C82.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C82.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C82.ltr uni10CCB <10 0 10 0>;\012    pos uni10C82.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C82.ltr uni10CCD <40 0 40 0>;\012    pos uni10C82.ltr uni10CCE <20 0 20 0>;\012    pos uni10C82.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C82.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C82.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C82.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C82.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C82.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C82.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C82.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C82.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C82.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C82.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C82.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C82.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C82.ltr uni10CEC <10 0 10 0>;\012    pos uni10C82.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C82.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C82.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C82.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C82.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C82.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C82.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C82.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C82.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C82.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C82.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C82.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C82.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C82.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C82.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C83.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C83.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C83.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C83.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C83.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C83.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C83.ltr uni10CCB <10 0 10 0>;\012    pos uni10C83.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C83.ltr uni10CCD <40 0 40 0>;\012    pos uni10C83.ltr uni10CCE <20 0 20 0>;\012    pos uni10C83.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C83.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C83.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C83.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C83.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C83.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C83.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C83.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C83.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C83.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C83.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C83.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C83.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C83.ltr uni10CEC <10 0 10 0>;\012    pos uni10C83.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C83.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C83.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C83.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C83.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C83.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C83.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C83.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C83.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C83.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C83.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C83.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C83.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C83.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C83.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C84.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C84.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C84.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C84.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C84.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C84.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C84.ltr uni10CCB <10 0 10 0>;\012    pos uni10C84.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C84.ltr uni10CCD <40 0 40 0>;\012    pos uni10C84.ltr uni10CCE <20 0 20 0>;\012    pos uni10C84.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C84.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C84.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C84.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C84.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C84.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C84.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C84.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C84.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C84.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C84.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C84.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C84.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C84.ltr uni10CEC <10 0 10 0>;\012    pos uni10C84.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C84.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C84.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C84.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C84.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C84.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C84.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C84.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C84.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C84.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C84.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C84.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C84.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C84.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C84.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C85.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C85.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C85.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C85.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C85.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C85.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C85.ltr uni10CCB <10 0 10 0>;\012    pos uni10C85.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C85.ltr uni10CCD <40 0 40 0>;\012    pos uni10C85.ltr uni10CCE <20 0 20 0>;\012    pos uni10C85.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C85.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C85.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C85.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C85.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C85.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C85.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C85.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C85.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C85.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C85.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C85.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C85.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C85.ltr uni10CEC <10 0 10 0>;\012    pos uni10C85.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C85.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C85.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C85.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C85.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C85.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C85.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C85.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C85.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C85.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C85.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C85.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C85.ltr uni10CE9.ltr
+ <20 0 20 0>;\012    pos uni10C85.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C85.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C86.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C86.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C86.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C86.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C86.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C86.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C86.ltr uni10CCB <10 0 10 0>;\012    pos uni10C86.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C86.ltr uni10CCD <40 0 40 0>;\012    pos uni10C86.ltr uni10CCE <20 0 20 0>;\012    pos uni10C86.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C86.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C86.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C86.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C86.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C86.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C86.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C86.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C86.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C86.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C86.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C86.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C86.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C86.ltr uni10CEC <10 0 10 0>;\012    pos uni10C86.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C86.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C86.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C86.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C86.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C86.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C86.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C86.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C86.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C86.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C86.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C86.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C86.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C86.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C86.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C87.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C87.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C87.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C87.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C87.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C87.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C87.ltr uni10CCB <10 0 10 0>;\012    pos uni10C87.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C87.ltr uni10CCD <40 0 40 0>;\012    pos uni10C87.ltr uni10CCE <20 0 20 0>;\012    pos uni10C87.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C87.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C87.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C87.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C87.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C87.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C87.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C87.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C87.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C87.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C87.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C87.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C87.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C87.ltr uni10CEC <10 0 10 0>;\012    pos uni10C87.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C87.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C87.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C87.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C87.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C87.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C87.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C87.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C87.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C87.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C87.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C87.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C87.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C87.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C87.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C88.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C88.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C88.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C88.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C88.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C88.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C88.ltr uni10CCB <10 0 10 0>;\012    pos uni10C88.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C88.ltr uni10CCD <40 0 40 0>;\012    pos uni10C88.ltr uni10CCE <20 0 20 0>;\012    pos uni10C88.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C88.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C88.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C88.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C88.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C88.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C88.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C88.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C88.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C88.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C88.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C88.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C88.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C88.ltr uni10CEC <10 0 10 0>;\012    pos uni10C88.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C88.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C88.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C88.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C88.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C88.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C88.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C88.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C88.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C88.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C88.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C88.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C88.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C88.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C88.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C89.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C89.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C89.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C89.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C89.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C89.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C89.ltr uni10CCB <10 0 10 0>;\012    pos uni10C89.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C89.ltr uni10CCD <40 0 40 0>;\012    pos uni10C89.ltr uni10CCE <20 0 20 0>;\012    pos uni10C89.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C89.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C89.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C89.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C89.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C89.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C89.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C89.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C89.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C89.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C89.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C89.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C89.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C89.ltr uni10CEC <10 0 10 0>;\012    pos uni10C89.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C89.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C89.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C89.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C89.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C89.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C89.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C89.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C89.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C89.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C89.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C89.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C89.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C89.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C89.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C8A.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C8A.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C8A.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C8A.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C8A.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C8A.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C8A.ltr uni10CCB <10 0 10 0>;\012    pos uni10C8A.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C8A.ltr uni10CCD <40 0 40 0>;\012    pos uni10C8A.ltr uni10CCE <20 0 20 0>;\012    pos uni10C8A.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C8A.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C8A.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C8A.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C8A.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C8A.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C8A.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C8A.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C8A.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C8A.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C8A.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C8A.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C8A.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C8A.ltr uni10CEC <10 0 10 0>;\012    pos uni10C8A.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C8A.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C8A.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C8A.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C8A.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C8A.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C8A.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C8A.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C8A.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C8A.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C8A.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C8A.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C8A.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C8A.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C8A.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C8B.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C8B.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C8B.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C8B.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C8B.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C8B.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C8B.ltr uni10CCB <10 0 10 0>;\012    pos
+ uni10C8B.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C8B.ltr uni10CCD <40 0 40 0>;\012    pos uni10C8B.ltr uni10CCE <20 0 20 0>;\012    pos uni10C8B.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C8B.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C8B.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C8B.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C8B.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C8B.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C8B.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C8B.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C8B.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C8B.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C8B.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C8B.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C8B.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C8B.ltr uni10CEC <10 0 10 0>;\012    pos uni10C8B.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C8B.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C8B.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C8B.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C8B.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C8B.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C8B.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C8B.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C8B.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C8B.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C8B.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C8B.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C8B.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C8B.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C8B.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C8C.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C8C.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C8C.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C8C.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C8C.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C8C.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C8C.ltr uni10CCB <10 0 10 0>;\012    pos uni10C8C.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C8C.ltr uni10CCD <40 0 40 0>;\012    pos uni10C8C.ltr uni10CCE <20 0 20 0>;\012    pos uni10C8C.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C8C.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C8C.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C8C.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C8C.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C8C.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C8C.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C8C.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C8C.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C8C.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C8C.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C8C.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C8C.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C8C.ltr uni10CEC <10 0 10 0>;\012    pos uni10C8C.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C8C.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C8C.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C8C.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C8C.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C8C.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C8C.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C8C.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C8C.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C8C.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C8C.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C8C.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C8C.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C8C.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C8C.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C8D.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C8D.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C8D.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C8D.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C8D.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C8D.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C8D.ltr uni10CCB <10 0 10 0>;\012    pos uni10C8D.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C8D.ltr uni10CCD <40 0 40 0>;\012    pos uni10C8D.ltr uni10CCE <20 0 20 0>;\012    pos uni10C8D.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C8D.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C8D.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C8D.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C8D.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C8D.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C8D.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C8D.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C8D.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C8D.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C8D.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C8D.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C8D.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C8D.ltr uni10CEC <10 0 10 0>;\012    pos uni10C8D.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C8D.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C8D.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C8D.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C8D.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C8D.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C8D.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C8D.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C8D.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C8D.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C8D.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C8D.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C8D.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C8D.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C8D.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C8E.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C8E.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C8E.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C8E.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C8E.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C8E.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C8E.ltr uni10CCB <10 0 10 0>;\012    pos uni10C8E.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C8E.ltr uni10CCD <40 0 40 0>;\012    pos uni10C8E.ltr uni10CCE <20 0 20 0>;\012    pos uni10C8E.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C8E.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C8E.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C8E.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C8E.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C8E.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C8E.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C8E.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C8E.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C8E.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C8E.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C8E.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C8E.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C8E.ltr uni10CEC <10 0 10 0>;\012    pos uni10C8E.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C8E.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C8E.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C8E.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C8E.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C8E.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C8E.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C8E.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C8E.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C8E.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C8E.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C8E.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C8E.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C8E.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C8E.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C8F.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C8F.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C8F.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C8F.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C8F.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C8F.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C8F.ltr uni10CCB <10 0 10 0>;\012    pos uni10C8F.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C8F.ltr uni10CCD <40 0 40 0>;\012    pos uni10C8F.ltr uni10CCE <20 0 20 0>;\012    pos uni10C8F.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C8F.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C8F.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C8F.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C8F.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C8F.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C8F.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C8F.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C8F.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C8F.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C8F.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C8F.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C8F.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C8F.ltr uni10CEC <10 0 10 0>;\012    pos uni10C8F.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C8F.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C8F.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C8F.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C8F.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C8F.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C8F.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C8F.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C8F.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C8F.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C8F.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C8F.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C8F.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C8F.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C8F.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C90.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C90.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C90.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C90.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C90.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C90.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C90.ltr uni10CCB <10 0 10 0>;\012    pos uni10C90.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C90.ltr uni10CCD <40 0 40 0>;\012    pos uni10C90.ltr uni10CCE <20 0 20 0>;\012    pos uni10C90.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C90.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C90.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C90.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C90.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C90.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C90.ltr uni10CD9 <20 0 20 0>;\012
+    pos uni10C90.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C90.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C90.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C90.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C90.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C90.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C90.ltr uni10CEC <10 0 10 0>;\012    pos uni10C90.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C90.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C90.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C90.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C90.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C90.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C90.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C90.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C90.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C90.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C90.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C90.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C90.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C90.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C90.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C91.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C91.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C91.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C91.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C91.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C91.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C91.ltr uni10CCB <10 0 10 0>;\012    pos uni10C91.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C91.ltr uni10CCD <40 0 40 0>;\012    pos uni10C91.ltr uni10CCE <20 0 20 0>;\012    pos uni10C91.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C91.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C91.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C91.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C91.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C91.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C91.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C91.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C91.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C91.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C91.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C91.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C91.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C91.ltr uni10CEC <10 0 10 0>;\012    pos uni10C91.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C91.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C91.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C91.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C91.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C91.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C91.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C91.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C91.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C91.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C91.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C91.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C91.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C91.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C91.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C92.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C92.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C92.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C92.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C92.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C92.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C92.ltr uni10CCB <10 0 10 0>;\012    pos uni10C92.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C92.ltr uni10CCD <40 0 40 0>;\012    pos uni10C92.ltr uni10CCE <20 0 20 0>;\012    pos uni10C92.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C92.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C92.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C92.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C92.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C92.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C92.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C92.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C92.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C92.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C92.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C92.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C92.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C92.ltr uni10CEC <10 0 10 0>;\012    pos uni10C92.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C92.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C92.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C92.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C92.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C92.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C92.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C92.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C92.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C92.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C92.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C92.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C92.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C92.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C92.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C93.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C93.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C93.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C93.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C93.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C93.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C93.ltr uni10CCB <10 0 10 0>;\012    pos uni10C93.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C93.ltr uni10CCD <40 0 40 0>;\012    pos uni10C93.ltr uni10CCE <20 0 20 0>;\012    pos uni10C93.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C93.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C93.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C93.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C93.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C93.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C93.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C93.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C93.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C93.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C93.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C93.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C93.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C93.ltr uni10CEC <10 0 10 0>;\012    pos uni10C93.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C93.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C93.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C93.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C93.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C93.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C93.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C93.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C93.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C93.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C93.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C93.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C93.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C93.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C93.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C94.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C94.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C94.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C94.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C94.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C94.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C94.ltr uni10CCB <10 0 10 0>;\012    pos uni10C94.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C94.ltr uni10CCD <40 0 40 0>;\012    pos uni10C94.ltr uni10CCE <20 0 20 0>;\012    pos uni10C94.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C94.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C94.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C94.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C94.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C94.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C94.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C94.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C94.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C94.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C94.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C94.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C94.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C94.ltr uni10CEC <10 0 10 0>;\012    pos uni10C94.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C94.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C94.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C94.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C94.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C94.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C94.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C94.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C94.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C94.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C94.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C94.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C94.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C94.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C94.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C95.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C95.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C95.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C95.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C95.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C95.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C95.ltr uni10CCB <10 0 10 0>;\012    pos uni10C95.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C95.ltr uni10CCD <40 0 40 0>;\012    pos uni10C95.ltr uni10CCE <20 0 20 0>;\012    pos uni10C95.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C95.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C95.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C95.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C95.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C95.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C95.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C95.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C95.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C95.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C95.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C95.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C95.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C95.ltr uni10CEC <10 0 10 0>;\012    pos uni10C95.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C95.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C95.ltr uni10CF2 <-10 0
+ -10 0>;\012    pos uni10C95.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C95.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C95.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C95.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C95.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C95.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C95.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C95.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C95.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C95.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C95.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C95.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C96.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C96.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C96.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C96.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C96.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C96.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C96.ltr uni10CCB <10 0 10 0>;\012    pos uni10C96.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C96.ltr uni10CCD <40 0 40 0>;\012    pos uni10C96.ltr uni10CCE <20 0 20 0>;\012    pos uni10C96.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C96.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C96.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C96.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C96.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C96.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C96.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C96.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C96.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C96.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C96.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C96.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C96.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C96.ltr uni10CEC <10 0 10 0>;\012    pos uni10C96.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C96.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C96.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C96.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C96.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C96.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C96.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C96.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C96.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C96.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C96.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C96.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C96.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C96.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C96.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C97.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C97.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C97.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C97.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C97.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C97.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C97.ltr uni10CCB <10 0 10 0>;\012    pos uni10C97.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C97.ltr uni10CCD <40 0 40 0>;\012    pos uni10C97.ltr uni10CCE <20 0 20 0>;\012    pos uni10C97.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C97.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C97.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C97.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C97.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C97.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C97.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C97.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C97.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C97.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C97.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C97.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C97.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C97.ltr uni10CEC <10 0 10 0>;\012    pos uni10C97.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C97.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C97.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C97.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C97.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C97.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C97.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C97.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C97.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C97.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C97.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C97.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C97.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C97.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C97.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C98.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C98.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C98.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C98.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C98.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C98.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C98.ltr uni10CCB <10 0 10 0>;\012    pos uni10C98.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C98.ltr uni10CCD <40 0 40 0>;\012    pos uni10C98.ltr uni10CCE <20 0 20 0>;\012    pos uni10C98.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C98.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C98.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C98.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C98.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C98.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C98.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C98.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C98.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C98.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C98.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C98.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C98.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C98.ltr uni10CEC <10 0 10 0>;\012    pos uni10C98.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C98.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C98.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C98.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C98.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C98.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C98.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C98.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C98.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C98.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C98.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C98.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C98.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C98.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C98.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C99.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C99.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C99.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C99.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C99.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C99.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C99.ltr uni10CCB <10 0 10 0>;\012    pos uni10C99.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C99.ltr uni10CCD <40 0 40 0>;\012    pos uni10C99.ltr uni10CCE <20 0 20 0>;\012    pos uni10C99.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C99.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C99.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C99.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C99.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C99.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C99.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C99.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C99.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C99.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C99.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C99.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C99.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C99.ltr uni10CEC <10 0 10 0>;\012    pos uni10C99.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C99.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C99.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C99.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C99.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C99.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C99.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C99.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C99.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C99.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C99.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C99.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C99.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C99.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C99.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C9A.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C9A.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C9A.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C9A.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C9A.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C9A.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C9A.ltr uni10CCB <10 0 10 0>;\012    pos uni10C9A.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C9A.ltr uni10CCD <40 0 40 0>;\012    pos uni10C9A.ltr uni10CCE <20 0 20 0>;\012    pos uni10C9A.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C9A.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C9A.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C9A.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C9A.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C9A.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C9A.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C9A.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C9A.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C9A.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C9A.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C9A.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C9A.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C9A.ltr uni10CEC <10 0 10 0>;\012    pos uni10C9A.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C9A.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C9A.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C9A.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C9A.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C9A.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C9A.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C9A.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C9A.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C9A.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C9A.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C9A.ltr uni10CE8.ltr <20 0 20
+ 0>;\012    pos uni10C9A.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C9A.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C9A.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C9B.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C9B.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C9B.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C9B.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C9B.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C9B.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C9B.ltr uni10CCB <10 0 10 0>;\012    pos uni10C9B.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C9B.ltr uni10CCD <40 0 40 0>;\012    pos uni10C9B.ltr uni10CCE <20 0 20 0>;\012    pos uni10C9B.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C9B.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C9B.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C9B.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C9B.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C9B.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C9B.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C9B.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C9B.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C9B.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C9B.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C9B.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C9B.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C9B.ltr uni10CEC <10 0 10 0>;\012    pos uni10C9B.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C9B.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C9B.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C9B.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C9B.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C9B.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C9B.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C9B.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C9B.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C9B.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C9B.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C9B.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C9B.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C9B.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C9B.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C9C.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C9C.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C9C.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C9C.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C9C.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C9C.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C9C.ltr uni10CCB <10 0 10 0>;\012    pos uni10C9C.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C9C.ltr uni10CCD <40 0 40 0>;\012    pos uni10C9C.ltr uni10CCE <20 0 20 0>;\012    pos uni10C9C.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C9C.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C9C.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C9C.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C9C.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C9C.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C9C.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C9C.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C9C.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C9C.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C9C.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C9C.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C9C.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C9C.ltr uni10CEC <10 0 10 0>;\012    pos uni10C9C.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C9C.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C9C.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C9C.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C9C.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C9C.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C9C.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C9C.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C9C.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C9C.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C9C.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C9C.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C9C.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C9C.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C9C.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C9D.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C9D.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C9D.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C9D.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C9D.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C9D.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C9D.ltr uni10CCB <10 0 10 0>;\012    pos uni10C9D.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C9D.ltr uni10CCD <40 0 40 0>;\012    pos uni10C9D.ltr uni10CCE <20 0 20 0>;\012    pos uni10C9D.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C9D.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C9D.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C9D.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C9D.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C9D.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C9D.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C9D.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C9D.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C9D.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C9D.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C9D.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C9D.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C9D.ltr uni10CEC <10 0 10 0>;\012    pos uni10C9D.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C9D.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C9D.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C9D.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C9D.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C9D.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C9D.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C9D.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C9D.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C9D.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C9D.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C9D.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C9D.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C9D.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C9D.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C9E.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C9E.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C9E.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C9E.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C9E.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C9E.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C9E.ltr uni10CCB <10 0 10 0>;\012    pos uni10C9E.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C9E.ltr uni10CCD <40 0 40 0>;\012    pos uni10C9E.ltr uni10CCE <20 0 20 0>;\012    pos uni10C9E.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C9E.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C9E.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C9E.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C9E.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C9E.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C9E.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C9E.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C9E.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C9E.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C9E.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C9E.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C9E.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C9E.ltr uni10CEC <10 0 10 0>;\012    pos uni10C9E.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C9E.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C9E.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C9E.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C9E.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C9E.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C9E.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C9E.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C9E.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C9E.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C9E.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C9E.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C9E.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C9E.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C9E.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10C9F.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10C9F.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10C9F.ltr uni10CC2 <20 0 20 0>;\012    pos uni10C9F.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10C9F.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10C9F.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10C9F.ltr uni10CCB <10 0 10 0>;\012    pos uni10C9F.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10C9F.ltr uni10CCD <40 0 40 0>;\012    pos uni10C9F.ltr uni10CCE <20 0 20 0>;\012    pos uni10C9F.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10C9F.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10C9F.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10C9F.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10C9F.ltr uni10CD6 <40 0 40 0>;\012    pos uni10C9F.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10C9F.ltr uni10CD9 <20 0 20 0>;\012    pos uni10C9F.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10C9F.ltr uni10CE4 <40 0 40 0>;\012    pos uni10C9F.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10C9F.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10C9F.ltr uni10CE8 <20 0 20 0>;\012    pos uni10C9F.ltr uni10CE9 <20 0 20 0>;\012    pos uni10C9F.ltr uni10CEC <10 0 10 0>;\012    pos uni10C9F.ltr uni10CED <-40 0 -40 0>;\012    pos uni10C9F.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10C9F.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10C9F.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10C9F.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10C9F.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10C9F.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10C9F.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10C9F.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10C9F.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10C9F.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10C9F.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10C9F.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10C9F.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10C9F.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA0.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CA0.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CA0.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CA0.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CA0.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CA0.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CA0.ltr
+ uni10CCB <10 0 10 0>;\012    pos uni10CA0.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CA0.ltr uni10CCD <40 0 40 0>;\012    pos uni10CA0.ltr uni10CCE <20 0 20 0>;\012    pos uni10CA0.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CA0.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CA0.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CA0.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CA0.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CA0.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CA0.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CA0.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CA0.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CA0.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CA0.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CA0.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CA0.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CA0.ltr uni10CEC <10 0 10 0>;\012    pos uni10CA0.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CA0.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CA0.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CA0.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA0.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA0.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA0.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA0.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA0.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA0.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA0.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA0.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA0.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CA0.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA0.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA1.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CA1.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CA1.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CA1.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CA1.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CA1.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CA1.ltr uni10CCB <10 0 10 0>;\012    pos uni10CA1.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CA1.ltr uni10CCD <40 0 40 0>;\012    pos uni10CA1.ltr uni10CCE <20 0 20 0>;\012    pos uni10CA1.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CA1.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CA1.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CA1.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CA1.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CA1.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CA1.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CA1.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CA1.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CA1.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CA1.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CA1.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CA1.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CA1.ltr uni10CEC <10 0 10 0>;\012    pos uni10CA1.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CA1.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CA1.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CA1.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA1.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA1.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA1.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA1.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA1.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA1.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA1.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA1.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA1.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CA1.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA1.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA2.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CA2.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CA2.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CA2.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CA2.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CA2.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CA2.ltr uni10CCB <10 0 10 0>;\012    pos uni10CA2.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CA2.ltr uni10CCD <40 0 40 0>;\012    pos uni10CA2.ltr uni10CCE <20 0 20 0>;\012    pos uni10CA2.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CA2.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CA2.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CA2.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CA2.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CA2.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CA2.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CA2.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CA2.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CA2.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CA2.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CA2.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CA2.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CA2.ltr uni10CEC <10 0 10 0>;\012    pos uni10CA2.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CA2.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CA2.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CA2.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA2.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA2.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA2.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA2.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA2.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA2.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA2.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA2.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA2.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CA2.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA2.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA3.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CA3.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CA3.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CA3.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CA3.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CA3.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CA3.ltr uni10CCB <10 0 10 0>;\012    pos uni10CA3.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CA3.ltr uni10CCD <40 0 40 0>;\012    pos uni10CA3.ltr uni10CCE <20 0 20 0>;\012    pos uni10CA3.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CA3.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CA3.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CA3.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CA3.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CA3.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CA3.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CA3.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CA3.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CA3.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CA3.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CA3.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CA3.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CA3.ltr uni10CEC <10 0 10 0>;\012    pos uni10CA3.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CA3.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CA3.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CA3.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA3.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA3.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA3.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA3.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA3.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA3.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA3.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA3.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA3.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CA3.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA3.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA4.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CA4.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CA4.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CA4.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CA4.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CA4.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CA4.ltr uni10CCB <10 0 10 0>;\012    pos uni10CA4.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CA4.ltr uni10CCD <40 0 40 0>;\012    pos uni10CA4.ltr uni10CCE <20 0 20 0>;\012    pos uni10CA4.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CA4.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CA4.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CA4.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CA4.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CA4.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CA4.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CA4.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CA4.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CA4.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CA4.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CA4.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CA4.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CA4.ltr uni10CEC <10 0 10 0>;\012    pos uni10CA4.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CA4.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CA4.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CA4.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA4.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA4.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA4.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA4.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA4.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA4.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA4.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA4.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA4.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CA4.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA4.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA5.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CA5.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CA5.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CA5.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CA5.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CA5.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CA5.ltr uni10CCB <10 0 10 0>;\012    pos uni10CA5.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CA5.ltr uni10CCD <40 0 40 0>;\012    pos uni10CA5.ltr uni10CCE <20 0 20 0>;\012    pos uni10CA5.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CA5.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CA5.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CA5.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CA5.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CA5.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CA5.ltr
+ uni10CD9 <20 0 20 0>;\012    pos uni10CA5.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CA5.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CA5.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CA5.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CA5.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CA5.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CA5.ltr uni10CEC <10 0 10 0>;\012    pos uni10CA5.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CA5.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CA5.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CA5.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA5.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA5.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA5.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA5.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA5.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA5.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA5.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA5.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA5.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CA5.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA5.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA6.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CA6.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CA6.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CA6.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CA6.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CA6.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CA6.ltr uni10CCB <10 0 10 0>;\012    pos uni10CA6.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CA6.ltr uni10CCD <40 0 40 0>;\012    pos uni10CA6.ltr uni10CCE <20 0 20 0>;\012    pos uni10CA6.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CA6.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CA6.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CA6.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CA6.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CA6.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CA6.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CA6.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CA6.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CA6.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CA6.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CA6.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CA6.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CA6.ltr uni10CEC <10 0 10 0>;\012    pos uni10CA6.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CA6.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CA6.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CA6.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA6.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA6.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA6.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA6.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA6.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA6.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA6.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA6.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA6.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CA6.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA6.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA7.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CA7.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CA7.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CA7.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CA7.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CA7.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CA7.ltr uni10CCB <10 0 10 0>;\012    pos uni10CA7.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CA7.ltr uni10CCD <40 0 40 0>;\012    pos uni10CA7.ltr uni10CCE <20 0 20 0>;\012    pos uni10CA7.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CA7.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CA7.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CA7.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CA7.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CA7.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CA7.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CA7.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CA7.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CA7.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CA7.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CA7.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CA7.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CA7.ltr uni10CEC <10 0 10 0>;\012    pos uni10CA7.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CA7.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CA7.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CA7.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA7.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA7.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA7.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA7.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA7.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA7.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA7.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA7.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA7.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CA7.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA7.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA8.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CA8.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CA8.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CA8.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CA8.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CA8.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CA8.ltr uni10CCB <10 0 10 0>;\012    pos uni10CA8.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CA8.ltr uni10CCD <40 0 40 0>;\012    pos uni10CA8.ltr uni10CCE <20 0 20 0>;\012    pos uni10CA8.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CA8.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CA8.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CA8.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CA8.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CA8.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CA8.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CA8.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CA8.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CA8.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CA8.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CA8.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CA8.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CA8.ltr uni10CEC <10 0 10 0>;\012    pos uni10CA8.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CA8.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CA8.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CA8.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA8.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA8.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA8.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA8.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA8.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA8.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA8.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA8.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA8.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CA8.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA8.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CA9.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CA9.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CA9.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CA9.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CA9.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CA9.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CA9.ltr uni10CCB <10 0 10 0>;\012    pos uni10CA9.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CA9.ltr uni10CCD <40 0 40 0>;\012    pos uni10CA9.ltr uni10CCE <20 0 20 0>;\012    pos uni10CA9.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CA9.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CA9.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CA9.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CA9.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CA9.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CA9.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CA9.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CA9.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CA9.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CA9.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CA9.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CA9.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CA9.ltr uni10CEC <10 0 10 0>;\012    pos uni10CA9.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CA9.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CA9.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CA9.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CA9.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CA9.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CA9.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CA9.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CA9.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CA9.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CA9.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CA9.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CA9.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CA9.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CA9.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CAA.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CAA.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CAA.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CAA.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CAA.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CAA.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CAA.ltr uni10CCB <10 0 10 0>;\012    pos uni10CAA.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CAA.ltr uni10CCD <40 0 40 0>;\012    pos uni10CAA.ltr uni10CCE <20 0 20 0>;\012    pos uni10CAA.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CAA.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CAA.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CAA.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CAA.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CAA.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CAA.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CAA.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CAA.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CAA.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CAA.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CAA.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CAA.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CAA.ltr uni10CEC <10 0 10 0>;\012    pos uni10CAA.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CAA.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CAA.ltr
+ uni10CF2 <-10 0 -10 0>;\012    pos uni10CAA.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CAA.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CAA.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CAA.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CAA.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CAA.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CAA.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CAA.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CAA.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CAA.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CAA.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CAA.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CAB.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CAB.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CAB.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CAB.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CAB.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CAB.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CAB.ltr uni10CCB <10 0 10 0>;\012    pos uni10CAB.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CAB.ltr uni10CCD <40 0 40 0>;\012    pos uni10CAB.ltr uni10CCE <20 0 20 0>;\012    pos uni10CAB.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CAB.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CAB.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CAB.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CAB.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CAB.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CAB.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CAB.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CAB.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CAB.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CAB.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CAB.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CAB.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CAB.ltr uni10CEC <10 0 10 0>;\012    pos uni10CAB.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CAB.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CAB.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CAB.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CAB.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CAB.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CAB.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CAB.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CAB.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CAB.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CAB.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CAB.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CAB.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CAB.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CAB.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CAC.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CAC.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CAC.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CAC.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CAC.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CAC.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CAC.ltr uni10CCB <10 0 10 0>;\012    pos uni10CAC.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CAC.ltr uni10CCD <40 0 40 0>;\012    pos uni10CAC.ltr uni10CCE <20 0 20 0>;\012    pos uni10CAC.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CAC.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CAC.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CAC.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CAC.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CAC.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CAC.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CAC.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CAC.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CAC.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CAC.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CAC.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CAC.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CAC.ltr uni10CEC <10 0 10 0>;\012    pos uni10CAC.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CAC.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CAC.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CAC.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CAC.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CAC.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CAC.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CAC.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CAC.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CAC.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CAC.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CAC.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CAC.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CAC.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CAC.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CAD.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CAD.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CAD.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CAD.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CAD.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CAD.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CAD.ltr uni10CCB <10 0 10 0>;\012    pos uni10CAD.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CAD.ltr uni10CCD <40 0 40 0>;\012    pos uni10CAD.ltr uni10CCE <20 0 20 0>;\012    pos uni10CAD.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CAD.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CAD.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CAD.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CAD.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CAD.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CAD.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CAD.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CAD.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CAD.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CAD.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CAD.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CAD.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CAD.ltr uni10CEC <10 0 10 0>;\012    pos uni10CAD.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CAD.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CAD.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CAD.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CAD.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CAD.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CAD.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CAD.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CAD.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CAD.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CAD.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CAD.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CAD.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CAD.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CAD.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CAE.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CAE.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CAE.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CAE.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CAE.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CAE.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CAE.ltr uni10CCB <10 0 10 0>;\012    pos uni10CAE.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CAE.ltr uni10CCD <40 0 40 0>;\012    pos uni10CAE.ltr uni10CCE <20 0 20 0>;\012    pos uni10CAE.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CAE.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CAE.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CAE.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CAE.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CAE.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CAE.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CAE.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CAE.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CAE.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CAE.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CAE.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CAE.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CAE.ltr uni10CEC <10 0 10 0>;\012    pos uni10CAE.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CAE.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CAE.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CAE.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CAE.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CAE.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CAE.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CAE.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CAE.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CAE.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CAE.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CAE.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CAE.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CAE.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CAE.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CAF.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CAF.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CAF.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CAF.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CAF.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CAF.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CAF.ltr uni10CCB <10 0 10 0>;\012    pos uni10CAF.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CAF.ltr uni10CCD <40 0 40 0>;\012    pos uni10CAF.ltr uni10CCE <20 0 20 0>;\012    pos uni10CAF.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CAF.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CAF.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CAF.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CAF.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CAF.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CAF.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CAF.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CAF.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CAF.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CAF.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CAF.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CAF.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CAF.ltr uni10CEC <10 0 10 0>;\012    pos uni10CAF.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CAF.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CAF.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CAF.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CAF.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CAF.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CAF.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CAF.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CAF.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CAF.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CAF.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CAF.ltr uni10CE8.ltr
+ <20 0 20 0>;\012    pos uni10CAF.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CAF.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CAF.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CB0.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CB0.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CB0.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CB0.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CB0.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CB0.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CB0.ltr uni10CCB <10 0 10 0>;\012    pos uni10CB0.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CB0.ltr uni10CCD <40 0 40 0>;\012    pos uni10CB0.ltr uni10CCE <20 0 20 0>;\012    pos uni10CB0.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CB0.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CB0.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CB0.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CB0.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CB0.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CB0.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CB0.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CB0.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CB0.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CB0.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CB0.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CB0.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CB0.ltr uni10CEC <10 0 10 0>;\012    pos uni10CB0.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CB0.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CB0.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CB0.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CB0.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CB0.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CB0.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CB0.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CB0.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CB0.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CB0.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CB0.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CB0.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CB0.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CB0.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CB1.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CB1.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CB1.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CB1.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CB1.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CB1.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CB1.ltr uni10CCB <10 0 10 0>;\012    pos uni10CB1.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CB1.ltr uni10CCD <40 0 40 0>;\012    pos uni10CB1.ltr uni10CCE <20 0 20 0>;\012    pos uni10CB1.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CB1.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CB1.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CB1.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CB1.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CB1.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CB1.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CB1.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CB1.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CB1.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CB1.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CB1.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CB1.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CB1.ltr uni10CEC <10 0 10 0>;\012    pos uni10CB1.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CB1.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CB1.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CB1.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CB1.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CB1.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CB1.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CB1.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CB1.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CB1.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CB1.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CB1.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CB1.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CB1.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CB1.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CB2.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CB2.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CB2.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CB2.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CB2.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CB2.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CB2.ltr uni10CCB <10 0 10 0>;\012    pos uni10CB2.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CB2.ltr uni10CCD <40 0 40 0>;\012    pos uni10CB2.ltr uni10CCE <20 0 20 0>;\012    pos uni10CB2.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CB2.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CB2.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CB2.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CB2.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CB2.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CB2.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CB2.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CB2.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CB2.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CB2.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CB2.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CB2.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CB2.ltr uni10CEC <10 0 10 0>;\012    pos uni10CB2.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CB2.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CB2.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CB2.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CB2.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CB2.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CB2.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CB2.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CB2.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CB2.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CB2.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CB2.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CB2.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CB2.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CB2.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CC0.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CC0.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CC0.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CC0.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CC0.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CC0.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CC0.ltr uni10CCB <10 0 10 0>;\012    pos uni10CC0.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CC0.ltr uni10CCD <40 0 40 0>;\012    pos uni10CC0.ltr uni10CCE <20 0 20 0>;\012    pos uni10CC0.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CC0.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CC0.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CC0.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CC0.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CC0.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CC0.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CC0.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CC0.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CC0.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CC0.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CC0.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CC0.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CC0.ltr uni10CEC <10 0 10 0>;\012    pos uni10CC0.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CC0.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CC0.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CC0.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CC0.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CC0.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CC0.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CC0.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CC0.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CC0.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CC0.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CC0.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CC0.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CC0.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CC0.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CC1.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CC1.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CC1.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CC1.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CC1.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CC1.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CC1.ltr uni10CCB <10 0 10 0>;\012    pos uni10CC1.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CC1.ltr uni10CCD <40 0 40 0>;\012    pos uni10CC1.ltr uni10CCE <20 0 20 0>;\012    pos uni10CC1.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CC1.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CC1.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CC1.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CC1.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CC1.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CC1.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CC1.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CC1.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CC1.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CC1.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CC1.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CC1.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CC1.ltr uni10CEC <10 0 10 0>;\012    pos uni10CC1.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CC1.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CC1.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CC1.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CC1.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CC1.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CC1.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CC1.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CC1.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CC1.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CC1.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CC1.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CC1.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CC1.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CC1.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CC2.ltr uni10CC0 <-10 0 -10 0>;\012    pos uni10CC2.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CC2.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CC2.ltr uni10CC3 <10 0 10 0>;\012    pos uni10CC2.ltr uni10CCC <-20 0 -20 0>;\012    pos uni10CC2.ltr uni10CD2 <-10 0 -10 0>;\012    pos
+ uni10CC2.ltr uni10CD7 <-20 0 -20 0>;\012    pos uni10CC2.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CC2.ltr uni10CE3 <-40 0 -40 0>;\012    pos uni10CC2.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CC2.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CC2.ltr uni10CEC <20 0 20 0>;\012    pos uni10CC2.ltr uni10CF2 <-20 0 -20 0>;\012    pos uni10CC2.ltr uni10CC0.ltr <-10 0 -10 0>;\012    pos uni10CC2.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CC2.ltr uni10CCC.ltr <-20 0 -20 0>;\012    pos uni10CC2.ltr uni10CD7.ltr <-20 0 -20 0>;\012    pos uni10CC2.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CC2.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CC2.ltr uni10CF2.ltr <-20 0 -20 0>;\012    pos uni10CC3.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CC3.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CC3.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CC3.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CC3.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CC3.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CC3.ltr uni10CCB <10 0 10 0>;\012    pos uni10CC3.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CC3.ltr uni10CCD <40 0 40 0>;\012    pos uni10CC3.ltr uni10CCE <20 0 20 0>;\012    pos uni10CC3.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CC3.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CC3.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CC3.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CC3.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CC3.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CC3.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CC3.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CC3.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CC3.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CC3.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CC3.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CC3.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CC3.ltr uni10CEC <10 0 10 0>;\012    pos uni10CC3.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CC3.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CC3.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CC3.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CC3.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CC3.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CC3.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CC3.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CC3.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CC3.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CC3.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CC3.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CC3.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CC3.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CC3.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CC4.ltr uni10CE3 <-20 0 -20 0>;\012    pos uni10CC5.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CC5.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CC5.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CC5.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CC5.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CC5.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CC5.ltr uni10CCB <10 0 10 0>;\012    pos uni10CC5.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CC5.ltr uni10CCD <40 0 40 0>;\012    pos uni10CC5.ltr uni10CCE <20 0 20 0>;\012    pos uni10CC5.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CC5.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CC5.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CC5.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CC5.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CC5.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CC5.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CC5.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CC5.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CC5.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CC5.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CC5.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CC5.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CC5.ltr uni10CEC <10 0 10 0>;\012    pos uni10CC5.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CC5.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CC5.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CC5.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CC5.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CC5.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CC5.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CC5.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CC5.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CC5.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CC5.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CC5.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CC5.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CC5.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CC5.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CC6.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CC6.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CC6.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CC6.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CC6.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CC6.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CC6.ltr uni10CCB <10 0 10 0>;\012    pos uni10CC6.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CC6.ltr uni10CCD <40 0 40 0>;\012    pos uni10CC6.ltr uni10CCE <20 0 20 0>;\012    pos uni10CC6.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CC6.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CC6.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CC6.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CC6.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CC6.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CC6.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CC6.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CC6.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CC6.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CC6.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CC6.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CC6.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CC6.ltr uni10CEC <10 0 10 0>;\012    pos uni10CC6.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CC6.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CC6.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CC6.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CC6.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CC6.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CC6.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CC6.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CC6.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CC6.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CC6.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CC6.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CC6.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CC6.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CC6.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CC7.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CC7.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CC7.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CC7.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CC7.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CC7.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CC7.ltr uni10CCB <10 0 10 0>;\012    pos uni10CC7.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CC7.ltr uni10CCD <40 0 40 0>;\012    pos uni10CC7.ltr uni10CCE <20 0 20 0>;\012    pos uni10CC7.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CC7.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CC7.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CC7.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CC7.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CC7.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CC7.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CC7.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CC7.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CC7.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CC7.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CC7.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CC7.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CC7.ltr uni10CEC <10 0 10 0>;\012    pos uni10CC7.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CC7.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CC7.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CC7.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CC7.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CC7.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CC7.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CC7.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CC7.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CC7.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CC7.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CC7.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CC7.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CC7.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CC7.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CC8.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CC8.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CC8.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CC8.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CC8.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CC8.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CC8.ltr uni10CCB <10 0 10 0>;\012    pos uni10CC8.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CC8.ltr uni10CCD <40 0 40 0>;\012    pos uni10CC8.ltr uni10CCE <20 0 20 0>;\012    pos uni10CC8.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CC8.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CC8.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CC8.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CC8.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CC8.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CC8.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CC8.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CC8.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CC8.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CC8.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CC8.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CC8.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CC8.ltr uni10CEC <10 0 10 0>;\012    pos uni10CC8.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CC8.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CC8.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CC8.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CC8.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CC8.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CC8.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CC8.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CC8.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CC8.ltr uni10CE4.ltr <40 0
+ 40 0>;\012    pos uni10CC8.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CC8.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CC8.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CC8.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CC8.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CC9.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CC9.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CC9.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CC9.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CC9.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CC9.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CC9.ltr uni10CCB <10 0 10 0>;\012    pos uni10CC9.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CC9.ltr uni10CCD <40 0 40 0>;\012    pos uni10CC9.ltr uni10CCE <20 0 20 0>;\012    pos uni10CC9.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CC9.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CC9.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CC9.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CC9.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CC9.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CC9.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CC9.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CC9.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CC9.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CC9.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CC9.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CC9.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CC9.ltr uni10CEC <10 0 10 0>;\012    pos uni10CC9.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CC9.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CC9.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CC9.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CC9.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CC9.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CC9.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CC9.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CC9.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CC9.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CC9.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CC9.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CC9.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CC9.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CC9.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CCA.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CCA.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CCA.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CCA.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CCA.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CCA.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CCA.ltr uni10CCB <10 0 10 0>;\012    pos uni10CCA.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CCA.ltr uni10CCD <40 0 40 0>;\012    pos uni10CCA.ltr uni10CCE <20 0 20 0>;\012    pos uni10CCA.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CCA.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CCA.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CCA.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CCA.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CCA.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CCA.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CCA.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CCA.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CCA.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CCA.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CCA.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CCA.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CCA.ltr uni10CEC <10 0 10 0>;\012    pos uni10CCA.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CCA.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CCA.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CCA.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CCA.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CCA.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CCA.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CCA.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CCA.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CCA.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CCA.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CCA.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CCA.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CCA.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CCA.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CCB.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CCB.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CCB.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CCB.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CCB.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CCB.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CCB.ltr uni10CCB <10 0 10 0>;\012    pos uni10CCB.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CCB.ltr uni10CCD <40 0 40 0>;\012    pos uni10CCB.ltr uni10CCE <20 0 20 0>;\012    pos uni10CCB.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CCB.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CCB.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CCB.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CCB.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CCB.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CCB.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CCB.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CCB.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CCB.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CCB.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CCB.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CCB.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CCB.ltr uni10CEC <10 0 10 0>;\012    pos uni10CCB.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CCB.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CCB.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CCB.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CCB.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CCB.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CCB.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CCB.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CCB.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CCB.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CCB.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CCB.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CCB.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CCB.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CCB.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CCC.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CCC.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CCC.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CCC.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CCC.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CCC.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CCC.ltr uni10CCB <10 0 10 0>;\012    pos uni10CCC.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CCC.ltr uni10CCD <40 0 40 0>;\012    pos uni10CCC.ltr uni10CCE <20 0 20 0>;\012    pos uni10CCC.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CCC.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CCC.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CCC.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CCC.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CCC.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CCC.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CCC.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CCC.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CCC.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CCC.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CCC.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CCC.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CCC.ltr uni10CEC <10 0 10 0>;\012    pos uni10CCC.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CCC.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CCC.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CCC.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CCC.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CCC.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CCC.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CCC.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CCC.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CCC.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CCC.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CCC.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CCC.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CCC.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CCC.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CCD.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CCD.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CCD.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CCD.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CCD.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CCD.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CCD.ltr uni10CCB <10 0 10 0>;\012    pos uni10CCD.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CCD.ltr uni10CCD <40 0 40 0>;\012    pos uni10CCD.ltr uni10CCE <20 0 20 0>;\012    pos uni10CCD.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CCD.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CCD.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CCD.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CCD.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CCD.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CCD.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CCD.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CCD.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CCD.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CCD.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CCD.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CCD.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CCD.ltr uni10CEC <10 0 10 0>;\012    pos uni10CCD.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CCD.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CCD.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CCD.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CCD.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CCD.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CCD.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CCD.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CCD.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CCD.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CCD.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CCD.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CCD.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CCD.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CCD.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CCE.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CCE.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CCE.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CCE.ltr uni10CC4 <-30 0 -30 0>;\012   
+ pos uni10CCE.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CCE.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CCE.ltr uni10CCB <10 0 10 0>;\012    pos uni10CCE.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CCE.ltr uni10CCD <40 0 40 0>;\012    pos uni10CCE.ltr uni10CCE <20 0 20 0>;\012    pos uni10CCE.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CCE.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CCE.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CCE.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CCE.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CCE.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CCE.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CCE.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CCE.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CCE.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CCE.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CCE.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CCE.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CCE.ltr uni10CEC <10 0 10 0>;\012    pos uni10CCE.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CCE.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CCE.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CCE.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CCE.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CCE.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CCE.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CCE.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CCE.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CCE.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CCE.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CCE.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CCE.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CCE.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CCE.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CCF.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CCF.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CCF.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CCF.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CCF.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CCF.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CCF.ltr uni10CCB <10 0 10 0>;\012    pos uni10CCF.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CCF.ltr uni10CCD <40 0 40 0>;\012    pos uni10CCF.ltr uni10CCE <20 0 20 0>;\012    pos uni10CCF.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CCF.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CCF.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CCF.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CCF.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CCF.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CCF.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CCF.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CCF.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CCF.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CCF.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CCF.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CCF.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CCF.ltr uni10CEC <10 0 10 0>;\012    pos uni10CCF.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CCF.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CCF.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CCF.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CCF.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CCF.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CCF.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CCF.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CCF.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CCF.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CCF.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CCF.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CCF.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CCF.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CCF.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CD0.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CD0.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CD0.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CD0.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CD0.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CD0.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CD0.ltr uni10CCB <10 0 10 0>;\012    pos uni10CD0.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CD0.ltr uni10CCD <40 0 40 0>;\012    pos uni10CD0.ltr uni10CCE <20 0 20 0>;\012    pos uni10CD0.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CD0.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CD0.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CD0.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CD0.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CD0.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CD0.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CD0.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CD0.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CD0.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CD0.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CD0.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CD0.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CD0.ltr uni10CEC <10 0 10 0>;\012    pos uni10CD0.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CD0.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CD0.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CD0.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CD0.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CD0.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CD0.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CD0.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CD0.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CD0.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CD0.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CD0.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CD0.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CD0.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CD0.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CD1.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CD1.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CD1.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CD1.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CD1.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CD1.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CD1.ltr uni10CCB <10 0 10 0>;\012    pos uni10CD1.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CD1.ltr uni10CCD <40 0 40 0>;\012    pos uni10CD1.ltr uni10CCE <20 0 20 0>;\012    pos uni10CD1.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CD1.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CD1.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CD1.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CD1.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CD1.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CD1.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CD1.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CD1.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CD1.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CD1.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CD1.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CD1.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CD1.ltr uni10CEC <10 0 10 0>;\012    pos uni10CD1.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CD1.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CD1.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CD1.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CD1.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CD1.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CD1.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CD1.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CD1.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CD1.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CD1.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CD1.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CD1.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CD1.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CD1.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CD2.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CD2.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CD2.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CD2.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CD2.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CD2.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CD2.ltr uni10CCB <10 0 10 0>;\012    pos uni10CD2.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CD2.ltr uni10CCD <40 0 40 0>;\012    pos uni10CD2.ltr uni10CCE <20 0 20 0>;\012    pos uni10CD2.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CD2.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CD2.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CD2.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CD2.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CD2.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CD2.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CD2.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CD2.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CD2.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CD2.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CD2.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CD2.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CD2.ltr uni10CEC <10 0 10 0>;\012    pos uni10CD2.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CD2.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CD2.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CD2.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CD2.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CD2.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CD2.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CD2.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CD2.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CD2.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CD2.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CD2.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CD2.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CD2.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CD2.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CD3.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CD3.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CD3.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CD3.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CD3.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CD3.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CD3.ltr uni10CCB <10 0 10 0>;\012    pos uni10CD3.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CD3.ltr uni10CCD <40 0 40 0>;\012    pos uni10CD3.ltr uni10CCE <20 0 20 0>;\012    pos uni10CD3.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CD3.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CD3.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CD3.ltr uni10CD4 <-40 0 -40
+ 0>;\012    pos uni10CD3.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CD3.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CD3.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CD3.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CD3.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CD3.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CD3.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CD3.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CD3.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CD3.ltr uni10CEC <10 0 10 0>;\012    pos uni10CD3.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CD3.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CD3.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CD3.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CD3.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CD3.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CD3.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CD3.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CD3.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CD3.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CD3.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CD3.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CD3.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CD3.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CD3.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CD4.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CD4.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CD4.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CD4.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CD4.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CD4.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CD4.ltr uni10CCB <10 0 10 0>;\012    pos uni10CD4.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CD4.ltr uni10CCD <40 0 40 0>;\012    pos uni10CD4.ltr uni10CCE <20 0 20 0>;\012    pos uni10CD4.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CD4.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CD4.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CD4.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CD4.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CD4.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CD4.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CD4.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CD4.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CD4.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CD4.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CD4.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CD4.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CD4.ltr uni10CEC <10 0 10 0>;\012    pos uni10CD4.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CD4.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CD4.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CD4.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CD4.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CD4.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CD4.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CD4.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CD4.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CD4.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CD4.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CD4.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CD4.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CD4.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CD4.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CD5.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CD5.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CD5.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CD5.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CD5.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CD5.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CD5.ltr uni10CCB <10 0 10 0>;\012    pos uni10CD5.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CD5.ltr uni10CCD <40 0 40 0>;\012    pos uni10CD5.ltr uni10CCE <20 0 20 0>;\012    pos uni10CD5.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CD5.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CD5.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CD5.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CD5.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CD5.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CD5.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CD5.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CD5.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CD5.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CD5.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CD5.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CD5.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CD5.ltr uni10CEC <10 0 10 0>;\012    pos uni10CD5.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CD5.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CD5.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CD5.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CD5.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CD5.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CD5.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CD5.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CD5.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CD5.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CD5.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CD5.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CD5.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CD5.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CD5.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CD6.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CD6.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CD6.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CD6.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CD6.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CD6.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CD6.ltr uni10CCB <10 0 10 0>;\012    pos uni10CD6.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CD6.ltr uni10CCD <40 0 40 0>;\012    pos uni10CD6.ltr uni10CCE <20 0 20 0>;\012    pos uni10CD6.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CD6.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CD6.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CD6.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CD6.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CD6.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CD6.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CD6.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CD6.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CD6.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CD6.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CD6.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CD6.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CD6.ltr uni10CEC <10 0 10 0>;\012    pos uni10CD6.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CD6.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CD6.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CD6.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CD6.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CD6.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CD6.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CD6.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CD6.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CD6.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CD6.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CD6.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CD6.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CD6.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CD6.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CD7.ltr uni10CC2 <-30 0 -30 0>;\012    pos uni10CD7.ltr uni10CC4 <-10 0 -10 0>;\012    pos uni10CD7.ltr uni10CC9 <-30 0 -30 0>;\012    pos uni10CD7.ltr uni10CCD <-20 0 -20 0>;\012    pos uni10CD7.ltr uni10CCF <-20 0 -20 0>;\012    pos uni10CD7.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CD7.ltr uni10CD1 <-20 0 -20 0>;\012    pos uni10CD7.ltr uni10CD5 <-30 0 -30 0>;\012    pos uni10CD7.ltr uni10CD6 <-20 0 -20 0>;\012    pos uni10CD7.ltr uni10CD9 <-30 0 -30 0>;\012    pos uni10CD7.ltr uni10CE4 <-20 0 -20 0>;\012    pos uni10CD7.ltr uni10CE6 <-40 0 -40 0>;\012    pos uni10CD7.ltr uni10CE7 <-30 0 -30 0>;\012    pos uni10CD7.ltr uni10CE8 <-30 0 -30 0>;\012    pos uni10CD7.ltr uni10CE9 <-30 0 -30 0>;\012    pos uni10CD7.ltr uni10CF0 <-40 0 -40 0>;\012    pos uni10CD7.ltr uni10CC2.ltr <-30 0 -30 0>;\012    pos uni10CD7.ltr uni10CCD.ltr <-20 0 -20 0>;\012    pos uni10CD7.ltr uni10CD6.ltr <-20 0 -20 0>;\012    pos uni10CD7.ltr uni10CE4.ltr <-20 0 -20 0>;\012    pos uni10CD7.ltr uni10CE6.ltr <-40 0 -40 0>;\012    pos uni10CD7.ltr uni10CE8.ltr <-30 0 -30 0>;\012    pos uni10CD7.ltr uni10CE9.ltr <-30 0 -30 0>;\012    pos uni10CD7.ltr uni10CF0.ltr <-40 0 -40 0>;\012    pos uni10CD8.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CD8.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CD8.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CD8.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CD8.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CD8.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CD8.ltr uni10CCB <10 0 10 0>;\012    pos uni10CD8.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CD8.ltr uni10CCD <40 0 40 0>;\012    pos uni10CD8.ltr uni10CCE <20 0 20 0>;\012    pos uni10CD8.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CD8.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CD8.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CD8.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CD8.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CD8.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CD8.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CD8.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CD8.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CD8.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CD8.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CD8.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CD8.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CD8.ltr uni10CEC <10 0 10 0>;\012    pos uni10CD8.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CD8.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CD8.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CD8.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CD8.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CD8.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CD8.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CD8.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CD8.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CD8.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CD8.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CD8.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CD8.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CD8.ltr uni10CF0.ltr <-60
+ 0 -60 0>;\012    pos uni10CD8.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CD9.ltr uni10CC2 <-30 0 -30 0>;\012    pos uni10CD9.ltr uni10CC4 <-10 0 -10 0>;\012    pos uni10CD9.ltr uni10CC9 <-30 0 -30 0>;\012    pos uni10CD9.ltr uni10CCD <-20 0 -20 0>;\012    pos uni10CD9.ltr uni10CCF <-20 0 -20 0>;\012    pos uni10CD9.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CD9.ltr uni10CD1 <-20 0 -20 0>;\012    pos uni10CD9.ltr uni10CD5 <-30 0 -30 0>;\012    pos uni10CD9.ltr uni10CD6 <-20 0 -20 0>;\012    pos uni10CD9.ltr uni10CD9 <-30 0 -30 0>;\012    pos uni10CD9.ltr uni10CE4 <-20 0 -20 0>;\012    pos uni10CD9.ltr uni10CE6 <-40 0 -40 0>;\012    pos uni10CD9.ltr uni10CE7 <-30 0 -30 0>;\012    pos uni10CD9.ltr uni10CE8 <-30 0 -30 0>;\012    pos uni10CD9.ltr uni10CE9 <-30 0 -30 0>;\012    pos uni10CD9.ltr uni10CF0 <-40 0 -40 0>;\012    pos uni10CD9.ltr uni10CC2.ltr <-30 0 -30 0>;\012    pos uni10CD9.ltr uni10CCD.ltr <-20 0 -20 0>;\012    pos uni10CD9.ltr uni10CD6.ltr <-20 0 -20 0>;\012    pos uni10CD9.ltr uni10CE4.ltr <-20 0 -20 0>;\012    pos uni10CD9.ltr uni10CE6.ltr <-40 0 -40 0>;\012    pos uni10CD9.ltr uni10CE8.ltr <-30 0 -30 0>;\012    pos uni10CD9.ltr uni10CE9.ltr <-30 0 -30 0>;\012    pos uni10CD9.ltr uni10CF0.ltr <-40 0 -40 0>;\012    pos uni10CDA.ltr uni10CC2 <-30 0 -30 0>;\012    pos uni10CDA.ltr uni10CC4 <-10 0 -10 0>;\012    pos uni10CDA.ltr uni10CC9 <-30 0 -30 0>;\012    pos uni10CDA.ltr uni10CCD <-20 0 -20 0>;\012    pos uni10CDA.ltr uni10CCF <-20 0 -20 0>;\012    pos uni10CDA.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CDA.ltr uni10CD1 <-20 0 -20 0>;\012    pos uni10CDA.ltr uni10CD5 <-30 0 -30 0>;\012    pos uni10CDA.ltr uni10CD6 <-20 0 -20 0>;\012    pos uni10CDA.ltr uni10CD9 <-30 0 -30 0>;\012    pos uni10CDA.ltr uni10CE4 <-20 0 -20 0>;\012    pos uni10CDA.ltr uni10CE6 <-40 0 -40 0>;\012    pos uni10CDA.ltr uni10CE7 <-30 0 -30 0>;\012    pos uni10CDA.ltr uni10CE8 <-30 0 -30 0>;\012    pos uni10CDA.ltr uni10CE9 <-30 0 -30 0>;\012    pos uni10CDA.ltr uni10CF0 <-40 0 -40 0>;\012    pos uni10CDA.ltr uni10CC2.ltr <-30 0 -30 0>;\012    pos uni10CDA.ltr uni10CCD.ltr <-20 0 -20 0>;\012    pos uni10CDA.ltr uni10CD6.ltr <-20 0 -20 0>;\012    pos uni10CDA.ltr uni10CE4.ltr <-20 0 -20 0>;\012    pos uni10CDA.ltr uni10CE6.ltr <-40 0 -40 0>;\012    pos uni10CDA.ltr uni10CE8.ltr <-30 0 -30 0>;\012    pos uni10CDA.ltr uni10CE9.ltr <-30 0 -30 0>;\012    pos uni10CDA.ltr uni10CF0.ltr <-40 0 -40 0>;\012    pos uni10CDB.ltr uni10CC2 <-30 0 -30 0>;\012    pos uni10CDB.ltr uni10CC4 <-10 0 -10 0>;\012    pos uni10CDB.ltr uni10CC9 <-30 0 -30 0>;\012    pos uni10CDB.ltr uni10CCD <-20 0 -20 0>;\012    pos uni10CDB.ltr uni10CCF <-20 0 -20 0>;\012    pos uni10CDB.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CDB.ltr uni10CD1 <-20 0 -20 0>;\012    pos uni10CDB.ltr uni10CD5 <-30 0 -30 0>;\012    pos uni10CDB.ltr uni10CD6 <-20 0 -20 0>;\012    pos uni10CDB.ltr uni10CD9 <-30 0 -30 0>;\012    pos uni10CDB.ltr uni10CE4 <-20 0 -20 0>;\012    pos uni10CDB.ltr uni10CE6 <-40 0 -40 0>;\012    pos uni10CDB.ltr uni10CE7 <-30 0 -30 0>;\012    pos uni10CDB.ltr uni10CE8 <-30 0 -30 0>;\012    pos uni10CDB.ltr uni10CE9 <-30 0 -30 0>;\012    pos uni10CDB.ltr uni10CF0 <-40 0 -40 0>;\012    pos uni10CDB.ltr uni10CC2.ltr <-30 0 -30 0>;\012    pos uni10CDB.ltr uni10CCD.ltr <-20 0 -20 0>;\012    pos uni10CDB.ltr uni10CD6.ltr <-20 0 -20 0>;\012    pos uni10CDB.ltr uni10CE4.ltr <-20 0 -20 0>;\012    pos uni10CDB.ltr uni10CE6.ltr <-40 0 -40 0>;\012    pos uni10CDB.ltr uni10CE8.ltr <-30 0 -30 0>;\012    pos uni10CDB.ltr uni10CE9.ltr <-30 0 -30 0>;\012    pos uni10CDB.ltr uni10CF0.ltr <-40 0 -40 0>;\012    pos uni10CDC.ltr uni10CC2 <-30 0 -30 0>;\012    pos uni10CDC.ltr uni10CC4 <-10 0 -10 0>;\012    pos uni10CDC.ltr uni10CC9 <-30 0 -30 0>;\012    pos uni10CDC.ltr uni10CCD <-20 0 -20 0>;\012    pos uni10CDC.ltr uni10CCF <-20 0 -20 0>;\012    pos uni10CDC.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CDC.ltr uni10CD1 <-20 0 -20 0>;\012    pos uni10CDC.ltr uni10CD5 <-30 0 -30 0>;\012    pos uni10CDC.ltr uni10CD6 <-20 0 -20 0>;\012    pos uni10CDC.ltr uni10CD9 <-30 0 -30 0>;\012    pos uni10CDC.ltr uni10CE4 <-20 0 -20 0>;\012    pos uni10CDC.ltr uni10CE6 <-40 0 -40 0>;\012    pos uni10CDC.ltr uni10CE7 <-30 0 -30 0>;\012    pos uni10CDC.ltr uni10CE8 <-30 0 -30 0>;\012    pos uni10CDC.ltr uni10CE9 <-30 0 -30 0>;\012    pos uni10CDC.ltr uni10CF0 <-40 0 -40 0>;\012    pos uni10CDC.ltr uni10CC2.ltr <-30 0 -30 0>;\012    pos uni10CDC.ltr uni10CCD.ltr <-20 0 -20 0>;\012    pos uni10CDC.ltr uni10CD6.ltr <-20 0 -20 0>;\012    pos uni10CDC.ltr uni10CE4.ltr <-20 0 -20 0>;\012    pos uni10CDC.ltr uni10CE6.ltr <-40 0 -40 0>;\012    pos uni10CDC.ltr uni10CE8.ltr <-30 0 -30 0>;\012    pos uni10CDC.ltr uni10CE9.ltr <-30 0 -30 0>;\012    pos uni10CDC.ltr uni10CF0.ltr <-40 0 -40 0>;\012    pos uni10CDD.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CDD.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CDD.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CDD.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CDD.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CDD.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CDD.ltr uni10CCB <10 0 10 0>;\012    pos uni10CDD.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CDD.ltr uni10CCD <40 0 40 0>;\012    pos uni10CDD.ltr uni10CCE <20 0 20 0>;\012    pos uni10CDD.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CDD.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CDD.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CDD.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CDD.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CDD.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CDD.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CDD.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CDD.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CDD.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CDD.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CDD.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CDD.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CDD.ltr uni10CEC <10 0 10 0>;\012    pos uni10CDD.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CDD.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CDD.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CDD.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CDD.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CDD.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CDD.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CDD.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CDD.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CDD.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CDD.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CDD.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CDD.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CDD.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CDD.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CDE.ltr uni10CC0 <-10 0 -10 0>;\012    pos uni10CDE.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CDE.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CDE.ltr uni10CC3 <10 0 10 0>;\012    pos uni10CDE.ltr uni10CCC <-20 0 -20 0>;\012    pos uni10CDE.ltr uni10CD2 <-10 0 -10 0>;\012    pos uni10CDE.ltr uni10CD7 <-20 0 -20 0>;\012    pos uni10CDE.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CDE.ltr uni10CE3 <-40 0 -40 0>;\012    pos uni10CDE.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CDE.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CDE.ltr uni10CEC <20 0 20 0>;\012    pos uni10CDE.ltr uni10CF2 <-20 0 -20 0>;\012    pos uni10CDE.ltr uni10CC0.ltr <-10 0 -10 0>;\012    pos uni10CDE.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CDE.ltr uni10CCC.ltr <-20 0 -20 0>;\012    pos uni10CDE.ltr uni10CD7.ltr <-20 0 -20 0>;\012    pos uni10CDE.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CDE.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CDE.ltr uni10CF2.ltr <-20 0 -20 0>;\012    pos uni10CDF.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CDF.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CDF.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CDF.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CDF.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CDF.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CDF.ltr uni10CCB <10 0 10 0>;\012    pos uni10CDF.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CDF.ltr uni10CCD <40 0 40 0>;\012    pos uni10CDF.ltr uni10CCE <20 0 20 0>;\012    pos uni10CDF.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CDF.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CDF.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CDF.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CDF.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CDF.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CDF.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CDF.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CDF.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CDF.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CDF.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CDF.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CDF.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CDF.ltr uni10CEC <10 0 10 0>;\012    pos uni10CDF.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CDF.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CDF.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CDF.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CDF.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CDF.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CDF.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CDF.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CDF.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CDF.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CDF.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CDF.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CDF.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CDF.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CDF.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CE0.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CE0.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CE0.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CE0.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CE0.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CE0.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CE0.ltr uni10CCB <10 0 10 0>;\012    pos uni10CE0.ltr
+ uni10CCC <-10 0 -10 0>;\012    pos uni10CE0.ltr uni10CCD <40 0 40 0>;\012    pos uni10CE0.ltr uni10CCE <20 0 20 0>;\012    pos uni10CE0.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CE0.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CE0.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CE0.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CE0.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CE0.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CE0.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CE0.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CE0.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CE0.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CE0.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CE0.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CE0.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CE0.ltr uni10CEC <10 0 10 0>;\012    pos uni10CE0.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CE0.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CE0.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CE0.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CE0.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CE0.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CE0.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CE0.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CE0.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CE0.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CE0.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CE0.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CE0.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CE0.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CE0.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CE1.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CE1.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CE1.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CE1.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CE1.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CE1.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CE1.ltr uni10CCB <10 0 10 0>;\012    pos uni10CE1.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CE1.ltr uni10CCD <40 0 40 0>;\012    pos uni10CE1.ltr uni10CCE <20 0 20 0>;\012    pos uni10CE1.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CE1.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CE1.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CE1.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CE1.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CE1.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CE1.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CE1.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CE1.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CE1.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CE1.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CE1.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CE1.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CE1.ltr uni10CEC <10 0 10 0>;\012    pos uni10CE1.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CE1.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CE1.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CE1.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CE1.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CE1.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CE1.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CE1.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CE1.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CE1.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CE1.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CE1.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CE1.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CE1.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CE1.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CE2.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CE2.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CE2.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CE2.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CE2.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CE2.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CE2.ltr uni10CCB <10 0 10 0>;\012    pos uni10CE2.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CE2.ltr uni10CCD <40 0 40 0>;\012    pos uni10CE2.ltr uni10CCE <20 0 20 0>;\012    pos uni10CE2.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CE2.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CE2.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CE2.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CE2.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CE2.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CE2.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CE2.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CE2.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CE2.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CE2.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CE2.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CE2.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CE2.ltr uni10CEC <10 0 10 0>;\012    pos uni10CE2.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CE2.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CE2.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CE2.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CE2.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CE2.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CE2.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CE2.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CE2.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CE2.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CE2.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CE2.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CE2.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CE2.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CE2.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CE3.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CE3.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CE3.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CE3.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CE3.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CE3.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CE3.ltr uni10CCB <10 0 10 0>;\012    pos uni10CE3.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CE3.ltr uni10CCD <40 0 40 0>;\012    pos uni10CE3.ltr uni10CCE <20 0 20 0>;\012    pos uni10CE3.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CE3.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CE3.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CE3.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CE3.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CE3.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CE3.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CE3.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CE3.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CE3.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CE3.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CE3.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CE3.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CE3.ltr uni10CEC <10 0 10 0>;\012    pos uni10CE3.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CE3.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CE3.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CE3.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CE3.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CE3.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CE3.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CE3.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CE3.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CE3.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CE3.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CE3.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CE3.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CE3.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CE3.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CE4.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CE4.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CE4.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CE4.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CE4.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CE4.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CE4.ltr uni10CCB <10 0 10 0>;\012    pos uni10CE4.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CE4.ltr uni10CCD <40 0 40 0>;\012    pos uni10CE4.ltr uni10CCE <20 0 20 0>;\012    pos uni10CE4.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CE4.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CE4.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CE4.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CE4.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CE4.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CE4.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CE4.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CE4.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CE4.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CE4.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CE4.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CE4.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CE4.ltr uni10CEC <10 0 10 0>;\012    pos uni10CE4.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CE4.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CE4.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CE4.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CE4.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CE4.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CE4.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CE4.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CE4.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CE4.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CE4.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CE4.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CE4.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CE4.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CE4.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CE5.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CE5.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CE5.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CE5.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CE5.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CE5.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CE5.ltr uni10CCB <10 0 10 0>;\012    pos uni10CE5.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CE5.ltr uni10CCD <40 0 40 0>;\012    pos uni10CE5.ltr uni10CCE <20 0 20 0>;\012    pos uni10CE5.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CE5.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CE5.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CE5.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CE5.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CE5.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CE5.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CE5.ltr
+ uni10CE3 <-30 0 -30 0>;\012    pos uni10CE5.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CE5.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CE5.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CE5.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CE5.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CE5.ltr uni10CEC <10 0 10 0>;\012    pos uni10CE5.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CE5.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CE5.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CE5.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CE5.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CE5.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CE5.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CE5.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CE5.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CE5.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CE5.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CE5.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CE5.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CE5.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CE5.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CE6.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CE6.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CE6.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CE6.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CE6.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CE6.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CE6.ltr uni10CCB <10 0 10 0>;\012    pos uni10CE6.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CE6.ltr uni10CCD <40 0 40 0>;\012    pos uni10CE6.ltr uni10CCE <20 0 20 0>;\012    pos uni10CE6.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CE6.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CE6.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CE6.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CE6.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CE6.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CE6.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CE6.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CE6.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CE6.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CE6.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CE6.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CE6.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CE6.ltr uni10CEC <10 0 10 0>;\012    pos uni10CE6.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CE6.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CE6.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CE6.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CE6.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CE6.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CE6.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CE6.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CE6.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CE6.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CE6.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CE6.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CE6.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CE6.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CE6.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CE7.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CE7.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CE7.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CE7.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CE7.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CE7.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CE7.ltr uni10CCB <10 0 10 0>;\012    pos uni10CE7.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CE7.ltr uni10CCD <40 0 40 0>;\012    pos uni10CE7.ltr uni10CCE <20 0 20 0>;\012    pos uni10CE7.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CE7.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CE7.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CE7.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CE7.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CE7.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CE7.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CE7.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CE7.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CE7.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CE7.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CE7.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CE7.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CE7.ltr uni10CEC <10 0 10 0>;\012    pos uni10CE7.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CE7.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CE7.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CE7.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CE7.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CE7.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CE7.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CE7.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CE7.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CE7.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CE7.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CE7.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CE7.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CE7.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CE7.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CE8.ltr uni10CC0 <-10 0 -10 0>;\012    pos uni10CE8.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CE8.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CE8.ltr uni10CC3 <10 0 10 0>;\012    pos uni10CE8.ltr uni10CCC <-20 0 -20 0>;\012    pos uni10CE8.ltr uni10CD2 <-10 0 -10 0>;\012    pos uni10CE8.ltr uni10CD7 <-20 0 -20 0>;\012    pos uni10CE8.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CE8.ltr uni10CE3 <-40 0 -40 0>;\012    pos uni10CE8.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CE8.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CE8.ltr uni10CEC <20 0 20 0>;\012    pos uni10CE8.ltr uni10CF2 <-20 0 -20 0>;\012    pos uni10CE8.ltr uni10CC0.ltr <-10 0 -10 0>;\012    pos uni10CE8.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CE8.ltr uni10CCC.ltr <-20 0 -20 0>;\012    pos uni10CE8.ltr uni10CD7.ltr <-20 0 -20 0>;\012    pos uni10CE8.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CE8.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CE8.ltr uni10CF2.ltr <-20 0 -20 0>;\012    pos uni10CE9.ltr uni10CC0 <-10 0 -10 0>;\012    pos uni10CE9.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CE9.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CE9.ltr uni10CC3 <10 0 10 0>;\012    pos uni10CE9.ltr uni10CCC <-20 0 -20 0>;\012    pos uni10CE9.ltr uni10CD2 <-10 0 -10 0>;\012    pos uni10CE9.ltr uni10CD7 <-20 0 -20 0>;\012    pos uni10CE9.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CE9.ltr uni10CE3 <-40 0 -40 0>;\012    pos uni10CE9.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CE9.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CE9.ltr uni10CEC <20 0 20 0>;\012    pos uni10CE9.ltr uni10CF2 <-20 0 -20 0>;\012    pos uni10CE9.ltr uni10CC0.ltr <-10 0 -10 0>;\012    pos uni10CE9.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CE9.ltr uni10CCC.ltr <-20 0 -20 0>;\012    pos uni10CE9.ltr uni10CD7.ltr <-20 0 -20 0>;\012    pos uni10CE9.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CE9.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CE9.ltr uni10CF2.ltr <-20 0 -20 0>;\012    pos uni10CEA.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CEA.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CEA.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CEA.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CEA.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CEA.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CEA.ltr uni10CCB <10 0 10 0>;\012    pos uni10CEA.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CEA.ltr uni10CCD <40 0 40 0>;\012    pos uni10CEA.ltr uni10CCE <20 0 20 0>;\012    pos uni10CEA.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CEA.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CEA.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CEA.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CEA.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CEA.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CEA.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CEA.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CEA.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CEA.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CEA.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CEA.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CEA.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CEA.ltr uni10CEC <10 0 10 0>;\012    pos uni10CEA.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CEA.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CEA.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CEA.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CEA.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CEA.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CEA.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CEA.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CEA.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CEA.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CEA.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CEA.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CEA.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CEA.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CEA.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CEB.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CEB.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CEB.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CEB.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CEB.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CEB.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CEB.ltr uni10CCB <10 0 10 0>;\012    pos uni10CEB.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CEB.ltr uni10CCD <40 0 40 0>;\012    pos uni10CEB.ltr uni10CCE <20 0 20 0>;\012    pos uni10CEB.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CEB.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CEB.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CEB.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CEB.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CEB.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CEB.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CEB.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CEB.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CEB.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CEB.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CEB.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CEB.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CEB.ltr uni10CEC <10 0 10 0>;\012    pos uni10CEB.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CEB.ltr uni10CF0 <-60 0 -60 0>;\012    pos
+ uni10CEB.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CEB.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CEB.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CEB.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CEB.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CEB.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CEB.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CEB.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CEB.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CEB.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CEB.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CEB.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CEB.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CEC.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CEC.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CEC.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CEC.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CEC.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CEC.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CEC.ltr uni10CCB <10 0 10 0>;\012    pos uni10CEC.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CEC.ltr uni10CCD <40 0 40 0>;\012    pos uni10CEC.ltr uni10CCE <20 0 20 0>;\012    pos uni10CEC.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CEC.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CEC.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CEC.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CEC.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CEC.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CEC.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CEC.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CEC.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CEC.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CEC.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CEC.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CEC.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CEC.ltr uni10CEC <10 0 10 0>;\012    pos uni10CEC.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CEC.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CEC.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CEC.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CEC.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CEC.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CEC.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CEC.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CEC.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CEC.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CEC.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CEC.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CEC.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CEC.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CEC.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CED.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CED.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CED.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CED.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CED.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CED.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CED.ltr uni10CCB <10 0 10 0>;\012    pos uni10CED.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CED.ltr uni10CCD <40 0 40 0>;\012    pos uni10CED.ltr uni10CCE <20 0 20 0>;\012    pos uni10CED.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CED.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CED.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CED.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CED.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CED.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CED.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CED.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CED.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CED.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CED.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CED.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CED.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CED.ltr uni10CEC <10 0 10 0>;\012    pos uni10CED.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CED.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CED.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CED.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CED.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CED.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CED.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CED.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CED.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CED.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CED.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CED.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CED.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CED.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CED.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CEE.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CEE.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CEE.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CEE.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CEE.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CEE.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CEE.ltr uni10CCB <10 0 10 0>;\012    pos uni10CEE.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CEE.ltr uni10CCD <40 0 40 0>;\012    pos uni10CEE.ltr uni10CCE <20 0 20 0>;\012    pos uni10CEE.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CEE.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CEE.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CEE.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CEE.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CEE.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CEE.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CEE.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CEE.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CEE.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CEE.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CEE.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CEE.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CEE.ltr uni10CEC <10 0 10 0>;\012    pos uni10CEE.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CEE.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CEE.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CEE.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CEE.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CEE.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CEE.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CEE.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CEE.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CEE.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CEE.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CEE.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CEE.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CEE.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CEE.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CEF.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CEF.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CEF.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CEF.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CEF.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CEF.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CEF.ltr uni10CCB <10 0 10 0>;\012    pos uni10CEF.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CEF.ltr uni10CCD <40 0 40 0>;\012    pos uni10CEF.ltr uni10CCE <20 0 20 0>;\012    pos uni10CEF.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CEF.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CEF.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CEF.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CEF.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CEF.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CEF.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CEF.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CEF.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CEF.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CEF.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CEF.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CEF.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CEF.ltr uni10CEC <10 0 10 0>;\012    pos uni10CEF.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CEF.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CEF.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CEF.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CEF.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CEF.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CEF.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CEF.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CEF.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CEF.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CEF.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CEF.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CEF.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CEF.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CEF.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CF0.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CF0.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CF0.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CF0.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CF0.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CF0.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CF0.ltr uni10CCB <10 0 10 0>;\012    pos uni10CF0.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CF0.ltr uni10CCD <40 0 40 0>;\012    pos uni10CF0.ltr uni10CCE <20 0 20 0>;\012    pos uni10CF0.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CF0.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CF0.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CF0.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CF0.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CF0.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CF0.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CF0.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CF0.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CF0.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CF0.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CF0.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CF0.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CF0.ltr uni10CEC <10 0 10 0>;\012    pos uni10CF0.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CF0.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CF0.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CF0.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CF0.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CF0.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CF0.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CF0.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CF0.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CF0.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CF0.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CF0.ltr
+ uni10CE8.ltr <20 0 20 0>;\012    pos uni10CF0.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CF0.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CF0.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CF1.ltr uni10CC0 <-40 0 -40 0>;\012    pos uni10CF1.ltr uni10CC1 <-30 0 -30 0>;\012    pos uni10CF1.ltr uni10CC2 <20 0 20 0>;\012    pos uni10CF1.ltr uni10CC4 <-30 0 -30 0>;\012    pos uni10CF1.ltr uni10CC7 <-10 0 -10 0>;\012    pos uni10CF1.ltr uni10CC9 <-20 0 -20 0>;\012    pos uni10CF1.ltr uni10CCB <10 0 10 0>;\012    pos uni10CF1.ltr uni10CCC <-10 0 -10 0>;\012    pos uni10CF1.ltr uni10CCD <40 0 40 0>;\012    pos uni10CF1.ltr uni10CCE <20 0 20 0>;\012    pos uni10CF1.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CF1.ltr uni10CD1 <-50 0 -50 0>;\012    pos uni10CF1.ltr uni10CD2 <-30 0 -30 0>;\012    pos uni10CF1.ltr uni10CD4 <-40 0 -40 0>;\012    pos uni10CF1.ltr uni10CD6 <40 0 40 0>;\012    pos uni10CF1.ltr uni10CD7 <-10 0 -10 0>;\012    pos uni10CF1.ltr uni10CD9 <20 0 20 0>;\012    pos uni10CF1.ltr uni10CE3 <-30 0 -30 0>;\012    pos uni10CF1.ltr uni10CE4 <40 0 40 0>;\012    pos uni10CF1.ltr uni10CE6 <-60 0 -60 0>;\012    pos uni10CF1.ltr uni10CE7 <-80 0 -80 0>;\012    pos uni10CF1.ltr uni10CE8 <20 0 20 0>;\012    pos uni10CF1.ltr uni10CE9 <20 0 20 0>;\012    pos uni10CF1.ltr uni10CEC <10 0 10 0>;\012    pos uni10CF1.ltr uni10CED <-40 0 -40 0>;\012    pos uni10CF1.ltr uni10CF0 <-60 0 -60 0>;\012    pos uni10CF1.ltr uni10CF2 <-10 0 -10 0>;\012    pos uni10CF1.ltr uni10CC0.ltr <-40 0 -40 0>;\012    pos uni10CF1.ltr uni10CC2.ltr <20 0 20 0>;\012    pos uni10CF1.ltr uni10CCC.ltr <-10 0 -10 0>;\012    pos uni10CF1.ltr uni10CCD.ltr <40 0 40 0>;\012    pos uni10CF1.ltr uni10CD6.ltr <40 0 40 0>;\012    pos uni10CF1.ltr uni10CD7.ltr <-10 0 -10 0>;\012    pos uni10CF1.ltr uni10CE4.ltr <40 0 40 0>;\012    pos uni10CF1.ltr uni10CE6.ltr <-60 0 -60 0>;\012    pos uni10CF1.ltr uni10CE8.ltr <20 0 20 0>;\012    pos uni10CF1.ltr uni10CE9.ltr <20 0 20 0>;\012    pos uni10CF1.ltr uni10CF0.ltr <-60 0 -60 0>;\012    pos uni10CF1.ltr uni10CF2.ltr <-10 0 -10 0>;\012    pos uni10CF2.ltr uni10CC2 <-30 0 -30 0>;\012    pos uni10CF2.ltr uni10CC4 <-10 0 -10 0>;\012    pos uni10CF2.ltr uni10CC9 <-30 0 -30 0>;\012    pos uni10CF2.ltr uni10CCD <-20 0 -20 0>;\012    pos uni10CF2.ltr uni10CCF <-20 0 -20 0>;\012    pos uni10CF2.ltr uni10CD0 <-30 0 -30 0>;\012    pos uni10CF2.ltr uni10CD1 <-20 0 -20 0>;\012    pos uni10CF2.ltr uni10CD5 <-30 0 -30 0>;\012    pos uni10CF2.ltr uni10CD6 <-20 0 -20 0>;\012    pos uni10CF2.ltr uni10CD9 <-30 0 -30 0>;\012    pos uni10CF2.ltr uni10CE4 <-20 0 -20 0>;\012    pos uni10CF2.ltr uni10CE6 <-40 0 -40 0>;\012    pos uni10CF2.ltr uni10CE7 <-30 0 -30 0>;\012    pos uni10CF2.ltr uni10CE8 <-30 0 -30 0>;\012    pos uni10CF2.ltr uni10CE9 <-30 0 -30 0>;\012    pos uni10CF2.ltr uni10CF0 <-40 0 -40 0>;\012    pos uni10CF2.ltr uni10CC2.ltr <-30 0 -30 0>;\012    pos uni10CF2.ltr uni10CCD.ltr <-20 0 -20 0>;\012    pos uni10CF2.ltr uni10CD6.ltr <-20 0 -20 0>;\012    pos uni10CF2.ltr uni10CE4.ltr <-20 0 -20 0>;\012    pos uni10CF2.ltr uni10CE6.ltr <-40 0 -40 0>;\012    pos uni10CF2.ltr uni10CE8.ltr <-30 0 -30 0>;\012    pos uni10CF2.ltr uni10CE9.ltr <-30 0 -30 0>;\012    pos uni10CF2.ltr uni10CF0.ltr <-40 0 -40 0>;\012  } kern_1;";
+name = kern;
+}
+);
+fontMaster = (
+{
+ascender = 859;
+capHeight = 714;
+customParameters = (
+{
+name = typoAscender;
+value = 859;
+},
+{
+name = typoDescender;
+value = -177;
+},
+{
+name = typoLineGap;
+value = 0;
+},
+{
+name = winAscent;
+value = 859;
+},
+{
+name = winDescent;
+value = 177;
+},
+{
+name = underlineThickness;
+value = 50;
+},
+{
+name = underlinePosition;
+value = -100;
+},
+{
+name = strikeoutPosition;
+value = 360;
+},
+{
+name = strikeoutSize;
+value = 50;
+},
+{
+name = subscriptXOffset;
+value = 0;
+},
+{
+name = subscriptXSize;
+value = 650;
+},
+{
+name = subscriptYOffset;
+value = 75;
+},
+{
+name = subscriptYSize;
+value = 600;
+},
+{
+name = superscriptXOffset;
+value = 0;
+},
+{
+name = superscriptXSize;
+value = 650;
+},
+{
+name = superscriptYOffset;
+value = 350;
+},
+{
+name = superscriptYSize;
+value = 600;
+}
+);
+descender = -177;
+guideLines = (
+{
+position = "{0, 250}";
+}
+);
+id = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+weight = Regular;
+widthValue = 100;
+weightValue = 100;
+xHeight = 600;
+}
+);
+glyphs = (
+{
+glyphname = .notdef;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"94 0 LINE",
+"94 714 LINE",
+"505 714 LINE",
+"505 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"145 51 LINE",
+"454 51 LINE",
+"454 663 LINE",
+"145 663 LINE"
+);
+}
+);
+width = 600;
+}
+);
+},
+{
+glyphname = NULL;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+width = 0;
+}
+);
+},
+{
+glyphname = CR;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+width = 333;
+}
+);
+},
+{
+glyphname = NULL.1;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+width = 0;
+}
+);
+unicode = 0000;
+},
+{
+glyphname = CR.1;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+width = 260;
+}
+);
+unicode = 000D;
+},
+{
+glyphname = space;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+width = 260;
+}
+);
+unicode = 0020;
+},
+{
+glyphname = uni10C80;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"310 -135 LINE",
+"310 339 LINE",
+"10 371 LINE",
+"10 476 LINE",
+"303 714 LINE",
+"400 714 LINE",
+"400 -135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"310 422 LINE",
+"310 619 LINE",
+"92 442 LINE"
+);
+}
+);
+width = 529;
+}
+);
+unicode = 10C80;
+},
+{
+glyphname = uni10C81;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"310 -135 LINE",
+"310 117 LINE",
+"23 362 LINE",
+"23 438 LINE",
+"307 714 LINE",
+"400 714 LINE",
+"400 -135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"310 232 LINE",
+"310 609 LINE",
+"107 401 LINE"
+);
+}
+);
+width = 529;
+}
+);
+unicode = 10C81;
+},
+{
+glyphname = uni10C82;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"4 -135 LINE",
+"286 308 LINE",
+"22 714 LINE",
+"132 714 LINE",
+"346 374 LINE",
+"563 714 LINE",
+"667 714 LINE",
+"404 310 LINE",
+"687 -135 LINE",
+"575 -135 LINE",
+"343 240 LINE",
+"108 -135 LINE"
+);
+}
+);
+width = 691;
+}
+);
+unicode = 10C82;
+},
+{
+glyphname = uni10C83;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"464 -135 LINE",
+"429 -107 OFFCURVE",
+"367 -51 OFFCURVE",
+"341 -23 QCURVE",
+"251 -134 LINE",
+"55 -46 LINE",
+"85 29 LINE",
+"226 -39 LINE",
+"288 44 LINE",
+"251 98 OFFCURVE",
+"211 219 OFFCURVE",
+"211 289 QCURVE SMOOTH",
+"211 360 OFFCURVE",
+"251 481 OFFCURVE",
+"288 536 QCURVE",
+"226 618 LINE",
+"85 550 LINE",
+"55 626 LINE",
+"251 713 LINE",
+"341 602 LINE",
+"367 631 OFFCURVE",
+"429 687 OFFCURVE",
+"463 714 QCURVE",
+"557 714 LINE",
+"592 687 OFFCURVE",
+"652 633 OFFCURVE",
+"678 604 QCURVE",
+"765 713 LINE",
+"963 626 LINE",
+"931 550 LINE",
+"791 618 LINE",
+"731 538 LINE",
+"769 483 OFFCURVE",
+"809 360 OFFCURVE",
+"809 289 QCURVE SMOOTH",
+"809 218 OFFCURVE",
+"769 96 OFFCURVE",
+"731 41 QCURVE",
+"791 -39 LINE",
+"931 29 LINE",
+"963 -46 LINE",
+"765 -134 LINE",
+"678 -25 LINE",
+"652 -53 OFFCURVE",
+"592 -108 OFFCURVE",
+"557 -135 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"512 -63 LINE",
+"581 -3 OFFCURVE",
+"671 104 OFFCURVE",
+"716 219 OFFCURVE",
+"716 289 QCURVE SMOOTH",
+"716 360 OFFCURVE",
+"671 475 OFFCURVE",
+"581 583 OFFCURVE",
+"512 643 QCURVE",
+"508 643 LINE",
+"440 583 OFFCURVE",
+"349 475 OFFCURVE",
+"304 360 OFFCURVE",
+"304 289 QCURVE SMOOTH",
+"304 219 OFFCURVE",
+"349 104 OFFCURVE",
+"440 -3 OFFCURVE",
+"508 -63 QCURVE"
+);
+}
+);
+width = 1018;
+}
+);
+unicode = 10C83;
+},
+{
+glyphname = uni10C84;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"265 -135 LINE",
+"265 590 LINE",
+"83 427 LINE",
+"24 491 LINE",
+"273 714 LINE",
+"347 714 LINE",
+"596 491 LINE",
+"537 427 LINE",
+"355 590 LINE",
+"355 -135 LINE"
+);
+}
+);
+width = 620;
+}
+);
+unicode = 10C84;
+},
+{
+glyphname = uni10C85;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"273 -135 LINE",
+"24 88 LINE",
+"83 152 LINE",
+"265 -11 LINE",
+"265 590 LINE",
+"83 427 LINE",
+"31 491 LINE",
+"273 714 LINE",
+"347 714 LINE",
+"589 491 LINE",
+"537 427 LINE",
+"355 590 LINE",
+"355 -11 LINE",
+"537 152 LINE",
+"596 88 LINE",
+"347 -135 LINE"
+);
+}
+);
+width = 620;
+}
+);
+unicode = 10C85;
+},
+{
+glyphname = uni10C86;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"124 -135 LINE",
+"124 714 LINE",
+"214 714 LINE",
+"214 456 LINE",
+"621 714 LINE",
+"708 714 LINE",
+"708 -135 LINE",
+"618 -135 LINE",
+"618 124 LINE",
+"211 -135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"214 -30 LINE",
+"618 221 LINE",
+"618 614 LINE",
+"214 357 LINE"
+);
+}
+);
+width = 832;
+}
+);
+unicode = 10C86;
+},
+{
+glyphname = uni10C87;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"265 -135 LINE",
+"265 236 LINE",
+"96 144 LINE",
+"57 216 LINE",
+"265 327 LINE",
+"265 714 LINE",
+"361 714 LINE",
+"361 377 LINE",
+"530 472 LINE",
+"569 398 LINE",
+"361 285 LINE",
+"361 -135 LINE"
+);
+}
+);
+width = 627;
+}
+);
+unicode = 10C87;
+},
+{
+glyphname = uni10C88;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"4 -135 LINE",
+"245 244 LINE",
+"54 187 LINE",
+"30 254 LINE",
+"274 326 LINE",
+"22 714 LINE",
+"132 714 LINE",
+"346 374 LINE",
+"563 714 LINE",
+"667 714 LINE",
+"448 378 LINE",
+"636 434 LINE",
+"652 364 LINE",
+"414 294 LINE",
+"687 -135 LINE",
+"575 -135 LINE",
+"343 240 LINE",
+"108 -135 LINE"
+);
+}
+);
+width = 691;
+}
+);
+unicode = 10C88;
+},
+{
+glyphname = uni10C89;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"86 -88 LINE",
+"129 -61 OFFCURVE",
+"200 -11 OFFCURVE",
+"228 13 QCURVE",
+"98 125 LINE",
+"153 184 LINE",
+"287 68 LINE",
+"334 119 OFFCURVE",
+"374 225 OFFCURVE",
+"374 289 QCURVE SMOOTH",
+"374 354 OFFCURVE",
+"333 459 OFFCURVE",
+"283 512 QCURVE",
+"153 399 LINE",
+"98 459 LINE",
+"224 567 LINE",
+"195 591 OFFCURVE",
+"124 643 OFFCURVE",
+"81 671 QCURVE",
+"142 738 LINE",
+"187 709 OFFCURVE",
+"262 654 OFFCURVE",
+"293 627 QCURVE",
+"418 735 LINE",
+"467 672 LINE",
+"352 572 LINE",
+"415 505 OFFCURVE",
+"468 370 OFFCURVE",
+"468 289 QCURVE SMOOTH",
+"468 209 OFFCURVE",
+"416 75 OFFCURVE",
+"354 10 QCURVE",
+"467 -88 LINE",
+"418 -151 LINE",
+"295 -45 LINE",
+"263 -72 OFFCURVE",
+"184 -129 OFFCURVE",
+"137 -159 QCURVE"
+);
+}
+);
+width = 563;
+}
+);
+unicode = 10C89;
+},
+{
+glyphname = uni10C8A;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"98 -88 LINE",
+"136 -64 OFFCURVE",
+"200 -20 OFFCURVE",
+"227 1 QCURVE",
+"160 69 OFFCURVE",
+"102 207 OFFCURVE",
+"102 289 QCURVE SMOOTH",
+"102 371 OFFCURVE",
+"159 509 OFFCURVE",
+"226 576 QCURVE",
+"198 599 OFFCURVE",
+"132 646 OFFCURVE",
+"93 671 QCURVE",
+"154 738 LINE",
+"236 685 OFFCURVE",
+"293 638 QCURVE",
+"350 685 OFFCURVE",
+"432 738 QCURVE",
+"493 671 LINE",
+"454 646 OFFCURVE",
+"388 599 OFFCURVE",
+"361 577 QCURVE",
+"427 509 OFFCURVE",
+"484 372 OFFCURVE",
+"484 289 QCURVE SMOOTH",
+"484 207 OFFCURVE",
+"427 69 OFFCURVE",
+"359 1 QCURVE",
+"386 -20 OFFCURVE",
+"451 -64 OFFCURVE",
+"488 -88 QCURVE",
+"436 -159 LINE",
+"395 -132 OFFCURVE",
+"323 -82 OFFCURVE",
+"293 -58 QCURVE",
+"263 -82 OFFCURVE",
+"191 -132 OFFCURVE",
+"150 -159 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"345 113 OFFCURVE",
+"390 223 OFFCURVE",
+"390 289 QCURVE SMOOTH",
+"390 355 OFFCURVE",
+"346 462 OFFCURVE",
+"293 516 QCURVE",
+"240 462 OFFCURVE",
+"196 355 OFFCURVE",
+"196 289 QCURVE SMOOTH",
+"196 223 OFFCURVE",
+"241 113 OFFCURVE",
+"293 60 QCURVE"
+);
+}
+);
+width = 586;
+}
+);
+unicode = 10C8A;
+},
+{
+glyphname = uni10C8B;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"280 -174 LINE",
+"88 -7 LINE",
+"174 44 OFFCURVE",
+"283 136 OFFCURVE",
+"336 231 OFFCURVE",
+"336 289 QCURVE SMOOTH",
+"336 348 OFFCURVE",
+"284 443 OFFCURVE",
+"174 534 OFFCURVE",
+"88 586 QCURVE",
+"280 752 LINE",
+"338 684 LINE",
+"231 595 LINE",
+"337 522 OFFCURVE",
+"430 379 OFFCURVE",
+"430 289 QCURVE SMOOTH",
+"430 201 OFFCURVE",
+"337 58 OFFCURVE",
+"231 -16 QCURVE",
+"338 -105 LINE"
+);
+}
+);
+width = 512;
+}
+);
+unicode = 10C8B;
+},
+{
+glyphname = uni10C8C;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"338 -135 LINE",
+"258 -73 OFFCURVE",
+"143 55 OFFCURVE",
+"81 201 OFFCURVE",
+"81 289 QCURVE SMOOTH",
+"81 378 OFFCURVE",
+"143 524 OFFCURVE",
+"258 653 OFFCURVE",
+"337 714 QCURVE",
+"431 714 LINE",
+"511 653 OFFCURVE",
+"625 524 OFFCURVE",
+"687 378 OFFCURVE",
+"687 289 QCURVE SMOOTH",
+"687 201 OFFCURVE",
+"625 55 OFFCURVE",
+"511 -73 OFFCURVE",
+"431 -135 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"386 342 LINE",
+"522 505 LINE",
+"497 539 OFFCURVE",
+"430 606 OFFCURVE",
+"386 643 QCURVE",
+"382 643 LINE",
+"296 571 OFFCURVE",
+"247 507 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"339 287 LINE",
+"209 445 LINE",
+"174 375 OFFCURVE",
+"174 289 QCURVE SMOOTH",
+"174 245 OFFCURVE",
+"192 168 OFFCURVE",
+"210 132 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"560 135 LINE",
+"594 204 OFFCURVE",
+"594 289 QCURVE SMOOTH",
+"594 374 OFFCURVE",
+"560 442 QCURVE",
+"432 287 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"386 -63 LINE",
+"428 -28 OFFCURVE",
+"494 38 OFFCURVE",
+"519 71 QCURVE",
+"386 231 LINE",
+"251 68 LINE",
+"276 37 OFFCURVE",
+"341 -28 OFFCURVE",
+"382 -63 QCURVE"
+);
+}
+);
+width = 769;
+}
+);
+unicode = 10C8C;
+},
+{
+glyphname = uni10C8D;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"21 -135 LINE",
+"360 714 LINE",
+"447 714 LINE",
+"780 -135 LINE",
+"681 -135 LINE",
+"524 269 LINE",
+"380 -135 LINE",
+"286 -135 LINE",
+"480 383 LINE",
+"468 413 LINE SMOOTH",
+"447 467 OFFCURVE",
+"414 560 OFFCURVE",
+"403 602 QCURVE",
+"399 602 LINE",
+"389 560 OFFCURVE",
+"354 465 OFFCURVE",
+"333 411 QCURVE SMOOTH",
+"121 -135 LINE"
+);
+}
+);
+width = 801;
+}
+);
+unicode = 10C8D;
+},
+{
+glyphname = uni10C8E;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"265 -135 LINE",
+"265 80 LINE",
+"96 -11 LINE",
+"57 61 LINE",
+"265 174 LINE",
+"265 337 LINE",
+"96 246 LINE",
+"57 318 LINE",
+"265 431 LINE",
+"265 714 LINE",
+"361 714 LINE",
+"361 483 LINE",
+"530 574 LINE",
+"569 500 LINE",
+"361 388 LINE",
+"361 226 LINE",
+"530 317 LINE",
+"569 243 LINE",
+"361 131 LINE",
+"361 -135 LINE"
+);
+}
+);
+width = 624;
+}
+);
+unicode = 10C8E;
+},
+{
+glyphname = uni10C8F;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"64 -135 LINE",
+"295 78 LINE",
+"51 305 LINE",
+"295 515 LINE",
+"64 714 LINE",
+"184 714 LINE",
+"354 566 LINE",
+"523 714 LINE",
+"645 714 LINE",
+"414 515 LINE",
+"659 305 LINE",
+"414 78 LINE",
+"645 -135 LINE",
+"523 -135 LINE",
+"354 24 LINE",
+"186 -135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"354 136 LINE",
+"534 306 LINE",
+"354 462 LINE",
+"174 306 LINE"
+);
+}
+);
+width = 710;
+}
+);
+unicode = 10C8F;
+},
+{
+glyphname = uni10C90;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"265 -135 LINE",
+"265 337 LINE",
+"96 246 LINE",
+"57 318 LINE",
+"265 431 LINE",
+"265 714 LINE",
+"361 714 LINE",
+"361 483 LINE",
+"530 574 LINE",
+"569 500 LINE",
+"361 388 LINE",
+"361 -135 LINE"
+);
+}
+);
+width = 627;
+}
+);
+unicode = 10C90;
+},
+{
+glyphname = uni10C91;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"278 -135 LINE",
+"278 624 LINE",
+"96 526 LINE",
+"57 598 LINE",
+"530 854 LINE",
+"569 780 LINE",
+"374 675 LINE",
+"374 -135 LINE"
+);
+}
+);
+width = 627;
+}
+);
+unicode = 10C91;
+},
+{
+glyphname = uni10C92;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"324 -135 LINE",
+"324 588 LINE",
+"86 353 LINE",
+"31 413 LINE",
+"337 714 LINE",
+"413 714 LINE",
+"413 -135 LINE"
+);
+}
+);
+width = 547;
+}
+);
+unicode = 10C92;
+},
+{
+glyphname = uni10C93;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"297 -135 LINE",
+"56 295 LINE",
+"297 714 LINE",
+"389 714 LINE",
+"629 295 LINE",
+"389 -135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"343 -49 LINE",
+"528 295 LINE",
+"343 629 LINE",
+"156 295 LINE"
+);
+}
+);
+width = 684;
+}
+);
+unicode = 10C93;
+},
+{
+glyphname = uni10C94;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"265 -135 LINE",
+"265 590 LINE",
+"83 427 LINE",
+"24 491 LINE",
+"273 714 LINE",
+"355 714 LINE",
+"355 -12 LINE",
+"537 152 LINE",
+"596 88 LINE",
+"347 -135 LINE"
+);
+}
+);
+width = 613;
+}
+);
+unicode = 10C94;
+},
+{
+glyphname = uni10C95;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"240 -165 LINE",
+"32 -65 LINE",
+"66 6 LINE",
+"199 -63 LINE",
+"408 294 LINE",
+"205 640 LINE",
+"72 572 LINE",
+"38 642 LINE",
+"246 744 LINE",
+"453 378 LINE",
+"661 744 LINE",
+"868 642 LINE",
+"835 572 LINE",
+"701 640 LINE",
+"499 294 LINE",
+"707 -63 LINE",
+"841 6 LINE",
+"874 -65 LINE",
+"667 -165 LINE",
+"453 211 LINE"
+);
+}
+);
+width = 907;
+}
+);
+unicode = 10C95;
+},
+{
+glyphname = uni10C96;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"18 -135 LINE",
+"360 714 LINE",
+"446 714 LINE",
+"784 -135 LINE",
+"685 -135 LINE",
+"613 49 LINE",
+"541 -135 LINE",
+"453 -135 LINE",
+"569 160 LINE",
+"509 314 LINE",
+"332 -135 LINE",
+"242 -135 LINE",
+"463 430 LINE",
+"445 479 OFFCURVE",
+"415 563 OFFCURVE",
+"404 602 QCURVE",
+"400 602 LINE",
+"388 562 OFFCURVE",
+"353 467 OFFCURVE",
+"332 413 QCURVE SMOOTH",
+"118 -135 LINE"
+);
+}
+);
+width = 801;
+}
+);
+unicode = 10C96;
+},
+{
+glyphname = uni10C97;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"338 -135 LINE",
+"260 -73 OFFCURVE",
+"147 55 OFFCURVE",
+"85 201 OFFCURVE",
+"85 289 QCURVE SMOOTH",
+"85 378 OFFCURVE",
+"146 524 OFFCURVE",
+"260 653 OFFCURVE",
+"337 714 QCURVE",
+"431 714 LINE",
+"509 653 OFFCURVE",
+"622 524 OFFCURVE",
+"683 378 OFFCURVE",
+"683 289 QCURVE SMOOTH",
+"683 201 OFFCURVE",
+"622 55 OFFCURVE",
+"509 -73 OFFCURVE",
+"431 -135 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"519 506 LINE",
+"494 539 OFFCURVE",
+"428 606 OFFCURVE",
+"386 643 QCURVE",
+"382 643 LINE",
+"314 583 OFFCURVE",
+"223 475 OFFCURVE",
+"178 360 OFFCURVE",
+"178 289 QCURVE SMOOTH",
+"178 209 OFFCURVE",
+"208 143 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"386 -63 LINE",
+"455 -3 OFFCURVE",
+"545 104 OFFCURVE",
+"590 219 OFFCURVE",
+"590 289 QCURVE SMOOTH",
+"590 374 OFFCURVE",
+"558 439 QCURVE",
+"250 74 LINE",
+"275 40 OFFCURVE",
+"341 -26 OFFCURVE",
+"382 -63 QCURVE"
+);
+}
+);
+width = 768;
+}
+);
+unicode = 10C97;
+},
+{
+glyphname = uni10C98;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"402 -135 LINE",
+"72 63 LINE",
+"72 150 LINE",
+"288 293 LINE",
+"72 437 LINE",
+"72 525 LINE",
+"402 714 LINE",
+"497 714 LINE",
+"497 -135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"407 310 LINE",
+"407 622 LINE",
+"156 479 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"407 -35 LINE",
+"407 277 LINE",
+"156 111 LINE"
+);
+}
+);
+width = 627;
+}
+);
+unicode = 10C98;
+},
+{
+glyphname = uni10C99;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"67 -88 LINE",
+"174 -20 OFFCURVE",
+"302 96 OFFCURVE",
+"358 216 OFFCURVE",
+"358 289 QCURVE SMOOTH",
+"358 343 OFFCURVE",
+"328 435 OFFCURVE",
+"260 522 OFFCURVE",
+"146 616 OFFCURVE",
+"62 671 QCURVE",
+"123 738 LINE",
+"245 659 OFFCURVE",
+"389 519 OFFCURVE",
+"452 375 OFFCURVE",
+"452 289 QCURVE SMOOTH",
+"452 203 OFFCURVE",
+"388 59 OFFCURVE",
+"242 -79 OFFCURVE",
+"118 -159 QCURVE"
+);
+}
+);
+width = 538;
+}
+);
+unicode = 10C99;
+},
+{
+glyphname = uni10C9A;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"122 -135 LINE",
+"122 714 LINE",
+"212 714 LINE",
+"336 647 OFFCURVE",
+"487 514 OFFCURVE",
+"557 372 OFFCURVE",
+"557 289 QCURVE SMOOTH",
+"557 205 OFFCURVE",
+"488 62 OFFCURVE",
+"336 -68 OFFCURVE",
+"212 -135 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"212 -37 LINE",
+"302 14 OFFCURVE",
+"412 113 OFFCURVE",
+"463 223 OFFCURVE",
+"463 289 QCURVE SMOOTH",
+"463 355 OFFCURVE",
+"414 463 OFFCURVE",
+"304 564 OFFCURVE",
+"212 618 QCURVE"
+);
+}
+);
+width = 633;
+}
+);
+unicode = 10C9A;
+},
+{
+glyphname = uni10C9B;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"55 63 LINE",
+"117 124 LINE",
+"299 -45 LINE",
+"359 7 OFFCURVE",
+"432 105 OFFCURVE",
+"465 216 OFFCURVE",
+"465 284 QCURVE SMOOTH",
+"465 350 OFFCURVE",
+"432 456 OFFCURVE",
+"355 557 OFFCURVE",
+"289 614 QCURVE",
+"117 455 LINE",
+"55 516 LINE",
+"291 734 LINE",
+"389 654 OFFCURVE",
+"507 513 OFFCURVE",
+"559 370 OFFCURVE",
+"559 284 QCURVE SMOOTH",
+"559 191 OFFCURVE",
+"500 44 OFFCURVE",
+"381 -86 OFFCURVE",
+"291 -155 QCURVE"
+);
+}
+);
+width = 634;
+}
+);
+unicode = 10C9B;
+},
+{
+glyphname = uni10C9C;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"37 109 LINE",
+"241 334 LINE",
+"301 271 LINE",
+"159 117 LINE",
+"319 -44 LINE",
+"407 36 OFFCURVE",
+"482 186 OFFCURVE",
+"482 278 QCURVE SMOOTH",
+"482 349 OFFCURVE",
+"439 466 OFFCURVE",
+"339 585 OFFCURVE",
+"251 659 QCURVE",
+"311 734 LINE",
+"409 651 OFFCURVE",
+"527 506 OFFCURVE",
+"579 362 OFFCURVE",
+"579 278 QCURVE SMOOTH",
+"579 191 OFFCURVE",
+"520 46 OFFCURVE",
+"401 -87 OFFCURVE",
+"311 -159 QCURVE"
+);
+}
+);
+width = 658;
+}
+);
+unicode = 10C9C;
+},
+{
+glyphname = uni10C9D;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"336 -145 LINE",
+"71 157 LINE",
+"293 415 LINE",
+"76 652 LINE",
+"140 718 LINE",
+"411 420 LINE",
+"190 161 LINE",
+"399 -79 LINE"
+);
+}
+);
+width = 482;
+}
+);
+unicode = 10C9D;
+},
+{
+glyphname = uni10C9E;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"123 -135 LINE",
+"123 714 LINE",
+"213 714 LINE",
+"213 298 LINE",
+"488 714 LINE",
+"597 714 LINE",
+"317 302 LINE",
+"606 -135 LINE",
+"492 -135 LINE",
+"213 296 LINE",
+"213 -135 LINE"
+);
+}
+);
+width = 624;
+}
+);
+unicode = 10C9E;
+},
+{
+glyphname = uni10C9F;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"39 107 LINE",
+"42 108 LINE",
+"37 111 LINE",
+"241 334 LINE",
+"305 270 LINE",
+"163 116 LINE",
+"320 -41 LINE",
+"352 -12 OFFCURVE",
+"402 43 OFFCURVE",
+"421 71 QCURVE",
+"364 122 LINE",
+"412 178 LINE",
+"458 137 LINE",
+"485 203 OFFCURVE",
+"485 279 QCURVE SMOOTH",
+"485 358 OFFCURVE",
+"456 425 QCURVE",
+"412 386 LINE",
+"364 442 LINE",
+"418 490 LINE",
+"390 528 OFFCURVE",
+"308 611 OFFCURVE",
+"251 659 QCURVE",
+"311 733 LINE",
+"369 684 OFFCURVE",
+"457 596 OFFCURVE",
+"488 553 QCURVE",
+"576 632 LINE",
+"624 575 LINE",
+"528 489 LINE",
+"555 440 OFFCURVE",
+"579 337 OFFCURVE",
+"579 279 QCURVE SMOOTH",
+"579 166 OFFCURVE",
+"527 74 QCURVE",
+"627 -15 LINE",
+"579 -70 LINE",
+"486 13 LINE",
+"454 -29 OFFCURVE",
+"367 -112 OFFCURVE",
+"311 -156 QCURVE"
+);
+}
+);
+width = 724;
+}
+);
+unicode = 10C9F;
+},
+{
+glyphname = uni10CA0;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"116 -156 LINE",
+"61 -101 LINE",
+"361 186 LINE",
+"361 340 LINE",
+"116 102 LINE",
+"61 157 LINE",
+"361 446 LINE",
+"361 600 LINE",
+"116 362 LINE",
+"61 417 LINE",
+"370 714 LINE",
+"451 714 LINE",
+"451 -135 LINE",
+"361 -135 LINE",
+"361 81 LINE"
+);
+}
+);
+width = 578;
+}
+);
+unicode = 10CA0;
+},
+{
+glyphname = uni10CA1;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"235 -170 LINE",
+"170 -110 LINE",
+"300 26 LINE",
+"269 68 OFFCURVE",
+"226 158 OFFCURVE",
+"215 207 QCURVE",
+"80 125 LINE",
+"39 203 LINE",
+"208 295 LINE",
+"209 357 OFFCURVE",
+"247 480 OFFCURVE",
+"293 539 QCURVE",
+"291 543 LINE",
+"160 475 LINE",
+"121 554 LINE",
+"464 714 LINE",
+"563 714 LINE",
+"906 554 LINE",
+"867 475 LINE",
+"735 543 LINE",
+"732 540 LINE",
+"779 481 OFFCURVE",
+"811 357 OFFCURVE",
+"812 295 QCURVE",
+"981 203 LINE",
+"939 125 LINE",
+"804 207 LINE",
+"785 112 OFFCURVE",
+"720 26 QCURVE",
+"856 -110 LINE",
+"792 -170 LINE",
+"667 -37 LINE",
+"642 -62 OFFCURVE",
+"593 -110 OFFCURVE",
+"563 -135 QCURVE",
+"465 -135 LINE",
+"434 -110 OFFCURVE",
+"379 -62 OFFCURVE",
+"354 -37 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"517 -63 LINE",
+"616 14 OFFCURVE",
+"725 183 OFFCURVE",
+"725 295 QCURVE SMOOTH",
+"725 403 OFFCURVE",
+"624 574 OFFCURVE",
+"517 638 QCURVE",
+"513 638 LINE",
+"407 574 OFFCURVE",
+"305 403 OFFCURVE",
+"305 295 QCURVE SMOOTH",
+"305 183 OFFCURVE",
+"415 14 OFFCURVE",
+"513 -63 QCURVE"
+);
+}
+);
+width = 1027;
+}
+);
+unicode = 10CA1;
+},
+{
+glyphname = uni10CA2;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"130 -135 LINE",
+"130 714 LINE",
+"220 714 LINE",
+"220 208 LINE",
+"613 471 LINE",
+"613 714 LINE",
+"703 714 LINE",
+"703 -135 LINE",
+"613 -135 LINE",
+"613 372 LINE",
+"220 114 LINE",
+"220 -135 LINE"
+);
+}
+);
+width = 832;
+}
+);
+unicode = 10CA2;
+},
+{
+glyphname = uni10CA3;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"93 127 LINE",
+"52 201 LINE",
+"514 474 LINE",
+"556 400 LINE"
+);
+}
+);
+width = 613;
+}
+);
+unicode = 10CA3;
+},
+{
+glyphname = uni10CA4;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"13 -135 LINE",
+"320 714 LINE",
+"411 714 LINE",
+"712 -135 LINE",
+"617 -135 LINE",
+"424 413 LINE SMOOTH",
+"406 464 OFFCURVE",
+"374 561 OFFCURVE",
+"364 601 QCURVE",
+"360 601 LINE",
+"350 561 OFFCURVE",
+"318 464 OFFCURVE",
+"299 411 QCURVE SMOOTH",
+"108 -135 LINE"
+);
+}
+);
+width = 724;
+}
+);
+unicode = 10CA4;
+},
+{
+glyphname = uni10CA5;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"124 -135 LINE",
+"124 714 LINE",
+"214 714 LINE",
+"214 -135 LINE"
+);
+}
+);
+width = 341;
+}
+);
+unicode = 10CA5;
+},
+{
+glyphname = uni10CA6;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"356 -135 LINE",
+"356 216 LINE",
+"10 691 LINE",
+"82 740 LINE",
+"356 356 LINE",
+"356 714 LINE",
+"446 714 LINE",
+"446 -135 LINE"
+);
+}
+);
+width = 567;
+}
+);
+unicode = 10CA6;
+},
+{
+glyphname = uni10CA7;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"388 -135 LINE",
+"388 394 LINE",
+"185 609 LINE",
+"76 496 LINE",
+"20 555 LINE",
+"188 726 LINE",
+"388 511 LINE",
+"388 714 LINE",
+"478 714 LINE",
+"478 510 LINE",
+"679 726 LINE",
+"847 555 LINE",
+"790 496 LINE",
+"681 609 LINE",
+"478 393 LINE",
+"478 -135 LINE"
+);
+}
+);
+width = 866;
+}
+);
+unicode = 10CA7;
+},
+{
+glyphname = uni10CA8;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"268 -136 LINE",
+"420 115 LINE",
+"343 240 LINE",
+"108 -135 LINE",
+"4 -135 LINE",
+"286 308 LINE",
+"22 714 LINE",
+"132 714 LINE",
+"227 564 LINE",
+"317 714 LINE",
+"413 714 LINE",
+"274 488 LINE",
+"346 374 LINE",
+"563 714 LINE",
+"667 714 LINE",
+"404 310 LINE",
+"687 -135 LINE",
+"575 -135 LINE",
+"468 38 LINE",
+"364 -136 LINE"
+);
+}
+);
+width = 691;
+}
+);
+unicode = 10CA8;
+},
+{
+glyphname = uni10CA9;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"607 -163 LINE",
+"320 -85 LINE",
+"345 -11 LINE",
+"548 -70 LINE",
+"352 238 LINE",
+"104 -136 LINE",
+"4 -136 LINE",
+"298 301 LINE",
+"34 714 LINE",
+"141 714 LINE",
+"356 365 LINE",
+"547 654 LINE",
+"344 594 LINE",
+"323 667 LINE",
+"609 748 LINE",
+"670 693 LINE",
+"407 306 LINE",
+"671 -98 LINE"
+);
+}
+);
+width = 724;
+}
+);
+unicode = 10CA9;
+},
+{
+glyphname = uni10CAA;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"124 -135 LINE",
+"124 714 LINE",
+"212 714 LINE",
+"437 540 LINE",
+"662 714 LINE",
+"750 714 LINE",
+"750 -135 LINE",
+"662 -135 LINE",
+"437 40 LINE",
+"212 -135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"214 -28 LINE",
+"437 140 LINE",
+"660 -28 LINE",
+"660 607 LINE",
+"437 439 LINE",
+"214 607 LINE"
+);
+}
+);
+width = 885;
+}
+);
+unicode = 10CAA;
+},
+{
+glyphname = uni10CAB;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"122 -135 LINE",
+"122 714 LINE",
+"204 714 LINE",
+"478 358 LINE",
+"755 714 LINE",
+"837 714 LINE",
+"837 -135 LINE",
+"755 -135 LINE",
+"478 223 LINE",
+"204 -135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"744 11 LINE",
+"748 11 LINE",
+"748 569 LINE",
+"744 569 LINE",
+"528 289 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"211 19 LINE",
+"215 19 LINE",
+"426 289 LINE",
+"215 561 LINE",
+"211 561 LINE"
+);
+}
+);
+width = 953;
+}
+);
+unicode = 10CAB;
+},
+{
+glyphname = uni10CAC;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"106 -151 LINE",
+"41 -91 LINE",
+"165 39 LINE",
+"127 94 OFFCURVE",
+"85 217 OFFCURVE",
+"85 289 QCURVE SMOOTH",
+"85 362 OFFCURVE",
+"127 486 OFFCURVE",
+"165 541 QCURVE",
+"41 669 LINE",
+"106 730 LINE",
+"218 605 LINE",
+"244 634 OFFCURVE",
+"303 688 OFFCURVE",
+"337 714 QCURVE",
+"431 714 LINE",
+"465 687 OFFCURVE",
+"526 633 OFFCURVE",
+"551 605 QCURVE",
+"663 730 LINE",
+"727 669 LINE",
+"603 540 LINE",
+"641 485 OFFCURVE",
+"683 361 OFFCURVE",
+"683 289 QCURVE SMOOTH",
+"683 217 OFFCURVE",
+"641 95 OFFCURVE",
+"603 39 QCURVE",
+"728 -91 LINE",
+"663 -151 LINE",
+"551 -26 LINE",
+"525 -54 OFFCURVE",
+"465 -108 OFFCURVE",
+"431 -135 QCURVE",
+"338 -135 LINE",
+"304 -108 OFFCURVE",
+"244 -54 OFFCURVE",
+"218 -26 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"386 -63 LINE",
+"455 -3 OFFCURVE",
+"545 104 OFFCURVE",
+"590 219 OFFCURVE",
+"590 289 QCURVE SMOOTH",
+"590 360 OFFCURVE",
+"545 475 OFFCURVE",
+"455 583 OFFCURVE",
+"386 643 QCURVE",
+"382 643 LINE",
+"314 583 OFFCURVE",
+"223 475 OFFCURVE",
+"178 360 OFFCURVE",
+"178 289 QCURVE SMOOTH",
+"178 219 OFFCURVE",
+"223 104 OFFCURVE",
+"314 -3 OFFCURVE",
+"382 -63 QCURVE"
+);
+}
+);
+width = 769;
+}
+);
+unicode = 10CAC;
+},
+{
+glyphname = uni10CAD;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"567 -136 LINE",
+"567 383 LINE",
+"220 127 LINE",
+"130 127 LINE",
+"130 714 LINE",
+"220 714 LINE",
+"220 231 LINE",
+"567 492 LINE",
+"657 492 LINE",
+"657 -136 LINE"
+);
+}
+);
+width = 788;
+}
+);
+unicode = 10CAD;
+},
+{
+glyphname = uni10CAE;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"124 -135 LINE",
+"124 714 LINE",
+"212 714 LINE",
+"437 540 LINE",
+"662 714 LINE",
+"750 714 LINE",
+"750 -135 LINE",
+"660 -135 LINE",
+"660 607 LINE",
+"437 439 LINE",
+"214 607 LINE",
+"214 -135 LINE"
+);
+}
+);
+width = 888;
+}
+);
+unicode = 10CAE;
+},
+{
+glyphname = uni10CAF;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"121 -136 LINE",
+"121 714 LINE",
+"211 714 LINE",
+"211 457 LINE",
+"618 714 LINE",
+"705 714 LINE",
+"705 -136 LINE",
+"615 -136 LINE",
+"615 123 LINE",
+"208 -136 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"211 207 LINE",
+"615 462 LINE",
+"615 623 LINE",
+"211 368 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"211 -42 LINE",
+"615 213 LINE",
+"615 373 LINE",
+"211 118 LINE"
+);
+}
+);
+width = 820;
+}
+);
+unicode = 10CAF;
+},
+{
+glyphname = uni10CB0;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"350 -136 LINE",
+"350 228 LINE",
+"10 691 LINE",
+"84 742 LINE",
+"350 370 LINE",
+"350 714 LINE",
+"440 714 LINE",
+"440 370 LINE",
+"706 742 LINE",
+"780 691 LINE",
+"440 228 LINE",
+"440 -136 LINE"
+);
+}
+);
+width = 796;
+}
+);
+unicode = 10CB0;
+},
+{
+glyphname = uni10CB1;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"387 -136 LINE",
+"185 76 LINE",
+"76 -38 LINE",
+"20 22 LINE",
+"188 190 LINE",
+"387 -24 LINE",
+"387 130 LINE",
+"185 343 LINE",
+"76 229 LINE",
+"20 288 LINE",
+"188 457 LINE",
+"387 243 LINE",
+"387 397 LINE",
+"185 609 LINE",
+"76 496 LINE",
+"20 555 LINE",
+"188 724 LINE",
+"387 510 LINE",
+"387 714 LINE",
+"477 714 LINE",
+"477 510 LINE",
+"677 724 LINE",
+"845 555 LINE",
+"788 496 LINE",
+"679 609 LINE",
+"477 397 LINE",
+"477 243 LINE",
+"677 457 LINE",
+"845 288 LINE",
+"788 229 LINE",
+"679 343 LINE",
+"477 130 LINE",
+"477 -24 LINE",
+"677 190 LINE",
+"845 22 LINE",
+"788 -38 LINE",
+"679 76 LINE",
+"477 -136 LINE"
+);
+}
+);
+width = 866;
+}
+);
+unicode = 10CB1;
+},
+{
+glyphname = uni10CB2;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"335 -135 LINE",
+"258 -73 OFFCURVE",
+"142 55 OFFCURVE",
+"78 201 OFFCURVE",
+"78 289 QCURVE SMOOTH",
+"78 378 OFFCURVE",
+"142 524 OFFCURVE",
+"258 653 OFFCURVE",
+"335 714 QCURVE",
+"434 714 LINE",
+"512 653 OFFCURVE",
+"627 524 OFFCURVE",
+"691 378 OFFCURVE",
+"691 289 QCURVE SMOOTH",
+"691 201 OFFCURVE",
+"627 55 OFFCURVE",
+"512 -73 OFFCURVE",
+"434 -135 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"342 614 LINE",
+"285 561 OFFCURVE",
+"210 461 OFFCURVE",
+"173 354 OFFCURVE",
+"173 289 QCURVE SMOOTH",
+"173 225 OFFCURVE",
+"210 118 OFFCURVE",
+"285 19 OFFCURVE",
+"342 -35 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"427 -35 LINE",
+"484 19 OFFCURVE",
+"559 118 OFFCURVE",
+"595 225 OFFCURVE",
+"595 289 QCURVE SMOOTH",
+"595 354 OFFCURVE",
+"559 461 OFFCURVE",
+"484 561 OFFCURVE",
+"427 614 QCURVE"
+);
+}
+);
+width = 769;
+}
+);
+unicode = 10CB2;
+},
+{
+glyphname = uni10CC0;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"262 0 LINE",
+"262 289 LINE",
+"32 300 LINE",
+"32 409 LINE",
+"230 600 LINE",
+"349 600 LINE",
+"349 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"262 366 LINE",
+"262 523 LINE",
+"108 373 LINE"
+);
+}
+);
+width = 444;
+}
+);
+unicode = 10CC0;
+},
+{
+glyphname = uni10CC1;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"251 0 LINE",
+"251 164 LINE",
+"42 334 LINE",
+"42 414 LINE",
+"253 600 LINE",
+"338 600 LINE",
+"338 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"251 268 LINE",
+"251 495 LINE",
+"118 375 LINE"
+);
+}
+);
+width = 433;
+}
+);
+unicode = 10CC1;
+},
+{
+glyphname = uni10CC2;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"10 0 LINE",
+"217 311 LINE",
+"22 600 LINE",
+"121 600 LINE",
+"270 371 LINE",
+"419 600 LINE",
+"513 600 LINE",
+"321 313 LINE",
+"528 0 LINE",
+"427 0 LINE",
+"267 253 LINE",
+"104 0 LINE"
+);
+}
+);
+width = 538;
+}
+);
+unicode = 10CC2;
+},
+{
+glyphname = uni10CC3;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"193 -1 LINE",
+"40 65 LINE",
+"70 131 LINE",
+"170 83 LINE",
+"208 132 LINE",
+"183 169 OFFCURVE",
+"155 252 OFFCURVE",
+"155 300 QCURVE SMOOTH",
+"155 347 OFFCURVE",
+"183 430 OFFCURVE",
+"208 467 QCURVE",
+"170 515 LINE",
+"70 467 LINE",
+"40 535 LINE",
+"193 600 LINE",
+"256 525 LINE",
+"276 545 OFFCURVE",
+"319 581 OFFCURVE",
+"343 600 QCURVE",
+"412 600 LINE",
+"435 582 OFFCURVE",
+"478 546 OFFCURVE",
+"497 527 QCURVE",
+"559 600 LINE",
+"711 535 LINE",
+"683 467 LINE",
+"581 515 LINE",
+"545 470 LINE",
+"572 433 OFFCURVE",
+"601 349 OFFCURVE",
+"601 300 QCURVE SMOOTH",
+"601 251 OFFCURVE",
+"572 168 OFFCURVE",
+"545 130 QCURVE",
+"581 83 LINE",
+"683 131 LINE",
+"711 65 LINE",
+"559 -1 LINE",
+"497 73 LINE",
+"478 54 OFFCURVE",
+"435 18 OFFCURVE",
+"412 0 QCURVE",
+"343 0 LINE",
+"295 36 OFFCURVE",
+"257 74 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"379 64 LINE",
+"451 125 OFFCURVE",
+"518 230 OFFCURVE",
+"518 300 QCURVE SMOOTH",
+"518 370 OFFCURVE",
+"450 475 OFFCURVE",
+"379 536 QCURVE",
+"377 536 LINE",
+"329 495 OFFCURVE",
+"267 423 OFFCURVE",
+"238 347 OFFCURVE",
+"238 300 QCURVE SMOOTH",
+"238 252 OFFCURVE",
+"268 176 OFFCURVE",
+"329 105 OFFCURVE",
+"377 64 QCURVE"
+);
+}
+);
+width = 751;
+}
+);
+unicode = 10CC3;
+},
+{
+glyphname = uni10CC4;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"180 0 LINE",
+"180 488 LINE",
+"53 376 LINE",
+"4 434 LINE",
+"195 600 LINE",
+"252 600 LINE",
+"443 434 LINE",
+"394 376 LINE",
+"267 488 LINE",
+"267 0 LINE"
+);
+}
+);
+width = 447;
+}
+);
+unicode = 10CC4;
+},
+{
+glyphname = uni10CC5;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"195 0 LINE",
+"4 166 LINE",
+"53 224 LINE",
+"180 112 LINE",
+"180 488 LINE",
+"53 376 LINE",
+"4 434 LINE",
+"195 600 LINE",
+"252 600 LINE",
+"443 434 LINE",
+"394 376 LINE",
+"267 488 LINE",
+"267 112 LINE",
+"394 224 LINE",
+"443 166 LINE",
+"252 0 LINE"
+);
+}
+);
+width = 447;
+}
+);
+unicode = 10CC5;
+},
+{
+glyphname = uni10CC6;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"180 600 LINE",
+"180 428 LINE",
+"444 600 LINE",
+"520 600 LINE",
+"520 0 LINE",
+"435 0 LINE",
+"435 170 LINE",
+"171 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"180 91 LINE",
+"435 255 LINE",
+"435 510 LINE",
+"180 343 LINE"
+);
+}
+);
+width = 615;
+}
+);
+unicode = 10CC6;
+},
+{
+glyphname = uni10CC7;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"175 0 LINE",
+"175 245 LINE",
+"60 186 LINE",
+"26 251 LINE",
+"175 328 LINE",
+"175 600 LINE",
+"262 600 LINE",
+"262 374 LINE",
+"378 434 LINE",
+"411 366 LINE",
+"262 290 LINE",
+"262 0 LINE"
+);
+}
+);
+width = 437;
+}
+);
+unicode = 10CC7;
+},
+{
+glyphname = uni10CC8;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"10 0 LINE",
+"178 252 LINE",
+"56 217 LINE",
+"33 278 LINE",
+"206 328 LINE",
+"22 600 LINE",
+"121 600 LINE",
+"270 371 LINE",
+"419 600 LINE",
+"513 600 LINE",
+"361 372 LINE",
+"481 407 LINE",
+"496 343 LINE",
+"332 296 LINE",
+"528 0 LINE",
+"427 0 LINE",
+"267 253 LINE",
+"104 0 LINE"
+);
+}
+);
+width = 538;
+}
+);
+unicode = 10CC8;
+},
+{
+glyphname = uni10CC9;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"311 -27 LINE",
+"226 51 LINE",
+"171 16 OFFCURVE",
+"91 -20 QCURVE",
+"54 47 LINE",
+"120 76 OFFCURVE",
+"166 104 QCURVE",
+"90 174 LINE",
+"138 229 LINE",
+"227 148 LINE",
+"265 181 OFFCURVE",
+"294 254 OFFCURVE",
+"294 300 QCURVE SMOOTH",
+"294 344 OFFCURVE",
+"265 414 OFFCURVE",
+"227 446 QCURVE",
+"138 365 LINE",
+"90 420 LINE",
+"167 490 LINE",
+"143 504 OFFCURVE",
+"85 535 OFFCURVE",
+"50 551 QCURVE",
+"95 618 LINE",
+"175 581 OFFCURVE",
+"229 546 QCURVE",
+"311 621 LINE",
+"354 561 LINE",
+"289 502 LINE",
+"339 459 OFFCURVE",
+"383 362 OFFCURVE",
+"383 300 QCURVE SMOOTH",
+"383 237 OFFCURVE",
+"337 139 OFFCURVE",
+"286 95 QCURVE",
+"354 33 LINE"
+);
+}
+);
+width = 411;
+}
+);
+unicode = 10CC9;
+},
+{
+glyphname = uni10CCA;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"54 47 LINE",
+"84 61 OFFCURVE",
+"135 86 OFFCURVE",
+"157 99 QCURVE",
+"108 142 OFFCURVE",
+"65 239 OFFCURVE",
+"65 300 QCURVE SMOOTH",
+"65 359 OFFCURVE",
+"108 455 OFFCURVE",
+"154 497 QCURVE",
+"132 510 OFFCURVE",
+"81 537 OFFCURVE",
+"50 551 QCURVE",
+"95 618 LINE",
+"170 584 OFFCURVE",
+"224 549 QCURVE",
+"278 584 OFFCURVE",
+"353 618 QCURVE",
+"398 551 LINE",
+"367 537 OFFCURVE",
+"316 510 OFFCURVE",
+"294 497 QCURVE",
+"341 455 OFFCURVE",
+"383 359 OFFCURVE",
+"383 300 QCURVE SMOOTH",
+"383 239 OFFCURVE",
+"340 142 OFFCURVE",
+"291 99 QCURVE",
+"313 86 OFFCURVE",
+"364 61 OFFCURVE",
+"394 47 QCURVE",
+"357 -20 LINE",
+"278 17 OFFCURVE",
+"224 50 QCURVE",
+"170 17 OFFCURVE",
+"91 -20 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"263 180 OFFCURVE",
+"294 254 OFFCURVE",
+"294 300 QCURVE SMOOTH",
+"294 345 OFFCURVE",
+"263 416 OFFCURVE",
+"224 449 QCURVE",
+"185 416 OFFCURVE",
+"154 345 OFFCURVE",
+"154 300 QCURVE SMOOTH",
+"154 254 OFFCURVE",
+"185 180 OFFCURVE",
+"224 146 QCURVE"
+);
+}
+);
+width = 428;
+}
+);
+unicode = 10CCA;
+},
+{
+glyphname = uni10CCB;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"196 -41 LINE",
+"34 97 LINE",
+"104 137 LINE",
+"168 178 OFFCURVE",
+"223 256 OFFCURVE",
+"223 300 QCURVE SMOOTH",
+"223 346 OFFCURVE",
+"161 428 OFFCURVE",
+"90 471 QCURVE",
+"34 502 LINE",
+"196 639 LINE",
+"247 580 LINE",
+"166 514 LINE",
+"244 462 OFFCURVE",
+"309 362 OFFCURVE",
+"309 300 QCURVE SMOOTH",
+"309 238 OFFCURVE",
+"244 137 OFFCURVE",
+"167 86 QCURVE",
+"247 20 LINE"
+);
+}
+);
+width = 354;
+}
+);
+unicode = 10CCB;
+},
+{
+glyphname = uni10CCC;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"243 0 LINE",
+"158 64 OFFCURVE",
+"55 206 OFFCURVE",
+"55 300 QCURVE SMOOTH",
+"55 394 OFFCURVE",
+"158 536 OFFCURVE",
+"243 600 QCURVE",
+"312 600 LINE",
+"397 536 OFFCURVE",
+"501 394 OFFCURVE",
+"501 300 QCURVE SMOOTH",
+"501 206 OFFCURVE",
+"397 64 OFFCURVE",
+"312 0 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"278 349 LINE",
+"366 449 LINE",
+"350 470 OFFCURVE",
+"306 513 OFFCURVE",
+"279 536 QCURVE",
+"277 536 LINE",
+"250 513 OFFCURVE",
+"207 470 OFFCURVE",
+"190 450 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"234 298 LINE",
+"154 392 LINE",
+"136 350 OFFCURVE",
+"136 300 QCURVE SMOOTH",
+"136 249 OFFCURVE",
+"154 207 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"402 208 LINE",
+"420 250 OFFCURVE",
+"420 300 QCURVE SMOOTH",
+"420 349 OFFCURVE",
+"402 391 QCURVE",
+"322 298 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"279 64 LINE",
+"332 108 OFFCURVE",
+"364 147 QCURVE",
+"278 247 LINE",
+"192 147 LINE",
+"224 108 OFFCURVE",
+"277 64 QCURVE"
+);
+}
+);
+width = 556;
+}
+);
+unicode = 10CCC;
+},
+{
+glyphname = uni10CCD;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"5 0 LINE",
+"247 600 LINE",
+"318 600 LINE",
+"561 0 LINE",
+"472 0 LINE",
+"383 225 LINE",
+"300 0 LINE",
+"213 0 LINE",
+"341 330 LINE",
+"325 371 LINE SMOOTH",
+"311 408 OFFCURVE",
+"291 471 OFFCURVE",
+"285 496 QCURVE",
+"281 496 LINE",
+"275 470 OFFCURVE",
+"256 415 OFFCURVE",
+"239 371 QCURVE SMOOTH",
+"92 0 LINE"
+);
+}
+);
+width = 565;
+}
+);
+unicode = 10CCD;
+},
+{
+glyphname = uni10CCE;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"183 0 LINE",
+"183 141 LINE",
+"67 76 LINE",
+"32 138 LINE",
+"183 223 LINE",
+"183 328 LINE",
+"67 262 LINE",
+"32 324 LINE",
+"183 409 LINE",
+"183 600 LINE",
+"270 600 LINE",
+"270 454 LINE",
+"392 522 LINE",
+"421 459 LINE",
+"270 372 LINE",
+"270 269 LINE",
+"392 336 LINE",
+"421 273 LINE",
+"270 185 LINE",
+"270 0 LINE"
+);
+}
+);
+width = 450;
+}
+);
+unicode = 10CCE;
+},
+{
+glyphname = uni10CCF;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"44 0 LINE",
+"213 154 LINE",
+"40 311 LINE",
+"213 455 LINE",
+"42 600 LINE",
+"151 600 LINE",
+"268 501 LINE",
+"386 600 LINE",
+"494 600 LINE",
+"324 455 LINE",
+"496 311 LINE",
+"323 154 LINE",
+"492 0 LINE",
+"385 0 LINE",
+"268 105 LINE",
+"152 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"268 205 LINE",
+"383 310 LINE",
+"268 407 LINE",
+"155 310 LINE"
+);
+}
+);
+width = 536;
+}
+);
+unicode = 10CCF;
+},
+{
+glyphname = uni10CD0;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"183 0 LINE",
+"183 362 LINE",
+"67 297 LINE",
+"32 359 LINE",
+"183 442 LINE",
+"183 600 LINE",
+"270 600 LINE",
+"270 490 LINE",
+"392 557 LINE",
+"421 494 LINE",
+"270 410 LINE",
+"270 0 LINE"
+);
+}
+);
+width = 452;
+}
+);
+unicode = 10CD0;
+},
+{
+glyphname = uni10CD1;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"186 0 LINE",
+"186 509 LINE",
+"43 430 LINE",
+"8 492 LINE",
+"392 703 LINE",
+"421 640 LINE",
+"273 558 LINE",
+"273 0 LINE"
+);
+}
+);
+width = 421;
+}
+);
+unicode = 10CD1;
+},
+{
+glyphname = uni10CD2;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"225 0 LINE",
+"225 485 LINE",
+"65 331 LINE",
+"11 383 LINE",
+"235 600 LINE",
+"312 600 LINE",
+"312 0 LINE"
+);
+}
+);
+width = 407;
+}
+);
+unicode = 10CD2;
+},
+{
+glyphname = uni10CD3;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"209 0 LINE",
+"33 304 LINE",
+"209 600 LINE",
+"285 600 LINE",
+"460 304 LINE",
+"285 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"247 83 LINE",
+"370 303 LINE",
+"247 517 LINE",
+"123 303 LINE"
+);
+}
+);
+width = 493;
+}
+);
+unicode = 10CD3;
+},
+{
+glyphname = uni10CD4;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"191 0 LINE",
+"191 488 LINE",
+"64 376 LINE",
+"15 434 LINE",
+"206 600 LINE",
+"278 600 LINE",
+"278 112 LINE",
+"405 224 LINE",
+"454 166 LINE",
+"263 0 LINE"
+);
+}
+);
+width = 469;
+}
+);
+unicode = 10CD4;
+},
+{
+glyphname = uni10CD5;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"194 -30 LINE",
+"28 46 LINE",
+"59 113 LINE",
+"155 67 LINE",
+"295 301 LINE",
+"159 526 LINE",
+"64 479 LINE",
+"33 547 LINE",
+"198 624 LINE",
+"343 375 LINE",
+"486 623 LINE",
+"653 547 LINE",
+"622 479 LINE",
+"526 526 LINE",
+"391 301 LINE",
+"531 67 LINE",
+"626 113 LINE",
+"657 46 LINE",
+"491 -30 LINE",
+"343 227 LINE"
+);
+}
+);
+width = 685;
+}
+);
+unicode = 10CD5;
+},
+{
+glyphname = uni10CD6;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"5 0 LINE",
+"270 600 LINE",
+"341 600 LINE",
+"607 0 LINE",
+"519 0 LINE",
+"468 117 LINE",
+"423 0 LINE",
+"339 0 LINE",
+"426 212 LINE",
+"385 305 LINE",
+"257 0 LINE",
+"173 0 LINE",
+"344 399 LINE",
+"333 428 OFFCURVE",
+"314 479 OFFCURVE",
+"308 498 QCURVE",
+"304 498 LINE",
+"297 474 OFFCURVE",
+"274 414 OFFCURVE",
+"255 371 QCURVE SMOOTH",
+"90 0 LINE"
+);
+}
+);
+width = 612;
+}
+);
+unicode = 10CD6;
+},
+{
+glyphname = uni10CD7;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"243 0 LINE",
+"158 64 OFFCURVE",
+"55 206 OFFCURVE",
+"55 300 QCURVE SMOOTH",
+"55 394 OFFCURVE",
+"158 536 OFFCURVE",
+"243 600 QCURVE",
+"312 600 LINE",
+"397 536 OFFCURVE",
+"501 394 OFFCURVE",
+"501 300 QCURVE SMOOTH",
+"501 206 OFFCURVE",
+"397 64 OFFCURVE",
+"312 0 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"366 448 LINE",
+"334 488 OFFCURVE",
+"279 536 QCURVE",
+"277 536 LINE",
+"229 495 OFFCURVE",
+"167 423 OFFCURVE",
+"138 347 OFFCURVE",
+"138 300 QCURVE SMOOTH",
+"138 251 OFFCURVE",
+"155 208 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"279 64 LINE",
+"351 125 OFFCURVE",
+"418 230 OFFCURVE",
+"418 300 QCURVE SMOOTH",
+"418 347 OFFCURVE",
+"401 389 QCURVE",
+"193 147 LINE",
+"209 127 OFFCURVE",
+"251 86 OFFCURVE",
+"277 64 QCURVE"
+);
+}
+);
+width = 556;
+}
+);
+unicode = 10CD7;
+},
+{
+glyphname = uni10CD8;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"307 0 LINE",
+"48 132 LINE",
+"48 231 LINE",
+"190 303 LINE",
+"48 380 LINE",
+"48 479 LINE",
+"303 600 LINE",
+"386 600 LINE",
+"386 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"306 320 LINE",
+"306 514 LINE",
+"121 426 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"306 93 LINE",
+"306 284 LINE",
+"121 185 LINE"
+);
+}
+);
+width = 481;
+}
+);
+unicode = 10CD8;
+},
+{
+glyphname = uni10CD9;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"36 47 LINE",
+"130 89 OFFCURVE",
+"234 164 OFFCURVE",
+"276 246 OFFCURVE",
+"276 300 QCURVE SMOOTH",
+"276 352 OFFCURVE",
+"234 431 OFFCURVE",
+"128 506 OFFCURVE",
+"32 551 QCURVE",
+"77 618 LINE",
+"181 570 OFFCURVE",
+"307 477 OFFCURVE",
+"365 369 OFFCURVE",
+"365 300 QCURVE SMOOTH",
+"365 230 OFFCURVE",
+"307 122 OFFCURVE",
+"179 28 OFFCURVE",
+"73 -20 QCURVE"
+);
+}
+);
+width = 420;
+}
+);
+unicode = 10CD9;
+},
+{
+glyphname = uni10CDA;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"180 600 LINE",
+"271 552 OFFCURVE",
+"383 459 OFFCURVE",
+"435 359 OFFCURVE",
+"435 300 QCURVE SMOOTH",
+"435 239 OFFCURVE",
+"384 138 OFFCURVE",
+"272 48 OFFCURVE",
+"180 0 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"180 87 LINE",
+"272 137 OFFCURVE",
+"348 235 OFFCURVE",
+"348 300 QCURVE SMOOTH",
+"348 340 OFFCURVE",
+"319 407 OFFCURVE",
+"247 474 OFFCURVE",
+"180 512 QCURVE"
+);
+}
+);
+width = 490;
+}
+);
+unicode = 10CDA;
+},
+{
+glyphname = uni10CDB;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"32 146 LINE",
+"90 204 LINE",
+"219 81 LINE",
+"281 134 OFFCURVE",
+"331 234 OFFCURVE",
+"331 295 QCURVE SMOOTH",
+"331 336 OFFCURVE",
+"309 406 OFFCURVE",
+"257 475 OFFCURVE",
+"212 514 QCURVE",
+"90 397 LINE",
+"32 455 LINE",
+"211 624 LINE",
+"287 564 OFFCURVE",
+"378 459 OFFCURVE",
+"418 355 OFFCURVE",
+"418 295 QCURVE SMOOTH",
+"418 200 OFFCURVE",
+"315 55 OFFCURVE",
+"211 -22 QCURVE"
+);
+}
+);
+width = 473;
+}
+);
+unicode = 10CDB;
+},
+{
+glyphname = uni10CDC;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"28 182 LINE",
+"182 348 LINE",
+"239 290 LINE",
+"141 187 LINE",
+"250 80 LINE",
+"315 133 OFFCURVE",
+"366 232 OFFCURVE",
+"366 293 QCURVE SMOOTH",
+"366 340 OFFCURVE",
+"334 419 OFFCURVE",
+"256 502 OFFCURVE",
+"187 554 QCURVE",
+"241 618 LINE",
+"319 559 OFFCURVE",
+"411 456 OFFCURVE",
+"452 353 OFFCURVE",
+"452 293 QCURVE SMOOTH",
+"452 199 OFFCURVE",
+"348 55 OFFCURVE",
+"241 -21 QCURVE"
+);
+}
+);
+width = 507;
+}
+);
+unicode = 10CDC;
+},
+{
+glyphname = uni10CDD;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"263 -18 LINE",
+"33 207 LINE",
+"231 390 LINE",
+"47 559 LINE",
+"104 618 LINE",
+"337 394 LINE",
+"140 211 LINE",
+"320 41 LINE"
+);
+}
+);
+width = 370;
+}
+);
+unicode = 10CDD;
+},
+{
+glyphname = uni10CDE;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"182 600 LINE",
+"182 308 LINE",
+"370 600 LINE",
+"467 600 LINE",
+"269 307 LINE",
+"474 0 LINE",
+"372 0 LINE",
+"182 300 LINE",
+"182 0 LINE"
+);
+}
+);
+width = 492;
+}
+);
+unicode = 10CDE;
+},
+{
+glyphname = uni10CDF;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"28 182 LINE",
+"182 348 LINE",
+"239 290 LINE",
+"141 187 LINE",
+"250 80 LINE",
+"292 114 OFFCURVE",
+"317 147 QCURVE",
+"269 187 LINE",
+"315 236 LINE",
+"351 206 LINE",
+"366 247 OFFCURVE",
+"366 293 QCURVE SMOOTH",
+"366 318 OFFCURVE",
+"358 363 OFFCURVE",
+"348 385 QCURVE",
+"314 356 LINE",
+"268 406 LINE",
+"311 442 LINE",
+"270 492 OFFCURVE",
+"187 554 QCURVE",
+"241 618 LINE",
+"285 585 OFFCURVE",
+"351 525 OFFCURVE",
+"375 496 QCURVE",
+"442 552 LINE",
+"487 503 LINE",
+"414 441 LINE",
+"434 406 OFFCURVE",
+"452 334 OFFCURVE",
+"452 293 QCURVE SMOOTH",
+"452 216 OFFCURVE",
+"416 151 QCURVE",
+"490 88 LINE",
+"445 38 LINE",
+"376 96 LINE",
+"351 67 OFFCURVE",
+"284 9 OFFCURVE",
+"241 -21 QCURVE"
+);
+}
+);
+width = 541;
+}
+);
+unicode = 10CDF;
+},
+{
+glyphname = uni10CE0;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"92 -9 LINE",
+"42 45 LINE",
+"273 232 LINE",
+"273 322 LINE",
+"92 170 LINE",
+"42 223 LINE",
+"273 411 LINE",
+"273 501 LINE",
+"92 348 LINE",
+"42 401 LINE",
+"283 600 LINE",
+"358 600 LINE",
+"358 0 LINE",
+"273 0 LINE",
+"273 144 LINE"
+);
+}
+);
+width = 453;
+}
+);
+unicode = 10CE0;
+},
+{
+glyphname = uni10CE1;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"170 -17 LINE",
+"111 36 LINE",
+"207 127 LINE",
+"171 177 OFFCURVE",
+"158 231 QCURVE",
+"52 174 LINE",
+"14 241 LINE",
+"150 311 LINE",
+"152 356 OFFCURVE",
+"180 432 OFFCURVE",
+"205 465 QCURVE",
+"82 406 LINE",
+"47 475 LINE",
+"337 600 LINE",
+"409 600 LINE",
+"699 475 LINE",
+"664 406 LINE",
+"540 466 LINE",
+"566 432 OFFCURVE",
+"595 356 OFFCURVE",
+"596 311 QCURVE",
+"732 241 LINE",
+"694 174 LINE",
+"588 231 LINE",
+"581 203 OFFCURVE",
+"556 152 OFFCURVE",
+"539 127 QCURVE",
+"635 36 LINE",
+"576 -17 LINE",
+"491 71 LINE",
+"472 53 OFFCURVE",
+"430 17 OFFCURVE",
+"407 0 QCURVE",
+"338 0 LINE",
+"315 17 OFFCURVE",
+"273 52 OFFCURVE",
+"255 71 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"374 64 LINE",
+"446 125 OFFCURVE",
+"513 230 OFFCURVE",
+"513 300 QCURVE SMOOTH",
+"513 372 OFFCURVE",
+"445 481 OFFCURVE",
+"374 536 QCURVE",
+"372 536 LINE",
+"299 481 OFFCURVE",
+"233 372 OFFCURVE",
+"233 300 QCURVE SMOOTH",
+"233 252 OFFCURVE",
+"263 176 OFFCURVE",
+"324 105 OFFCURVE",
+"372 64 QCURVE"
+);
+}
+);
+width = 746;
+}
+);
+unicode = 10CE1;
+},
+{
+glyphname = uni10CE2;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"182 600 LINE",
+"182 264 LINE",
+"445 434 LINE",
+"445 600 LINE",
+"532 600 LINE",
+"532 0 LINE",
+"445 0 LINE",
+"445 345 LINE",
+"182 175 LINE",
+"182 0 LINE"
+);
+}
+);
+width = 627;
+}
+);
+unicode = 10CE2;
+},
+{
+glyphname = uni10CE3;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"66 177 LINE",
+"27 245 LINE",
+"369 440 LINE",
+"409 372 LINE"
+);
+}
+);
+width = 441;
+}
+);
+unicode = 10CE3;
+},
+{
+glyphname = uni10CE4;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"5 0 LINE",
+"247 600 LINE",
+"318 600 LINE",
+"561 0 LINE",
+"472 0 LINE",
+"325 371 LINE SMOOTH",
+"311 408 OFFCURVE",
+"291 471 OFFCURVE",
+"285 496 QCURVE",
+"281 496 LINE",
+"275 470 OFFCURVE",
+"256 415 OFFCURVE",
+"239 371 QCURVE SMOOTH",
+"92 0 LINE"
+);
+}
+);
+width = 566;
+}
+);
+unicode = 10CE4;
+},
+{
+glyphname = uni10CE5;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"182 600 LINE",
+"182 0 LINE"
+);
+}
+);
+width = 277;
+}
+);
+unicode = 10CE5;
+},
+{
+glyphname = uni10CE6;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"285 0 LINE",
+"285 241 LINE",
+"18 567 LINE",
+"83 624 LINE",
+"285 371 LINE",
+"285 600 LINE",
+"372 600 LINE",
+"372 0 LINE"
+);
+}
+);
+width = 467;
+}
+);
+unicode = 10CE6;
+},
+{
+glyphname = uni10CE7;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"288 0 LINE",
+"288 350 LINE",
+"143 508 LINE",
+"67 430 LINE",
+"14 482 LINE",
+"147 611 LINE",
+"288 455 LINE",
+"288 600 LINE",
+"373 600 LINE",
+"373 456 LINE",
+"515 611 LINE",
+"647 482 LINE",
+"595 430 LINE",
+"518 508 LINE",
+"373 351 LINE",
+"373 0 LINE"
+);
+}
+);
+width = 661;
+}
+);
+unicode = 10CE7;
+},
+{
+glyphname = uni10CE8;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"10 0 LINE",
+"217 311 LINE",
+"22 600 LINE",
+"121 600 LINE",
+"182 507 LINE",
+"239 600 LINE",
+"327 600 LINE",
+"225 440 LINE",
+"270 371 LINE",
+"419 600 LINE",
+"513 600 LINE",
+"321 313 LINE",
+"528 0 LINE",
+"427 0 LINE",
+"358 109 LINE",
+"290 0 LINE",
+"203 0 LINE",
+"315 177 LINE",
+"267 253 LINE",
+"104 0 LINE"
+);
+}
+);
+width = 538;
+}
+);
+unicode = 10CE8;
+},
+{
+glyphname = uni10CE9;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"444 -24 LINE",
+"241 34 LINE",
+"263 102 LINE",
+"388 63 LINE",
+"267 253 LINE",
+"104 0 LINE",
+"10 0 LINE",
+"217 311 LINE",
+"22 600 LINE",
+"121 600 LINE",
+"270 371 LINE",
+"380 535 LINE",
+"263 499 LINE",
+"243 567 LINE",
+"441 625 LINE",
+"502 584 LINE",
+"321 313 LINE",
+"513 22 LINE"
+);
+}
+);
+width = 517;
+}
+);
+unicode = 10CE9;
+},
+{
+glyphname = uni10CEA;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"172 600 LINE",
+"331 486 LINE",
+"488 600 LINE",
+"567 600 LINE",
+"567 0 LINE",
+"488 0 LINE",
+"331 114 LINE",
+"172 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"180 100 LINE",
+"331 206 LINE",
+"482 100 LINE",
+"482 499 LINE",
+"331 394 LINE",
+"180 499 LINE"
+);
+}
+);
+width = 662;
+}
+);
+unicode = 10CEA;
+},
+{
+glyphname = uni10CEB;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"173 600 LINE",
+"356 355 LINE",
+"542 600 LINE",
+"615 600 LINE",
+"615 0 LINE",
+"542 0 LINE",
+"356 243 LINE",
+"173 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"537 126 LINE",
+"540 126 LINE",
+"540 472 LINE",
+"537 472 LINE",
+"403 300 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"175 131 LINE",
+"178 131 LINE",
+"309 300 LINE",
+"178 467 LINE",
+"175 467 LINE"
+);
+}
+);
+width = 710;
+}
+);
+unicode = 10CEB;
+},
+{
+glyphname = uni10CEC;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"97 -15 LINE",
+"38 38 LINE",
+"127 129 LINE",
+"100 167 OFFCURVE",
+"71 251 OFFCURVE",
+"71 300 QCURVE SMOOTH",
+"71 349 OFFCURVE",
+"100 434 OFFCURVE",
+"127 471 QCURVE",
+"38 560 LINE",
+"97 613 LINE",
+"176 528 LINE",
+"211 564 OFFCURVE",
+"259 600 QCURVE",
+"328 600 LINE",
+"375 564 OFFCURVE",
+"412 528 QCURVE",
+"492 613 LINE",
+"551 560 LINE",
+"461 471 LINE",
+"487 433 OFFCURVE",
+"517 349 OFFCURVE",
+"517 300 QCURVE SMOOTH",
+"517 251 OFFCURVE",
+"487 167 OFFCURVE",
+"461 129 QCURVE",
+"551 38 LINE",
+"492 -15 LINE",
+"412 71 LINE",
+"393 53 OFFCURVE",
+"351 17 OFFCURVE",
+"328 0 QCURVE",
+"259 0 LINE",
+"213 35 OFFCURVE",
+"176 71 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"295 64 LINE",
+"367 125 OFFCURVE",
+"434 230 OFFCURVE",
+"434 300 QCURVE SMOOTH",
+"434 370 OFFCURVE",
+"366 475 OFFCURVE",
+"295 536 QCURVE",
+"293 536 LINE",
+"245 495 OFFCURVE",
+"183 423 OFFCURVE",
+"154 347 OFFCURVE",
+"154 300 QCURVE SMOOTH",
+"154 252 OFFCURVE",
+"184 176 OFFCURVE",
+"245 105 OFFCURVE",
+"293 64 QCURVE"
+);
+}
+);
+width = 589;
+}
+);
+unicode = 10CEC;
+},
+{
+glyphname = uni10CED;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"404 0 LINE",
+"404 354 LINE",
+"170 169 LINE",
+"86 169 LINE",
+"86 600 LINE",
+"173 600 LINE",
+"173 272 LINE",
+"406 457 LINE",
+"491 457 LINE",
+"491 0 LINE"
+);
+}
+);
+width = 577;
+}
+);
+unicode = 10CED;
+},
+{
+glyphname = uni10CEE;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"172 600 LINE",
+"331 486 LINE",
+"488 600 LINE",
+"567 600 LINE",
+"567 0 LINE",
+"482 0 LINE",
+"482 499 LINE",
+"331 394 LINE",
+"180 499 LINE",
+"180 0 LINE"
+);
+}
+);
+width = 662;
+}
+);
+unicode = 10CEE;
+},
+{
+glyphname = uni10CEF;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"180 600 LINE",
+"180 427 LINE",
+"435 600 LINE",
+"520 600 LINE",
+"520 0 LINE",
+"435 0 LINE",
+"435 173 LINE",
+"180 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"180 254 LINE",
+"435 427 LINE",
+"435 519 LINE",
+"180 346 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"180 81 LINE",
+"435 254 LINE",
+"435 346 LINE",
+"180 173 LINE"
+);
+}
+);
+width = 615;
+}
+);
+unicode = 10CEF;
+},
+{
+glyphname = uni10CF0;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"267 0 LINE",
+"267 261 LINE",
+"12 570 LINE",
+"81 617 LINE",
+"267 386 LINE",
+"267 600 LINE",
+"354 600 LINE",
+"354 386 LINE",
+"542 617 LINE",
+"610 570 LINE",
+"354 261 LINE",
+"354 0 LINE"
+);
+}
+);
+width = 622;
+}
+);
+unicode = 10CF0;
+},
+{
+glyphname = uni10CF1;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"310 0 LINE",
+"166 152 LINE",
+"77 85 LINE",
+"30 140 LINE",
+"169 246 LINE",
+"310 98 LINE",
+"310 192 LINE",
+"166 336 LINE",
+"77 268 LINE",
+"30 324 LINE",
+"169 429 LINE",
+"310 285 LINE",
+"310 375 LINE",
+"166 519 LINE",
+"77 452 LINE",
+"30 507 LINE",
+"169 613 LINE",
+"310 469 LINE",
+"310 600 LINE",
+"395 600 LINE",
+"395 469 LINE",
+"537 613 LINE",
+"676 507 LINE",
+"629 452 LINE",
+"540 519 LINE",
+"395 375 LINE",
+"395 285 LINE",
+"537 429 LINE",
+"676 324 LINE",
+"629 268 LINE",
+"540 336 LINE",
+"395 192 LINE",
+"395 98 LINE",
+"537 246 LINE",
+"676 140 LINE",
+"629 85 LINE",
+"540 152 LINE",
+"395 0 LINE"
+);
+}
+);
+width = 706;
+}
+);
+unicode = 10CF1;
+},
+{
+glyphname = uni10CF2;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"243 0 LINE",
+"158 64 OFFCURVE",
+"55 206 OFFCURVE",
+"55 300 QCURVE SMOOTH",
+"55 394 OFFCURVE",
+"158 536 OFFCURVE",
+"243 600 QCURVE",
+"312 600 LINE",
+"397 536 OFFCURVE",
+"501 394 OFFCURVE",
+"501 300 QCURVE SMOOTH",
+"501 206 OFFCURVE",
+"397 64 OFFCURVE",
+"312 0 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"240 503 LINE",
+"187 454 OFFCURVE",
+"138 360 OFFCURVE",
+"138 300 QCURVE SMOOTH",
+"138 239 OFFCURVE",
+"188 146 OFFCURVE",
+"240 97 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"317 98 LINE",
+"369 147 OFFCURVE",
+"418 239 OFFCURVE",
+"418 300 QCURVE SMOOTH",
+"418 360 OFFCURVE",
+"369 453 OFFCURVE",
+"317 502 QCURVE"
+);
+}
+);
+width = 556;
+}
+);
+unicode = 10CF2;
+},
+{
+glyphname = uni10CFA;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"124 -135 LINE",
+"124 714 LINE",
+"214 714 LINE",
+"214 -135 LINE"
+);
+}
+);
+width = 341;
+}
+);
+unicode = 10CFA;
+},
+{
+glyphname = uni10CFB;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"13 714 LINE",
+"108 714 LINE",
+"299 168 LINE SMOOTH",
+"318 115 OFFCURVE",
+"350 18 OFFCURVE",
+"360 -22 QCURVE",
+"364 -22 LINE",
+"374 18 OFFCURVE",
+"406 115 OFFCURVE",
+"424 166 QCURVE SMOOTH",
+"617 714 LINE",
+"712 714 LINE",
+"411 -135 LINE",
+"320 -135 LINE"
+);
+}
+);
+width = 724;
+}
+);
+unicode = 10CFB;
+},
+{
+glyphname = uni10CFC;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"4 -135 LINE",
+"286 308 LINE",
+"22 714 LINE",
+"132 714 LINE",
+"346 374 LINE",
+"563 714 LINE",
+"667 714 LINE",
+"404 310 LINE",
+"687 -135 LINE",
+"575 -135 LINE",
+"343 240 LINE",
+"108 -135 LINE"
+);
+}
+);
+width = 691;
+}
+);
+unicode = 10CFC;
+},
+{
+glyphname = uni10CFD;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"408 90 LINE",
+"617 714 LINE",
+"712 714 LINE",
+"411 -135 LINE",
+"320 -135 LINE",
+"13 714 LINE",
+"108 714 LINE",
+"319 91 LINE",
+"318 718 LINE",
+"408 718 LINE"
+);
+}
+);
+width = 724;
+}
+);
+unicode = 10CFD;
+},
+{
+glyphname = uni10CFE;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"390 185 LINE",
+"390 -135 LINE",
+"300 -135 LINE",
+"300 182 LINE",
+"108 -135 LINE",
+"4 -135 LINE",
+"286 308 LINE",
+"22 714 LINE",
+"132 714 LINE",
+"300 450 LINE",
+"300 714 LINE",
+"390 714 LINE",
+"390 457 LINE",
+"563 714 LINE",
+"667 714 LINE",
+"404 310 LINE",
+"687 -135 LINE",
+"575 -135 LINE"
+);
+}
+);
+width = 691;
+}
+);
+unicode = 10CFE;
+},
+{
+glyphname = uni10CFF;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"251 259 LINE",
+"-1 260 LINE",
+"-2 347 LINE",
+"255 347 LINE",
+"22 714 LINE",
+"132 714 LINE",
+"300 450 LINE",
+"300 714 LINE",
+"390 714 LINE",
+"390 457 LINE",
+"563 714 LINE",
+"667 714 LINE",
+"430 347 LINE",
+"687 347 LINE",
+"686 261 LINE",
+"433 263 LINE",
+"687 -135 LINE",
+"575 -135 LINE",
+"390 185 LINE",
+"390 -135 LINE",
+"300 -135 LINE",
+"300 182 LINE",
+"108 -135 LINE",
+"4 -135 LINE"
+);
+}
+);
+width = 691;
+}
+);
+unicode = 10CFF;
+},
+{
+glyphname = uni10C80.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"129 -135 LINE",
+"129 714 LINE",
+"226 714 LINE",
+"519 476 LINE",
+"519 371 LINE",
+"219 339 LINE",
+"219 -135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"219 422 LINE",
+"437 442 LINE",
+"219 619 LINE"
+);
+}
+);
+width = 529;
+}
+);
+},
+{
+glyphname = uni10C81.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"129 -135 LINE",
+"129 714 LINE",
+"222 714 LINE",
+"506 438 LINE",
+"506 362 LINE",
+"219 117 LINE",
+"219 -135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"219 232 LINE",
+"422 401 LINE",
+"219 609 LINE"
+);
+}
+);
+width = 529;
+}
+);
+},
+{
+glyphname = uni10C82.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"4 -135 LINE",
+"287 310 LINE",
+"24 714 LINE",
+"128 714 LINE",
+"345 374 LINE",
+"559 714 LINE",
+"669 714 LINE",
+"405 308 LINE",
+"687 -135 LINE",
+"583 -135 LINE",
+"348 240 LINE",
+"116 -135 LINE"
+);
+}
+);
+width = 691;
+}
+);
+},
+{
+glyphname = uni10C83.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"461 -135 LINE",
+"427 -108 OFFCURVE",
+"366 -53 OFFCURVE",
+"340 -25 QCURVE",
+"253 -134 LINE",
+"55 -46 LINE",
+"87 29 LINE",
+"227 -39 LINE",
+"287 41 LINE",
+"250 96 OFFCURVE",
+"209 218 OFFCURVE",
+"209 289 QCURVE SMOOTH",
+"209 360 OFFCURVE",
+"250 483 OFFCURVE",
+"287 538 QCURVE",
+"227 618 LINE",
+"87 550 LINE",
+"55 626 LINE",
+"253 713 LINE",
+"340 604 LINE",
+"366 633 OFFCURVE",
+"427 687 OFFCURVE",
+"461 714 QCURVE",
+"555 714 LINE",
+"590 687 OFFCURVE",
+"651 631 OFFCURVE",
+"677 602 QCURVE",
+"767 713 LINE",
+"963 626 LINE",
+"933 550 LINE",
+"792 618 LINE",
+"730 536 LINE",
+"767 481 OFFCURVE",
+"807 360 OFFCURVE",
+"807 289 QCURVE SMOOTH",
+"807 219 OFFCURVE",
+"767 98 OFFCURVE",
+"730 44 QCURVE",
+"792 -39 LINE",
+"933 29 LINE",
+"963 -46 LINE",
+"767 -134 LINE",
+"677 -23 LINE",
+"651 -51 OFFCURVE",
+"589 -107 OFFCURVE",
+"554 -135 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"510 -63 LINE",
+"579 -3 OFFCURVE",
+"669 104 OFFCURVE",
+"714 219 OFFCURVE",
+"714 289 QCURVE SMOOTH",
+"714 360 OFFCURVE",
+"669 475 OFFCURVE",
+"579 583 OFFCURVE",
+"510 643 QCURVE",
+"506 643 LINE",
+"437 583 OFFCURVE",
+"347 475 OFFCURVE",
+"302 360 OFFCURVE",
+"302 289 QCURVE SMOOTH",
+"302 219 OFFCURVE",
+"347 104 OFFCURVE",
+"437 -3 OFFCURVE",
+"506 -63 QCURVE"
+);
+}
+);
+width = 1018;
+}
+);
+},
+{
+glyphname = uni10C84.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"265 -135 LINE",
+"265 590 LINE",
+"83 427 LINE",
+"24 491 LINE",
+"273 714 LINE",
+"347 714 LINE",
+"596 491 LINE",
+"537 427 LINE",
+"355 590 LINE",
+"355 -135 LINE"
+);
+}
+);
+width = 620;
+}
+);
+},
+{
+glyphname = uni10C85.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"273 -135 LINE",
+"24 88 LINE",
+"83 152 LINE",
+"265 -11 LINE",
+"265 590 LINE",
+"83 427 LINE",
+"31 491 LINE",
+"273 714 LINE",
+"347 714 LINE",
+"589 491 LINE",
+"537 427 LINE",
+"355 590 LINE",
+"355 -11 LINE",
+"537 152 LINE",
+"596 88 LINE",
+"347 -135 LINE"
+);
+}
+);
+width = 620;
+}
+);
+},
+{
+glyphname = uni10C86.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"124 -135 LINE",
+"124 714 LINE",
+"211 714 LINE",
+"618 456 LINE",
+"618 714 LINE",
+"708 714 LINE",
+"708 -135 LINE",
+"621 -135 LINE",
+"214 124 LINE",
+"214 -135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"618 -30 LINE",
+"618 357 LINE",
+"214 614 LINE",
+"214 221 LINE"
+);
+}
+);
+width = 832;
+}
+);
+},
+{
+glyphname = uni10C87.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"266 -135 LINE",
+"266 285 LINE",
+"58 398 LINE",
+"97 472 LINE",
+"266 377 LINE",
+"266 714 LINE",
+"362 714 LINE",
+"362 327 LINE",
+"570 216 LINE",
+"531 144 LINE",
+"362 236 LINE",
+"362 -135 LINE"
+);
+}
+);
+width = 627;
+}
+);
+},
+{
+glyphname = uni10C88.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"4 -135 LINE",
+"277 294 LINE",
+"39 364 LINE",
+"55 434 LINE",
+"243 378 LINE",
+"24 714 LINE",
+"128 714 LINE",
+"345 374 LINE",
+"559 714 LINE",
+"669 714 LINE",
+"417 326 LINE",
+"661 254 LINE",
+"637 187 LINE",
+"446 244 LINE",
+"687 -135 LINE",
+"583 -135 LINE",
+"348 240 LINE",
+"116 -135 LINE"
+);
+}
+);
+width = 691;
+}
+);
+},
+{
+glyphname = uni10C89.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"426 -159 LINE",
+"379 -129 OFFCURVE",
+"300 -72 OFFCURVE",
+"268 -45 QCURVE",
+"145 -151 LINE",
+"96 -88 LINE",
+"209 10 LINE",
+"147 75 OFFCURVE",
+"95 209 OFFCURVE",
+"95 289 QCURVE SMOOTH",
+"95 370 OFFCURVE",
+"148 505 OFFCURVE",
+"211 572 QCURVE",
+"96 672 LINE",
+"145 735 LINE",
+"270 627 LINE",
+"301 654 OFFCURVE",
+"376 709 OFFCURVE",
+"421 738 QCURVE",
+"482 671 LINE",
+"439 643 OFFCURVE",
+"368 591 OFFCURVE",
+"339 567 QCURVE",
+"465 459 LINE",
+"410 399 LINE",
+"280 512 LINE",
+"230 459 OFFCURVE",
+"189 354 OFFCURVE",
+"189 289 QCURVE SMOOTH",
+"189 225 OFFCURVE",
+"230 119 OFFCURVE",
+"276 68 QCURVE",
+"410 184 LINE",
+"465 125 LINE",
+"335 13 LINE",
+"364 -11 OFFCURVE",
+"434 -61 OFFCURVE",
+"477 -88 QCURVE"
+);
+}
+);
+width = 563;
+}
+);
+},
+{
+glyphname = uni10C8A.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"98 -88 LINE",
+"136 -64 OFFCURVE",
+"200 -20 OFFCURVE",
+"227 1 QCURVE",
+"160 69 OFFCURVE",
+"102 207 OFFCURVE",
+"102 289 QCURVE SMOOTH",
+"102 372 OFFCURVE",
+"159 509 OFFCURVE",
+"225 577 QCURVE",
+"198 599 OFFCURVE",
+"132 646 OFFCURVE",
+"93 671 QCURVE",
+"154 738 LINE",
+"236 685 OFFCURVE",
+"293 638 QCURVE",
+"350 685 OFFCURVE",
+"432 738 QCURVE",
+"493 671 LINE",
+"454 646 OFFCURVE",
+"388 599 OFFCURVE",
+"360 576 QCURVE",
+"427 509 OFFCURVE",
+"484 371 OFFCURVE",
+"484 289 QCURVE SMOOTH",
+"484 207 OFFCURVE",
+"427 69 OFFCURVE",
+"359 1 QCURVE",
+"386 -20 OFFCURVE",
+"451 -64 OFFCURVE",
+"488 -88 QCURVE",
+"436 -159 LINE",
+"395 -132 OFFCURVE",
+"323 -82 OFFCURVE",
+"293 -58 QCURVE",
+"263 -82 OFFCURVE",
+"191 -132 OFFCURVE",
+"150 -159 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"345 113 OFFCURVE",
+"390 223 OFFCURVE",
+"390 289 QCURVE SMOOTH",
+"390 355 OFFCURVE",
+"346 462 OFFCURVE",
+"293 516 QCURVE",
+"240 462 OFFCURVE",
+"196 355 OFFCURVE",
+"196 289 QCURVE SMOOTH",
+"196 223 OFFCURVE",
+"241 113 OFFCURVE",
+"293 60 QCURVE"
+);
+}
+);
+width = 586;
+}
+);
+},
+{
+glyphname = uni10C8B.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"232 -174 LINE",
+"174 -105 LINE",
+"281 -16 LINE",
+"175 58 OFFCURVE",
+"82 201 OFFCURVE",
+"82 289 QCURVE SMOOTH",
+"82 379 OFFCURVE",
+"175 522 OFFCURVE",
+"281 595 QCURVE",
+"174 684 LINE",
+"232 752 LINE",
+"424 586 LINE",
+"338 534 OFFCURVE",
+"228 443 OFFCURVE",
+"176 348 OFFCURVE",
+"176 289 QCURVE SMOOTH",
+"176 231 OFFCURVE",
+"229 136 OFFCURVE",
+"339 44 OFFCURVE",
+"424 -7 QCURVE"
+);
+}
+);
+width = 512;
+}
+);
+},
+{
+glyphname = uni10C8C.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"338 -135 LINE",
+"259 -73 OFFCURVE",
+"144 55 OFFCURVE",
+"82 201 OFFCURVE",
+"82 289 QCURVE SMOOTH",
+"82 378 OFFCURVE",
+"144 524 OFFCURVE",
+"259 653 OFFCURVE",
+"338 714 QCURVE",
+"432 714 LINE",
+"512 653 OFFCURVE",
+"626 524 OFFCURVE",
+"688 378 OFFCURVE",
+"688 289 QCURVE SMOOTH",
+"688 201 OFFCURVE",
+"626 55 OFFCURVE",
+"511 -73 OFFCURVE",
+"431 -135 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"383 342 LINE",
+"522 507 LINE",
+"473 571 OFFCURVE",
+"387 643 QCURVE",
+"383 643 LINE",
+"340 606 OFFCURVE",
+"272 539 OFFCURVE",
+"247 505 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"559 132 LINE",
+"577 168 OFFCURVE",
+"595 245 OFFCURVE",
+"595 289 QCURVE SMOOTH",
+"595 375 OFFCURVE",
+"560 445 QCURVE",
+"430 287 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"337 287 LINE",
+"209 442 LINE",
+"175 374 OFFCURVE",
+"175 289 QCURVE SMOOTH",
+"175 204 OFFCURVE",
+"209 135 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"387 -63 LINE",
+"428 -28 OFFCURVE",
+"493 37 OFFCURVE",
+"518 68 QCURVE",
+"383 231 LINE",
+"250 71 LINE",
+"275 38 OFFCURVE",
+"341 -28 OFFCURVE",
+"383 -63 QCURVE"
+);
+}
+);
+width = 769;
+}
+);
+},
+{
+glyphname = uni10C8D.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"21 -135 LINE",
+"354 714 LINE",
+"441 714 LINE",
+"780 -135 LINE",
+"680 -135 LINE",
+"468 411 LINE SMOOTH",
+"447 465 OFFCURVE",
+"413 560 OFFCURVE",
+"402 602 QCURVE",
+"398 602 LINE",
+"388 560 OFFCURVE",
+"354 467 OFFCURVE",
+"333 413 QCURVE SMOOTH",
+"321 383 LINE",
+"515 -135 LINE",
+"421 -135 LINE",
+"277 269 LINE",
+"120 -135 LINE"
+);
+}
+);
+width = 801;
+}
+);
+},
+{
+glyphname = uni10C8E.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"263 -135 LINE",
+"263 131 LINE",
+"55 243 LINE",
+"94 317 LINE",
+"263 226 LINE",
+"263 388 LINE",
+"55 500 LINE",
+"94 574 LINE",
+"263 483 LINE",
+"263 714 LINE",
+"359 714 LINE",
+"359 431 LINE",
+"567 318 LINE",
+"528 246 LINE",
+"359 337 LINE",
+"359 174 LINE",
+"567 61 LINE",
+"528 -11 LINE",
+"359 80 LINE",
+"359 -135 LINE"
+);
+}
+);
+width = 624;
+}
+);
+},
+{
+glyphname = uni10C8F.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"65 -135 LINE",
+"296 78 LINE",
+"51 305 LINE",
+"296 515 LINE",
+"65 714 LINE",
+"187 714 LINE",
+"356 566 LINE",
+"526 714 LINE",
+"646 714 LINE",
+"415 515 LINE",
+"659 305 LINE",
+"415 78 LINE",
+"646 -135 LINE",
+"524 -135 LINE",
+"356 24 LINE",
+"187 -135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"356 136 LINE",
+"536 306 LINE",
+"356 462 LINE",
+"176 306 LINE"
+);
+}
+);
+width = 710;
+}
+);
+},
+{
+glyphname = uni10C90.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"266 -135 LINE",
+"266 388 LINE",
+"58 500 LINE",
+"97 574 LINE",
+"266 483 LINE",
+"266 714 LINE",
+"362 714 LINE",
+"362 431 LINE",
+"570 318 LINE",
+"531 246 LINE",
+"362 337 LINE",
+"362 -135 LINE"
+);
+}
+);
+width = 627;
+}
+);
+},
+{
+glyphname = uni10C91.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"253 -135 LINE",
+"253 675 LINE",
+"58 780 LINE",
+"97 854 LINE",
+"570 598 LINE",
+"531 526 LINE",
+"349 624 LINE",
+"349 -135 LINE"
+);
+}
+);
+width = 627;
+}
+);
+},
+{
+glyphname = uni10C92.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"134 -135 LINE",
+"134 714 LINE",
+"210 714 LINE",
+"516 413 LINE",
+"461 353 LINE",
+"223 588 LINE",
+"223 -135 LINE"
+);
+}
+);
+width = 547;
+}
+);
+},
+{
+glyphname = uni10C93.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"295 -135 LINE",
+"55 295 LINE",
+"295 714 LINE",
+"387 714 LINE",
+"628 295 LINE",
+"387 -135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"341 -49 LINE",
+"528 295 LINE",
+"341 629 LINE",
+"156 295 LINE"
+);
+}
+);
+width = 684;
+}
+);
+},
+{
+glyphname = uni10C94.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"266 -135 LINE",
+"17 88 LINE",
+"76 152 LINE",
+"258 -12 LINE",
+"258 714 LINE",
+"340 714 LINE",
+"589 491 LINE",
+"530 427 LINE",
+"348 590 LINE",
+"348 -135 LINE"
+);
+}
+);
+width = 613;
+}
+);
+},
+{
+glyphname = uni10C95.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"240 -165 LINE",
+"33 -65 LINE",
+"66 6 LINE",
+"200 -63 LINE",
+"408 294 LINE",
+"206 640 LINE",
+"72 572 LINE",
+"39 642 LINE",
+"246 744 LINE",
+"454 378 LINE",
+"661 744 LINE",
+"869 642 LINE",
+"835 572 LINE",
+"702 640 LINE",
+"499 294 LINE",
+"708 -63 LINE",
+"841 6 LINE",
+"875 -65 LINE",
+"667 -165 LINE",
+"454 211 LINE"
+);
+}
+);
+width = 907;
+}
+);
+},
+{
+glyphname = uni10C96.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"17 -135 LINE",
+"355 714 LINE",
+"441 714 LINE",
+"783 -135 LINE",
+"683 -135 LINE",
+"469 413 LINE SMOOTH",
+"448 467 OFFCURVE",
+"413 562 OFFCURVE",
+"401 602 QCURVE",
+"397 602 LINE",
+"386 563 OFFCURVE",
+"356 479 OFFCURVE",
+"338 430 QCURVE",
+"559 -135 LINE",
+"469 -135 LINE",
+"292 314 LINE",
+"232 160 LINE",
+"348 -135 LINE",
+"260 -135 LINE",
+"188 49 LINE",
+"116 -135 LINE"
+);
+}
+);
+width = 801;
+}
+);
+},
+{
+glyphname = uni10C97.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"337 -135 LINE",
+"260 -73 OFFCURVE",
+"146 55 OFFCURVE",
+"85 201 OFFCURVE",
+"85 289 QCURVE SMOOTH",
+"85 378 OFFCURVE",
+"146 524 OFFCURVE",
+"260 653 OFFCURVE",
+"337 714 QCURVE",
+"431 714 LINE",
+"509 653 OFFCURVE",
+"622 524 OFFCURVE",
+"683 378 OFFCURVE",
+"683 289 QCURVE SMOOTH",
+"683 201 OFFCURVE",
+"622 55 OFFCURVE",
+"508 -73 OFFCURVE",
+"430 -135 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"560 143 LINE",
+"590 209 OFFCURVE",
+"590 289 QCURVE SMOOTH",
+"590 360 OFFCURVE",
+"545 475 OFFCURVE",
+"455 583 OFFCURVE",
+"386 643 QCURVE",
+"382 643 LINE",
+"340 606 OFFCURVE",
+"274 539 OFFCURVE",
+"249 506 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"386 -63 LINE",
+"427 -26 OFFCURVE",
+"493 40 OFFCURVE",
+"518 74 QCURVE",
+"210 439 LINE",
+"178 374 OFFCURVE",
+"178 289 QCURVE SMOOTH",
+"178 219 OFFCURVE",
+"223 104 OFFCURVE",
+"313 -3 OFFCURVE",
+"382 -63 QCURVE"
+);
+}
+);
+width = 768;
+}
+);
+},
+{
+glyphname = uni10C98.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"130 -135 LINE",
+"130 714 LINE",
+"225 714 LINE",
+"555 525 LINE",
+"555 437 LINE",
+"339 293 LINE",
+"555 150 LINE",
+"555 63 LINE",
+"225 -135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"220 310 LINE",
+"471 479 LINE",
+"220 622 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"220 -35 LINE",
+"471 111 LINE",
+"220 277 LINE"
+);
+}
+);
+width = 627;
+}
+);
+},
+{
+glyphname = uni10C99.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"420 -159 LINE",
+"296 -79 OFFCURVE",
+"150 59 OFFCURVE",
+"86 203 OFFCURVE",
+"86 289 QCURVE SMOOTH",
+"86 375 OFFCURVE",
+"149 519 OFFCURVE",
+"294 659 OFFCURVE",
+"415 738 QCURVE",
+"476 671 LINE",
+"392 616 OFFCURVE",
+"278 522 OFFCURVE",
+"210 435 OFFCURVE",
+"180 343 OFFCURVE",
+"180 289 QCURVE SMOOTH",
+"180 216 OFFCURVE",
+"236 96 OFFCURVE",
+"364 -20 OFFCURVE",
+"471 -88 QCURVE"
+);
+}
+);
+width = 538;
+}
+);
+},
+{
+glyphname = uni10C9A.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"421 -135 LINE",
+"297 -68 OFFCURVE",
+"145 62 OFFCURVE",
+"76 205 OFFCURVE",
+"76 289 QCURVE SMOOTH",
+"76 372 OFFCURVE",
+"146 514 OFFCURVE",
+"298 647 OFFCURVE",
+"421 714 QCURVE",
+"511 714 LINE",
+"511 -135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"421 618 LINE",
+"330 564 OFFCURVE",
+"219 463 OFFCURVE",
+"170 355 OFFCURVE",
+"170 289 QCURVE SMOOTH",
+"170 223 OFFCURVE",
+"221 113 OFFCURVE",
+"332 14 OFFCURVE",
+"421 -37 QCURVE"
+);
+}
+);
+width = 633;
+}
+);
+},
+{
+glyphname = uni10C9B.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"343 -155 LINE",
+"253 -86 OFFCURVE",
+"134 44 OFFCURVE",
+"75 191 OFFCURVE",
+"75 284 QCURVE SMOOTH",
+"75 370 OFFCURVE",
+"127 513 OFFCURVE",
+"245 654 OFFCURVE",
+"343 734 QCURVE",
+"579 516 LINE",
+"517 455 LINE",
+"345 614 LINE",
+"280 557 OFFCURVE",
+"202 456 OFFCURVE",
+"169 350 OFFCURVE",
+"169 284 QCURVE SMOOTH",
+"169 216 OFFCURVE",
+"202 105 OFFCURVE",
+"275 7 OFFCURVE",
+"335 -45 QCURVE",
+"517 124 LINE",
+"579 63 LINE"
+);
+}
+);
+width = 634;
+}
+);
+},
+{
+glyphname = uni10C9C.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"347 -159 LINE",
+"257 -87 OFFCURVE",
+"138 46 OFFCURVE",
+"79 191 OFFCURVE",
+"79 278 QCURVE SMOOTH",
+"79 362 OFFCURVE",
+"131 506 OFFCURVE",
+"249 651 OFFCURVE",
+"347 734 QCURVE",
+"407 659 LINE",
+"320 585 OFFCURVE",
+"219 466 OFFCURVE",
+"176 349 OFFCURVE",
+"176 278 QCURVE SMOOTH",
+"176 186 OFFCURVE",
+"251 36 OFFCURVE",
+"339 -44 QCURVE",
+"500 117 LINE",
+"357 271 LINE",
+"417 334 LINE",
+"621 109 LINE"
+);
+}
+);
+width = 658;
+}
+);
+},
+{
+glyphname = uni10C9D.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"146 -145 LINE",
+"83 -79 LINE",
+"292 161 LINE",
+"71 420 LINE",
+"342 718 LINE",
+"406 652 LINE",
+"189 415 LINE",
+"411 157 LINE"
+);
+}
+);
+width = 482;
+}
+);
+},
+{
+glyphname = uni10C9E.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"18 -135 LINE",
+"307 302 LINE",
+"27 714 LINE",
+"136 714 LINE",
+"411 298 LINE",
+"411 714 LINE",
+"501 714 LINE",
+"501 -135 LINE",
+"411 -135 LINE",
+"411 296 LINE",
+"132 -135 LINE"
+);
+}
+);
+width = 624;
+}
+);
+},
+{
+glyphname = uni10C9F.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"413 -156 LINE",
+"358 -112 OFFCURVE",
+"270 -29 OFFCURVE",
+"238 13 QCURVE",
+"145 -70 LINE",
+"97 -15 LINE",
+"197 74 LINE",
+"145 166 OFFCURVE",
+"145 279 QCURVE SMOOTH",
+"145 337 OFFCURVE",
+"169 440 OFFCURVE",
+"196 489 QCURVE",
+"100 575 LINE",
+"148 632 LINE",
+"236 553 LINE",
+"268 596 OFFCURVE",
+"355 684 OFFCURVE",
+"413 733 QCURVE",
+"473 659 LINE",
+"416 611 OFFCURVE",
+"334 528 OFFCURVE",
+"306 490 QCURVE",
+"360 442 LINE",
+"312 386 LINE",
+"268 425 LINE",
+"239 358 OFFCURVE",
+"239 279 QCURVE SMOOTH",
+"239 203 OFFCURVE",
+"266 137 QCURVE",
+"312 178 LINE",
+"360 122 LINE",
+"303 71 LINE",
+"322 43 OFFCURVE",
+"373 -12 OFFCURVE",
+"404 -41 QCURVE",
+"561 116 LINE",
+"419 270 LINE",
+"483 334 LINE",
+"687 111 LINE",
+"682 108 LINE",
+"685 107 LINE"
+);
+}
+);
+width = 724;
+}
+);
+},
+{
+glyphname = uni10CA0.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"462 -156 LINE",
+"217 81 LINE",
+"217 -135 LINE",
+"127 -135 LINE",
+"127 714 LINE",
+"208 714 LINE",
+"517 417 LINE",
+"462 362 LINE",
+"217 600 LINE",
+"217 446 LINE",
+"517 157 LINE",
+"462 102 LINE",
+"217 340 LINE",
+"217 186 LINE",
+"517 -101 LINE"
+);
+}
+);
+width = 578;
+}
+);
+},
+{
+glyphname = uni10CA1.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"235 -170 LINE",
+"171 -110 LINE",
+"307 26 LINE",
+"242 112 OFFCURVE",
+"223 207 QCURVE",
+"88 125 LINE",
+"46 203 LINE",
+"215 295 LINE",
+"216 357 OFFCURVE",
+"249 481 OFFCURVE",
+"295 540 QCURVE",
+"292 543 LINE",
+"160 475 LINE",
+"121 554 LINE",
+"464 714 LINE",
+"563 714 LINE",
+"906 554 LINE",
+"867 475 LINE",
+"736 543 LINE",
+"734 539 LINE",
+"780 480 OFFCURVE",
+"818 357 OFFCURVE",
+"819 295 QCURVE",
+"988 203 LINE",
+"947 125 LINE",
+"812 207 LINE",
+"802 158 OFFCURVE",
+"759 68 OFFCURVE",
+"727 26 QCURVE",
+"857 -110 LINE",
+"792 -170 LINE",
+"673 -37 LINE",
+"648 -62 OFFCURVE",
+"593 -110 OFFCURVE",
+"562 -135 QCURVE",
+"464 -135 LINE",
+"434 -110 OFFCURVE",
+"385 -62 OFFCURVE",
+"360 -37 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"514 -63 LINE",
+"612 14 OFFCURVE",
+"722 183 OFFCURVE",
+"722 295 QCURVE SMOOTH",
+"722 403 OFFCURVE",
+"620 574 OFFCURVE",
+"514 638 QCURVE",
+"510 638 LINE",
+"404 574 OFFCURVE",
+"302 403 OFFCURVE",
+"302 295 QCURVE SMOOTH",
+"302 183 OFFCURVE",
+"411 14 OFFCURVE",
+"510 -63 QCURVE"
+);
+}
+);
+width = 1027;
+}
+);
+},
+{
+glyphname = uni10CA2.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"129 -135 LINE",
+"129 714 LINE",
+"219 714 LINE",
+"219 471 LINE",
+"612 208 LINE",
+"612 714 LINE",
+"702 714 LINE",
+"702 -135 LINE",
+"612 -135 LINE",
+"612 114 LINE",
+"219 372 LINE",
+"219 -135 LINE"
+);
+}
+);
+width = 832;
+}
+);
+},
+{
+glyphname = uni10CA3.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"520 127 LINE",
+"57 400 LINE",
+"99 474 LINE",
+"561 201 LINE"
+);
+}
+);
+width = 613;
+}
+);
+},
+{
+glyphname = uni10CA4.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"12 -135 LINE",
+"313 714 LINE",
+"404 714 LINE",
+"711 -135 LINE",
+"616 -135 LINE",
+"425 411 LINE SMOOTH",
+"406 464 OFFCURVE",
+"374 561 OFFCURVE",
+"364 601 QCURVE",
+"360 601 LINE",
+"350 561 OFFCURVE",
+"318 464 OFFCURVE",
+"300 413 QCURVE SMOOTH",
+"107 -135 LINE"
+);
+}
+);
+width = 724;
+}
+);
+},
+{
+glyphname = uni10CA5.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"127 -135 LINE",
+"127 714 LINE",
+"217 714 LINE",
+"217 -135 LINE"
+);
+}
+);
+width = 341;
+}
+);
+},
+{
+glyphname = uni10CA6.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"121 -135 LINE",
+"121 714 LINE",
+"211 714 LINE",
+"211 356 LINE",
+"485 740 LINE",
+"557 691 LINE",
+"211 216 LINE",
+"211 -135 LINE"
+);
+}
+);
+width = 567;
+}
+);
+},
+{
+glyphname = uni10CA7.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"388 -135 LINE",
+"388 393 LINE",
+"185 609 LINE",
+"76 496 LINE",
+"19 555 LINE",
+"187 726 LINE",
+"388 510 LINE",
+"388 714 LINE",
+"478 714 LINE",
+"478 511 LINE",
+"678 726 LINE",
+"846 555 LINE",
+"790 496 LINE",
+"681 609 LINE",
+"478 394 LINE",
+"478 -135 LINE"
+);
+}
+);
+width = 866;
+}
+);
+},
+{
+glyphname = uni10CA8.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"4 -135 LINE",
+"287 310 LINE",
+"24 714 LINE",
+"128 714 LINE",
+"345 374 LINE",
+"417 488 LINE",
+"278 714 LINE",
+"374 714 LINE",
+"464 564 LINE",
+"559 714 LINE",
+"669 714 LINE",
+"405 308 LINE",
+"687 -135 LINE",
+"583 -135 LINE",
+"348 240 LINE",
+"271 115 LINE",
+"423 -135 LINE",
+"327 -135 LINE",
+"223 38 LINE",
+"116 -135 LINE"
+);
+}
+);
+width = 691;
+}
+);
+},
+{
+glyphname = uni10CA9.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"117 -163 LINE",
+"53 -98 LINE",
+"317 306 LINE",
+"54 693 LINE",
+"115 748 LINE",
+"401 667 LINE",
+"380 594 LINE",
+"177 654 LINE",
+"368 365 LINE",
+"583 714 LINE",
+"690 714 LINE",
+"426 301 LINE",
+"720 -135 LINE",
+"620 -135 LINE",
+"372 238 LINE",
+"176 -70 LINE",
+"379 -11 LINE",
+"404 -85 LINE"
+);
+}
+);
+width = 724;
+}
+);
+},
+{
+glyphname = uni10CAA.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"135 -135 LINE",
+"135 714 LINE",
+"223 714 LINE",
+"448 540 LINE",
+"673 714 LINE",
+"761 714 LINE",
+"761 -135 LINE",
+"673 -135 LINE",
+"448 40 LINE",
+"223 -135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"225 -28 LINE",
+"448 140 LINE",
+"671 -28 LINE",
+"671 607 LINE",
+"448 439 LINE",
+"225 607 LINE"
+);
+}
+);
+width = 885;
+}
+);
+},
+{
+glyphname = uni10CAB.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"116 -135 LINE",
+"116 714 LINE",
+"198 714 LINE",
+"475 358 LINE",
+"749 714 LINE",
+"831 714 LINE",
+"831 -135 LINE",
+"749 -135 LINE",
+"475 223 LINE",
+"198 -135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"205 11 LINE",
+"209 11 LINE",
+"425 289 LINE",
+"209 569 LINE",
+"205 569 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"738 19 LINE",
+"742 19 LINE",
+"742 561 LINE",
+"738 561 LINE",
+"527 289 LINE"
+);
+}
+);
+width = 953;
+}
+);
+},
+{
+glyphname = uni10CAC.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"106 -151 LINE",
+"41 -91 LINE",
+"166 39 LINE",
+"128 95 OFFCURVE",
+"86 217 OFFCURVE",
+"86 289 QCURVE SMOOTH",
+"86 361 OFFCURVE",
+"128 485 OFFCURVE",
+"166 540 QCURVE",
+"42 669 LINE",
+"106 730 LINE",
+"218 605 LINE",
+"244 633 OFFCURVE",
+"304 687 OFFCURVE",
+"338 714 QCURVE",
+"432 714 LINE",
+"466 688 OFFCURVE",
+"526 634 OFFCURVE",
+"551 605 QCURVE",
+"663 730 LINE",
+"728 669 LINE",
+"604 541 LINE",
+"642 486 OFFCURVE",
+"684 362 OFFCURVE",
+"684 289 QCURVE SMOOTH",
+"684 217 OFFCURVE",
+"642 94 OFFCURVE",
+"604 39 QCURVE",
+"728 -91 LINE",
+"663 -151 LINE",
+"551 -26 LINE",
+"526 -54 OFFCURVE",
+"465 -108 OFFCURVE",
+"431 -135 QCURVE",
+"338 -135 LINE",
+"304 -108 OFFCURVE",
+"244 -54 OFFCURVE",
+"218 -26 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"387 -63 LINE",
+"456 -3 OFFCURVE",
+"546 104 OFFCURVE",
+"591 219 OFFCURVE",
+"591 289 QCURVE SMOOTH",
+"591 360 OFFCURVE",
+"546 475 OFFCURVE",
+"456 583 OFFCURVE",
+"387 643 QCURVE",
+"383 643 LINE",
+"314 583 OFFCURVE",
+"224 475 OFFCURVE",
+"179 360 OFFCURVE",
+"179 289 QCURVE SMOOTH",
+"179 219 OFFCURVE",
+"224 104 OFFCURVE",
+"314 -3 OFFCURVE",
+"383 -63 QCURVE"
+);
+}
+);
+width = 769;
+}
+);
+},
+{
+glyphname = uni10CAD.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"131 -135 LINE",
+"131 492 LINE",
+"221 492 LINE",
+"568 231 LINE",
+"568 714 LINE",
+"658 714 LINE",
+"658 127 LINE",
+"568 127 LINE",
+"221 383 LINE",
+"221 -135 LINE"
+);
+}
+);
+width = 788;
+}
+);
+},
+{
+glyphname = uni10CAE.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"138 -135 LINE",
+"138 714 LINE",
+"226 714 LINE",
+"451 540 LINE",
+"676 714 LINE",
+"764 714 LINE",
+"764 -135 LINE",
+"674 -135 LINE",
+"674 607 LINE",
+"451 439 LINE",
+"228 607 LINE",
+"228 -135 LINE"
+);
+}
+);
+width = 888;
+}
+);
+},
+{
+glyphname = uni10CAF.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"115 -135 LINE",
+"115 714 LINE",
+"202 714 LINE",
+"609 457 LINE",
+"609 714 LINE",
+"699 714 LINE",
+"699 -135 LINE",
+"612 -135 LINE",
+"205 123 LINE",
+"205 -135 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"609 207 LINE",
+"609 368 LINE",
+"205 623 LINE",
+"205 462 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"609 -42 LINE",
+"609 118 LINE",
+"205 373 LINE",
+"205 213 LINE"
+);
+}
+);
+width = 820;
+}
+);
+},
+{
+glyphname = uni10CB0.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"356 -135 LINE",
+"356 228 LINE",
+"16 691 LINE",
+"90 742 LINE",
+"356 370 LINE",
+"356 714 LINE",
+"446 714 LINE",
+"446 370 LINE",
+"712 742 LINE",
+"786 691 LINE",
+"446 228 LINE",
+"446 -135 LINE"
+);
+}
+);
+width = 796;
+}
+);
+},
+{
+glyphname = uni10CB1.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"389 -135 LINE",
+"187 77 LINE",
+"78 -37 LINE",
+"21 23 LINE",
+"189 191 LINE",
+"389 -23 LINE",
+"389 131 LINE",
+"187 343 LINE",
+"78 229 LINE",
+"21 288 LINE",
+"189 457 LINE",
+"389 243 LINE",
+"389 397 LINE",
+"187 609 LINE",
+"78 496 LINE",
+"21 555 LINE",
+"189 724 LINE",
+"389 510 LINE",
+"389 714 LINE",
+"479 714 LINE",
+"479 510 LINE",
+"678 724 LINE",
+"846 555 LINE",
+"790 496 LINE",
+"681 609 LINE",
+"479 397 LINE",
+"479 243 LINE",
+"678 457 LINE",
+"846 288 LINE",
+"790 229 LINE",
+"681 343 LINE",
+"479 131 LINE",
+"479 -23 LINE",
+"678 191 LINE",
+"846 23 LINE",
+"790 -37 LINE",
+"681 77 LINE",
+"479 -135 LINE"
+);
+}
+);
+width = 866;
+}
+);
+},
+{
+glyphname = uni10CB2.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"335 -135 LINE",
+"258 -73 OFFCURVE",
+"142 55 OFFCURVE",
+"78 201 OFFCURVE",
+"78 289 QCURVE SMOOTH",
+"78 378 OFFCURVE",
+"142 524 OFFCURVE",
+"258 653 OFFCURVE",
+"335 714 QCURVE",
+"434 714 LINE",
+"512 653 OFFCURVE",
+"627 524 OFFCURVE",
+"691 378 OFFCURVE",
+"691 289 QCURVE SMOOTH",
+"691 201 OFFCURVE",
+"627 55 OFFCURVE",
+"512 -73 OFFCURVE",
+"434 -135 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"342 614 LINE",
+"285 561 OFFCURVE",
+"211 461 OFFCURVE",
+"174 354 OFFCURVE",
+"174 289 QCURVE SMOOTH",
+"174 225 OFFCURVE",
+"211 118 OFFCURVE",
+"285 19 OFFCURVE",
+"342 -35 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"427 -35 LINE",
+"485 19 OFFCURVE",
+"559 118 OFFCURVE",
+"596 225 OFFCURVE",
+"596 289 QCURVE SMOOTH",
+"596 354 OFFCURVE",
+"559 461 OFFCURVE",
+"485 561 OFFCURVE",
+"427 614 QCURVE"
+);
+}
+);
+width = 769;
+}
+);
+},
+{
+glyphname = uni10CC0.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"214 600 LINE",
+"412 409 LINE",
+"412 300 LINE",
+"182 289 LINE",
+"182 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"182 366 LINE",
+"336 373 LINE",
+"182 523 LINE"
+);
+}
+);
+width = 444;
+}
+);
+},
+{
+glyphname = uni10CC1.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"180 600 LINE",
+"391 414 LINE",
+"391 334 LINE",
+"182 164 LINE",
+"182 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"182 268 LINE",
+"315 375 LINE",
+"182 495 LINE"
+);
+}
+);
+width = 433;
+}
+);
+},
+{
+glyphname = uni10CC2.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"10 0 LINE",
+"217 313 LINE",
+"25 600 LINE",
+"119 600 LINE",
+"268 371 LINE",
+"417 600 LINE",
+"516 600 LINE",
+"321 311 LINE",
+"528 0 LINE",
+"434 0 LINE",
+"271 253 LINE",
+"111 0 LINE"
+);
+}
+);
+width = 538;
+}
+);
+},
+{
+glyphname = uni10CC3.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"192 -1 LINE",
+"40 65 LINE",
+"68 131 LINE",
+"170 83 LINE",
+"206 130 LINE",
+"179 168 OFFCURVE",
+"150 251 OFFCURVE",
+"150 300 QCURVE SMOOTH",
+"150 349 OFFCURVE",
+"179 433 OFFCURVE",
+"206 470 QCURVE",
+"170 515 LINE",
+"68 467 LINE",
+"40 535 LINE",
+"192 600 LINE",
+"254 527 LINE",
+"273 546 OFFCURVE",
+"316 582 OFFCURVE",
+"339 600 QCURVE",
+"408 600 LINE",
+"432 581 OFFCURVE",
+"476 545 OFFCURVE",
+"495 525 QCURVE",
+"558 600 LINE",
+"711 535 LINE",
+"681 467 LINE",
+"581 515 LINE",
+"543 467 LINE",
+"569 430 OFFCURVE",
+"596 347 OFFCURVE",
+"596 300 QCURVE SMOOTH",
+"596 252 OFFCURVE",
+"569 169 OFFCURVE",
+"543 132 QCURVE",
+"581 83 LINE",
+"681 131 LINE",
+"711 65 LINE",
+"558 -1 LINE",
+"494 74 LINE",
+"456 36 OFFCURVE",
+"408 0 QCURVE",
+"339 0 LINE",
+"316 18 OFFCURVE",
+"273 54 OFFCURVE",
+"254 73 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"374 64 LINE",
+"422 105 OFFCURVE",
+"484 176 OFFCURVE",
+"513 252 OFFCURVE",
+"513 300 QCURVE SMOOTH",
+"513 347 OFFCURVE",
+"484 423 OFFCURVE",
+"423 495 OFFCURVE",
+"374 536 QCURVE",
+"372 536 LINE",
+"301 475 OFFCURVE",
+"233 370 OFFCURVE",
+"233 300 QCURVE SMOOTH",
+"233 230 OFFCURVE",
+"300 125 OFFCURVE",
+"372 64 QCURVE"
+);
+}
+);
+width = 751;
+}
+);
+},
+{
+glyphname = uni10CC4.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"180 0 LINE",
+"180 488 LINE",
+"53 376 LINE",
+"4 434 LINE",
+"195 600 LINE",
+"252 600 LINE",
+"443 434 LINE",
+"394 376 LINE",
+"267 488 LINE",
+"267 0 LINE"
+);
+}
+);
+width = 447;
+}
+);
+},
+{
+glyphname = uni10CC5.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"195 0 LINE",
+"4 166 LINE",
+"53 224 LINE",
+"180 112 LINE",
+"180 488 LINE",
+"53 376 LINE",
+"4 434 LINE",
+"195 600 LINE",
+"252 600 LINE",
+"443 434 LINE",
+"394 376 LINE",
+"267 488 LINE",
+"267 112 LINE",
+"394 224 LINE",
+"443 166 LINE",
+"252 0 LINE"
+);
+}
+);
+width = 447;
+}
+);
+},
+{
+glyphname = uni10CC6.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"171 600 LINE",
+"435 428 LINE",
+"435 600 LINE",
+"520 600 LINE",
+"520 0 LINE",
+"444 0 LINE",
+"180 170 LINE",
+"180 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"435 91 LINE",
+"435 343 LINE",
+"180 510 LINE",
+"180 255 LINE"
+);
+}
+);
+width = 615;
+}
+);
+},
+{
+glyphname = uni10CC7.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"175 0 LINE",
+"175 290 LINE",
+"26 366 LINE",
+"59 434 LINE",
+"175 374 LINE",
+"175 600 LINE",
+"262 600 LINE",
+"262 328 LINE",
+"411 251 LINE",
+"377 186 LINE",
+"262 245 LINE",
+"262 0 LINE"
+);
+}
+);
+width = 437;
+}
+);
+},
+{
+glyphname = uni10CC8.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"10 0 LINE",
+"206 296 LINE",
+"42 343 LINE",
+"57 407 LINE",
+"177 372 LINE",
+"25 600 LINE",
+"119 600 LINE",
+"268 371 LINE",
+"417 600 LINE",
+"516 600 LINE",
+"332 328 LINE",
+"505 278 LINE",
+"482 217 LINE",
+"360 252 LINE",
+"528 0 LINE",
+"434 0 LINE",
+"271 253 LINE",
+"111 0 LINE"
+);
+}
+);
+width = 538;
+}
+);
+},
+{
+glyphname = uni10CC9.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"100 -27 LINE",
+"57 33 LINE",
+"125 95 LINE",
+"74 139 OFFCURVE",
+"28 237 OFFCURVE",
+"28 300 QCURVE SMOOTH",
+"28 362 OFFCURVE",
+"73 459 OFFCURVE",
+"122 502 QCURVE",
+"57 561 LINE",
+"100 621 LINE",
+"182 546 LINE",
+"236 581 OFFCURVE",
+"316 618 QCURVE",
+"361 551 LINE",
+"326 535 OFFCURVE",
+"268 504 OFFCURVE",
+"244 490 QCURVE",
+"321 420 LINE",
+"273 365 LINE",
+"184 446 LINE",
+"147 414 OFFCURVE",
+"117 344 OFFCURVE",
+"117 300 QCURVE SMOOTH",
+"117 254 OFFCURVE",
+"147 181 OFFCURVE",
+"184 148 QCURVE",
+"273 229 LINE",
+"321 174 LINE",
+"245 104 LINE",
+"291 76 OFFCURVE",
+"357 47 QCURVE",
+"320 -20 LINE",
+"240 16 OFFCURVE",
+"185 51 QCURVE"
+);
+}
+);
+width = 411;
+}
+);
+},
+{
+glyphname = uni10CCA.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"34 47 LINE",
+"64 61 OFFCURVE",
+"115 86 OFFCURVE",
+"137 99 QCURVE",
+"88 142 OFFCURVE",
+"45 239 OFFCURVE",
+"45 300 QCURVE SMOOTH",
+"45 359 OFFCURVE",
+"88 455 OFFCURVE",
+"134 497 QCURVE",
+"112 510 OFFCURVE",
+"61 537 OFFCURVE",
+"30 551 QCURVE",
+"75 618 LINE",
+"150 584 OFFCURVE",
+"204 549 QCURVE",
+"258 584 OFFCURVE",
+"333 618 QCURVE",
+"378 551 LINE",
+"347 537 OFFCURVE",
+"296 510 OFFCURVE",
+"274 497 QCURVE",
+"321 455 OFFCURVE",
+"363 359 OFFCURVE",
+"363 300 QCURVE SMOOTH",
+"363 239 OFFCURVE",
+"320 142 OFFCURVE",
+"271 99 QCURVE",
+"293 86 OFFCURVE",
+"344 61 OFFCURVE",
+"374 47 QCURVE",
+"337 -20 LINE",
+"258 17 OFFCURVE",
+"204 50 QCURVE",
+"150 17 OFFCURVE",
+"71 -20 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"243 180 OFFCURVE",
+"274 254 OFFCURVE",
+"274 300 QCURVE SMOOTH",
+"274 345 OFFCURVE",
+"243 416 OFFCURVE",
+"204 449 QCURVE",
+"165 416 OFFCURVE",
+"134 345 OFFCURVE",
+"134 300 QCURVE SMOOTH",
+"134 254 OFFCURVE",
+"165 180 OFFCURVE",
+"204 146 QCURVE"
+);
+}
+);
+width = 428;
+}
+);
+},
+{
+glyphname = uni10CCB.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"158 -41 LINE",
+"107 20 LINE",
+"187 86 LINE",
+"110 137 OFFCURVE",
+"45 238 OFFCURVE",
+"45 300 QCURVE SMOOTH",
+"45 362 OFFCURVE",
+"110 462 OFFCURVE",
+"188 514 QCURVE",
+"107 580 LINE",
+"158 639 LINE",
+"320 502 LINE",
+"264 471 LINE",
+"193 428 OFFCURVE",
+"131 346 OFFCURVE",
+"131 300 QCURVE SMOOTH",
+"131 256 OFFCURVE",
+"186 178 OFFCURVE",
+"250 137 QCURVE",
+"320 97 LINE"
+);
+}
+);
+width = 354;
+}
+);
+},
+{
+glyphname = uni10CCC.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"244 0 LINE",
+"159 64 OFFCURVE",
+"55 206 OFFCURVE",
+"55 300 QCURVE SMOOTH",
+"55 394 OFFCURVE",
+"159 536 OFFCURVE",
+"244 600 QCURVE",
+"313 600 LINE",
+"398 536 OFFCURVE",
+"501 394 OFFCURVE",
+"501 300 QCURVE SMOOTH",
+"501 206 OFFCURVE",
+"398 64 OFFCURVE",
+"313 0 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"278 349 LINE",
+"366 450 LINE",
+"350 470 OFFCURVE",
+"306 513 OFFCURVE",
+"279 536 QCURVE",
+"277 536 LINE",
+"250 513 OFFCURVE",
+"207 470 OFFCURVE",
+"190 449 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"402 207 LINE",
+"420 249 OFFCURVE",
+"420 300 QCURVE SMOOTH",
+"420 350 OFFCURVE",
+"402 392 QCURVE",
+"322 298 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"234 298 LINE",
+"154 391 LINE",
+"136 349 OFFCURVE",
+"136 300 QCURVE SMOOTH",
+"136 250 OFFCURVE",
+"154 208 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"279 64 LINE",
+"332 108 OFFCURVE",
+"364 147 QCURVE",
+"278 247 LINE",
+"192 147 LINE",
+"224 108 OFFCURVE",
+"277 64 QCURVE"
+);
+}
+);
+width = 556;
+}
+);
+},
+{
+glyphname = uni10CCD.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"4 0 LINE",
+"247 600 LINE",
+"318 600 LINE",
+"560 0 LINE",
+"473 0 LINE",
+"326 371 LINE SMOOTH",
+"309 415 OFFCURVE",
+"290 470 OFFCURVE",
+"284 496 QCURVE",
+"280 496 LINE",
+"274 471 OFFCURVE",
+"254 408 OFFCURVE",
+"240 371 QCURVE SMOOTH",
+"224 330 LINE",
+"352 0 LINE",
+"265 0 LINE",
+"182 225 LINE",
+"93 0 LINE"
+);
+}
+);
+width = 565;
+}
+);
+},
+{
+glyphname = uni10CCE.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"180 0 LINE",
+"180 185 LINE",
+"29 273 LINE",
+"58 336 LINE",
+"180 269 LINE",
+"180 372 LINE",
+"29 459 LINE",
+"58 522 LINE",
+"180 454 LINE",
+"180 600 LINE",
+"267 600 LINE",
+"267 409 LINE",
+"418 324 LINE",
+"383 262 LINE",
+"267 328 LINE",
+"267 223 LINE",
+"418 138 LINE",
+"383 76 LINE",
+"267 141 LINE",
+"267 0 LINE"
+);
+}
+);
+width = 450;
+}
+);
+},
+{
+glyphname = uni10CCF.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"44 0 LINE",
+"213 154 LINE",
+"40 311 LINE",
+"212 455 LINE",
+"42 600 LINE",
+"150 600 LINE",
+"268 501 LINE",
+"385 600 LINE",
+"494 600 LINE",
+"323 455 LINE",
+"496 311 LINE",
+"323 154 LINE",
+"492 0 LINE",
+"384 0 LINE",
+"268 105 LINE",
+"151 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"268 205 LINE",
+"381 310 LINE",
+"268 407 LINE",
+"153 310 LINE"
+);
+}
+);
+width = 536;
+}
+);
+},
+{
+glyphname = uni10CD0.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"182 0 LINE",
+"182 410 LINE",
+"31 494 LINE",
+"60 557 LINE",
+"182 490 LINE",
+"182 600 LINE",
+"269 600 LINE",
+"269 442 LINE",
+"420 359 LINE",
+"385 297 LINE",
+"269 362 LINE",
+"269 0 LINE"
+);
+}
+);
+width = 452;
+}
+);
+},
+{
+glyphname = uni10CD1.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"148 0 LINE",
+"148 558 LINE",
+"0 640 LINE",
+"29 703 LINE",
+"413 492 LINE",
+"378 430 LINE",
+"235 509 LINE",
+"235 0 LINE"
+);
+}
+);
+width = 421;
+}
+);
+},
+{
+glyphname = uni10CD2.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"172 600 LINE",
+"396 383 LINE",
+"342 331 LINE",
+"182 485 LINE",
+"182 0 LINE"
+);
+}
+);
+width = 407;
+}
+);
+},
+{
+glyphname = uni10CD3.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"208 0 LINE",
+"33 304 LINE",
+"208 600 LINE",
+"284 600 LINE",
+"460 304 LINE",
+"284 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"246 83 LINE",
+"370 303 LINE",
+"246 517 LINE",
+"123 303 LINE"
+);
+}
+);
+width = 493;
+}
+);
+},
+{
+glyphname = uni10CD4.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"206 0 LINE",
+"15 166 LINE",
+"64 224 LINE",
+"191 112 LINE",
+"191 600 LINE",
+"263 600 LINE",
+"454 434 LINE",
+"405 376 LINE",
+"278 488 LINE",
+"278 0 LINE"
+);
+}
+);
+width = 469;
+}
+);
+},
+{
+glyphname = uni10CD5.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"194 -30 LINE",
+"28 46 LINE",
+"59 113 LINE",
+"154 67 LINE",
+"294 301 LINE",
+"159 526 LINE",
+"63 479 LINE",
+"32 547 LINE",
+"199 623 LINE",
+"342 375 LINE",
+"487 624 LINE",
+"652 547 LINE",
+"621 479 LINE",
+"526 526 LINE",
+"390 301 LINE",
+"530 67 LINE",
+"626 113 LINE",
+"657 46 LINE",
+"491 -30 LINE",
+"342 227 LINE"
+);
+}
+);
+width = 685;
+}
+);
+},
+{
+glyphname = uni10CD6.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"5 0 LINE",
+"271 600 LINE",
+"342 600 LINE",
+"607 0 LINE",
+"522 0 LINE",
+"357 371 LINE SMOOTH",
+"338 414 OFFCURVE",
+"316 474 OFFCURVE",
+"308 498 QCURVE",
+"304 498 LINE",
+"298 479 OFFCURVE",
+"279 428 OFFCURVE",
+"268 399 QCURVE",
+"439 0 LINE",
+"355 0 LINE",
+"227 305 LINE",
+"186 212 LINE",
+"273 0 LINE",
+"189 0 LINE",
+"144 117 LINE",
+"93 0 LINE"
+);
+}
+);
+width = 612;
+}
+);
+},
+{
+glyphname = uni10CD7.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"244 0 LINE",
+"159 64 OFFCURVE",
+"55 206 OFFCURVE",
+"55 300 QCURVE SMOOTH",
+"55 394 OFFCURVE",
+"159 536 OFFCURVE",
+"244 600 QCURVE",
+"313 600 LINE",
+"398 536 OFFCURVE",
+"501 394 OFFCURVE",
+"501 300 QCURVE SMOOTH",
+"501 206 OFFCURVE",
+"398 64 OFFCURVE",
+"313 0 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"401 208 LINE",
+"418 251 OFFCURVE",
+"418 300 QCURVE SMOOTH",
+"418 347 OFFCURVE",
+"389 423 OFFCURVE",
+"328 495 OFFCURVE",
+"279 536 QCURVE",
+"277 536 LINE",
+"222 488 OFFCURVE",
+"190 448 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"279 64 LINE",
+"305 86 OFFCURVE",
+"347 127 OFFCURVE",
+"363 147 QCURVE",
+"155 389 LINE",
+"138 347 OFFCURVE",
+"138 300 QCURVE SMOOTH",
+"138 230 OFFCURVE",
+"205 125 OFFCURVE",
+"277 64 QCURVE"
+);
+}
+);
+width = 556;
+}
+);
+},
+{
+glyphname = uni10CD8.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"178 600 LINE",
+"433 479 LINE",
+"433 380 LINE",
+"291 303 LINE",
+"433 231 LINE",
+"433 132 LINE",
+"174 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"175 320 LINE",
+"360 426 LINE",
+"175 514 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"175 93 LINE",
+"360 185 LINE",
+"175 284 LINE"
+);
+}
+);
+width = 481;
+}
+);
+},
+{
+glyphname = uni10CD9.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"347 -20 LINE",
+"242 28 OFFCURVE",
+"113 122 OFFCURVE",
+"55 230 OFFCURVE",
+"55 300 QCURVE SMOOTH",
+"55 369 OFFCURVE",
+"113 477 OFFCURVE",
+"240 570 OFFCURVE",
+"343 618 QCURVE",
+"388 551 LINE",
+"293 506 OFFCURVE",
+"186 431 OFFCURVE",
+"144 352 OFFCURVE",
+"144 300 QCURVE SMOOTH",
+"144 246 OFFCURVE",
+"186 164 OFFCURVE",
+"291 89 OFFCURVE",
+"384 47 QCURVE"
+);
+}
+);
+width = 420;
+}
+);
+},
+{
+glyphname = uni10CDA.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"310 0 LINE",
+"218 48 OFFCURVE",
+"106 138 OFFCURVE",
+"55 239 OFFCURVE",
+"55 300 QCURVE SMOOTH",
+"55 359 OFFCURVE",
+"107 459 OFFCURVE",
+"220 552 OFFCURVE",
+"310 600 QCURVE",
+"395 600 LINE",
+"395 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"310 512 LINE",
+"244 474 OFFCURVE",
+"171 407 OFFCURVE",
+"142 340 OFFCURVE",
+"142 300 QCURVE SMOOTH",
+"142 235 OFFCURVE",
+"218 137 OFFCURVE",
+"310 87 QCURVE"
+);
+}
+);
+width = 490;
+}
+);
+},
+{
+glyphname = uni10CDB.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"262 -22 LINE",
+"159 55 OFFCURVE",
+"55 200 OFFCURVE",
+"55 295 QCURVE SMOOTH",
+"55 355 OFFCURVE",
+"95 459 OFFCURVE",
+"186 564 OFFCURVE",
+"262 624 QCURVE",
+"441 455 LINE",
+"383 397 LINE",
+"261 514 LINE",
+"216 475 OFFCURVE",
+"164 406 OFFCURVE",
+"142 336 OFFCURVE",
+"142 295 QCURVE SMOOTH",
+"142 234 OFFCURVE",
+"193 134 OFFCURVE",
+"254 81 QCURVE",
+"383 204 LINE",
+"441 146 LINE"
+);
+}
+);
+width = 473;
+}
+);
+},
+{
+glyphname = uni10CDC.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"266 -21 LINE",
+"159 55 OFFCURVE",
+"55 199 OFFCURVE",
+"55 293 QCURVE SMOOTH",
+"55 353 OFFCURVE",
+"96 456 OFFCURVE",
+"188 559 OFFCURVE",
+"266 618 QCURVE",
+"320 554 LINE",
+"251 502 OFFCURVE",
+"173 419 OFFCURVE",
+"141 340 OFFCURVE",
+"141 293 QCURVE SMOOTH",
+"141 232 OFFCURVE",
+"193 133 OFFCURVE",
+"257 80 QCURVE",
+"366 187 LINE",
+"268 290 LINE",
+"325 348 LINE",
+"479 182 LINE"
+);
+}
+);
+width = 507;
+}
+);
+},
+{
+glyphname = uni10CDD.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"107 -18 LINE",
+"50 41 LINE",
+"230 211 LINE",
+"33 394 LINE",
+"266 618 LINE",
+"323 559 LINE",
+"139 390 LINE",
+"337 207 LINE"
+);
+}
+);
+width = 370;
+}
+);
+},
+{
+glyphname = uni10CDE.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"18 0 LINE",
+"223 307 LINE",
+"25 600 LINE",
+"122 600 LINE",
+"310 308 LINE",
+"310 600 LINE",
+"397 600 LINE",
+"397 0 LINE",
+"310 0 LINE",
+"310 300 LINE",
+"120 0 LINE"
+);
+}
+);
+width = 492;
+}
+);
+},
+{
+glyphname = uni10CDF.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"300 -21 LINE",
+"257 9 OFFCURVE",
+"190 67 OFFCURVE",
+"165 96 QCURVE",
+"96 38 LINE",
+"51 88 LINE",
+"125 151 LINE",
+"89 216 OFFCURVE",
+"89 293 QCURVE SMOOTH",
+"89 334 OFFCURVE",
+"107 406 OFFCURVE",
+"127 441 QCURVE",
+"54 503 LINE",
+"99 552 LINE",
+"166 496 LINE",
+"190 525 OFFCURVE",
+"257 585 OFFCURVE",
+"300 618 QCURVE",
+"354 554 LINE",
+"271 492 OFFCURVE",
+"230 442 QCURVE",
+"273 406 LINE",
+"227 356 LINE",
+"193 385 LINE",
+"183 363 OFFCURVE",
+"175 318 OFFCURVE",
+"175 293 QCURVE SMOOTH",
+"175 247 OFFCURVE",
+"190 206 QCURVE",
+"226 236 LINE",
+"272 187 LINE",
+"224 147 LINE",
+"249 114 OFFCURVE",
+"291 80 QCURVE",
+"400 187 LINE",
+"302 290 LINE",
+"359 348 LINE",
+"513 182 LINE"
+);
+}
+);
+width = 541;
+}
+);
+},
+{
+glyphname = uni10CE0.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"361 -9 LINE",
+"180 144 LINE",
+"180 0 LINE",
+"95 0 LINE",
+"95 600 LINE",
+"170 600 LINE",
+"411 401 LINE",
+"361 348 LINE",
+"180 501 LINE",
+"180 411 LINE",
+"411 223 LINE",
+"361 170 LINE",
+"180 322 LINE",
+"180 232 LINE",
+"411 45 LINE"
+);
+}
+);
+width = 453;
+}
+);
+},
+{
+glyphname = uni10CE1.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"170 -17 LINE",
+"111 36 LINE",
+"207 127 LINE",
+"190 152 OFFCURVE",
+"165 203 OFFCURVE",
+"158 231 QCURVE",
+"52 174 LINE",
+"14 241 LINE",
+"150 311 LINE",
+"152 356 OFFCURVE",
+"181 432 OFFCURVE",
+"206 466 QCURVE",
+"82 406 LINE",
+"47 475 LINE",
+"337 600 LINE",
+"409 600 LINE",
+"699 475 LINE",
+"664 406 LINE",
+"541 465 LINE",
+"566 432 OFFCURVE",
+"595 356 OFFCURVE",
+"596 311 QCURVE",
+"732 241 LINE",
+"694 174 LINE",
+"588 231 LINE",
+"575 177 OFFCURVE",
+"539 127 QCURVE",
+"635 36 LINE",
+"576 -17 LINE",
+"491 71 LINE",
+"473 52 OFFCURVE",
+"431 17 OFFCURVE",
+"408 0 QCURVE",
+"339 0 LINE",
+"316 17 OFFCURVE",
+"274 53 OFFCURVE",
+"255 71 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"374 64 LINE",
+"422 105 OFFCURVE",
+"484 176 OFFCURVE",
+"513 252 OFFCURVE",
+"513 300 QCURVE SMOOTH",
+"513 372 OFFCURVE",
+"447 481 OFFCURVE",
+"374 536 QCURVE",
+"372 536 LINE",
+"301 481 OFFCURVE",
+"233 372 OFFCURVE",
+"233 300 QCURVE SMOOTH",
+"233 230 OFFCURVE",
+"300 125 OFFCURVE",
+"372 64 QCURVE"
+);
+}
+);
+width = 746;
+}
+);
+},
+{
+glyphname = uni10CE2.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"182 600 LINE",
+"182 434 LINE",
+"445 264 LINE",
+"445 600 LINE",
+"532 600 LINE",
+"532 0 LINE",
+"445 0 LINE",
+"445 175 LINE",
+"182 345 LINE",
+"182 0 LINE"
+);
+}
+);
+width = 627;
+}
+);
+},
+{
+glyphname = uni10CE3.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"375 177 LINE",
+"32 372 LINE",
+"72 440 LINE",
+"414 245 LINE"
+);
+}
+);
+width = 441;
+}
+);
+},
+{
+glyphname = uni10CE4.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"5 0 LINE",
+"248 600 LINE",
+"319 600 LINE",
+"561 0 LINE",
+"474 0 LINE",
+"327 371 LINE SMOOTH",
+"310 415 OFFCURVE",
+"291 470 OFFCURVE",
+"285 496 QCURVE",
+"281 496 LINE",
+"275 471 OFFCURVE",
+"255 408 OFFCURVE",
+"241 371 QCURVE SMOOTH",
+"94 0 LINE"
+);
+}
+);
+width = 566;
+}
+);
+},
+{
+glyphname = uni10CE5.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"182 600 LINE",
+"182 0 LINE"
+);
+}
+);
+width = 277;
+}
+);
+},
+{
+glyphname = uni10CE6.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"182 600 LINE",
+"182 371 LINE",
+"384 624 LINE",
+"449 567 LINE",
+"182 241 LINE",
+"182 0 LINE"
+);
+}
+);
+width = 467;
+}
+);
+},
+{
+glyphname = uni10CE7.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"288 0 LINE",
+"288 351 LINE",
+"143 508 LINE",
+"66 430 LINE",
+"14 482 LINE",
+"146 611 LINE",
+"288 456 LINE",
+"288 600 LINE",
+"373 600 LINE",
+"373 455 LINE",
+"514 611 LINE",
+"647 482 LINE",
+"594 430 LINE",
+"518 508 LINE",
+"373 350 LINE",
+"373 0 LINE"
+);
+}
+);
+width = 661;
+}
+);
+},
+{
+glyphname = uni10CE8.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"10 0 LINE",
+"217 313 LINE",
+"25 600 LINE",
+"119 600 LINE",
+"268 371 LINE",
+"313 440 LINE",
+"211 600 LINE",
+"299 600 LINE",
+"356 507 LINE",
+"417 600 LINE",
+"516 600 LINE",
+"321 311 LINE",
+"528 0 LINE",
+"434 0 LINE",
+"271 253 LINE",
+"223 177 LINE",
+"335 0 LINE",
+"248 0 LINE",
+"180 109 LINE",
+"111 0 LINE"
+);
+}
+);
+width = 538;
+}
+);
+},
+{
+glyphname = uni10CE9.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"73 -24 LINE",
+"4 22 LINE",
+"196 313 LINE",
+"15 584 LINE",
+"76 625 LINE",
+"274 567 LINE",
+"254 499 LINE",
+"137 535 LINE",
+"247 371 LINE",
+"396 600 LINE",
+"495 600 LINE",
+"300 311 LINE",
+"507 0 LINE",
+"413 0 LINE",
+"250 253 LINE",
+"129 63 LINE",
+"254 102 LINE",
+"276 34 LINE"
+);
+}
+);
+width = 517;
+}
+);
+},
+{
+glyphname = uni10CEA.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"174 600 LINE",
+"331 486 LINE",
+"490 600 LINE",
+"567 600 LINE",
+"567 0 LINE",
+"490 0 LINE",
+"331 114 LINE",
+"174 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"180 100 LINE",
+"331 206 LINE",
+"482 100 LINE",
+"482 499 LINE",
+"331 394 LINE",
+"180 499 LINE"
+);
+}
+);
+width = 662;
+}
+);
+},
+{
+glyphname = uni10CEB.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"168 600 LINE",
+"354 355 LINE",
+"537 600 LINE",
+"615 600 LINE",
+"615 0 LINE",
+"537 0 LINE",
+"354 243 LINE",
+"168 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"170 126 LINE",
+"173 126 LINE",
+"307 300 LINE",
+"173 472 LINE",
+"170 472 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"532 131 LINE",
+"535 131 LINE",
+"535 467 LINE",
+"532 467 LINE",
+"401 300 LINE"
+);
+}
+);
+width = 710;
+}
+);
+},
+{
+glyphname = uni10CEC.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"97 -15 LINE",
+"38 38 LINE",
+"128 129 LINE",
+"102 167 OFFCURVE",
+"72 251 OFFCURVE",
+"72 300 QCURVE SMOOTH",
+"72 349 OFFCURVE",
+"102 433 OFFCURVE",
+"128 471 QCURVE",
+"38 560 LINE",
+"97 613 LINE",
+"177 528 LINE",
+"215 564 OFFCURVE",
+"261 600 QCURVE",
+"330 600 LINE",
+"378 564 OFFCURVE",
+"413 528 QCURVE",
+"492 613 LINE",
+"551 560 LINE",
+"462 471 LINE",
+"489 434 OFFCURVE",
+"518 349 OFFCURVE",
+"518 300 QCURVE SMOOTH",
+"518 251 OFFCURVE",
+"489 167 OFFCURVE",
+"462 129 QCURVE",
+"551 38 LINE",
+"492 -15 LINE",
+"413 71 LINE",
+"377 35 OFFCURVE",
+"330 0 QCURVE",
+"261 0 LINE",
+"238 17 OFFCURVE",
+"196 53 OFFCURVE",
+"177 71 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"296 64 LINE",
+"344 105 OFFCURVE",
+"406 176 OFFCURVE",
+"435 252 OFFCURVE",
+"435 300 QCURVE SMOOTH",
+"435 347 OFFCURVE",
+"406 423 OFFCURVE",
+"345 495 OFFCURVE",
+"296 536 QCURVE",
+"294 536 LINE",
+"223 475 OFFCURVE",
+"155 370 OFFCURVE",
+"155 300 QCURVE SMOOTH",
+"155 230 OFFCURVE",
+"222 125 OFFCURVE",
+"294 64 QCURVE"
+);
+}
+);
+width = 589;
+}
+);
+},
+{
+glyphname = uni10CED.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"86 0 LINE",
+"86 457 LINE",
+"171 457 LINE",
+"404 272 LINE",
+"404 600 LINE",
+"491 600 LINE",
+"491 169 LINE",
+"407 169 LINE",
+"173 354 LINE",
+"173 0 LINE"
+);
+}
+);
+width = 577;
+}
+);
+},
+{
+glyphname = uni10CEE.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"174 600 LINE",
+"331 486 LINE",
+"490 600 LINE",
+"567 600 LINE",
+"567 0 LINE",
+"482 0 LINE",
+"482 499 LINE",
+"331 394 LINE",
+"180 499 LINE",
+"180 0 LINE"
+);
+}
+);
+width = 662;
+}
+);
+},
+{
+glyphname = uni10CEF.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"95 0 LINE",
+"95 600 LINE",
+"180 600 LINE",
+"435 427 LINE",
+"435 600 LINE",
+"520 600 LINE",
+"520 0 LINE",
+"435 0 LINE",
+"180 173 LINE",
+"180 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"435 254 LINE",
+"435 346 LINE",
+"180 519 LINE",
+"180 427 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"435 81 LINE",
+"435 173 LINE",
+"180 346 LINE",
+"180 254 LINE"
+);
+}
+);
+width = 615;
+}
+);
+},
+{
+glyphname = uni10CF0.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"268 0 LINE",
+"268 261 LINE",
+"12 570 LINE",
+"80 617 LINE",
+"268 386 LINE",
+"268 600 LINE",
+"355 600 LINE",
+"355 386 LINE",
+"541 617 LINE",
+"610 570 LINE",
+"355 261 LINE",
+"355 0 LINE"
+);
+}
+);
+width = 622;
+}
+);
+},
+{
+glyphname = uni10CF1.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"311 0 LINE",
+"166 152 LINE",
+"77 85 LINE",
+"30 140 LINE",
+"169 246 LINE",
+"311 98 LINE",
+"311 192 LINE",
+"166 336 LINE",
+"77 268 LINE",
+"30 324 LINE",
+"169 429 LINE",
+"311 285 LINE",
+"311 375 LINE",
+"166 519 LINE",
+"77 452 LINE",
+"30 507 LINE",
+"169 613 LINE",
+"311 469 LINE",
+"311 600 LINE",
+"396 600 LINE",
+"396 469 LINE",
+"537 613 LINE",
+"676 507 LINE",
+"629 452 LINE",
+"540 519 LINE",
+"396 375 LINE",
+"396 285 LINE",
+"537 429 LINE",
+"676 324 LINE",
+"629 268 LINE",
+"540 336 LINE",
+"396 192 LINE",
+"396 98 LINE",
+"537 246 LINE",
+"676 140 LINE",
+"629 85 LINE",
+"540 152 LINE",
+"396 0 LINE"
+);
+}
+);
+width = 706;
+}
+);
+},
+{
+glyphname = uni10CF2.ltr;
+layers = (
+{
+layerId = "66F296CE-5C58-4A37-8D8A-6B97B2D70587";
+paths = (
+{
+closed = 1;
+nodes = (
+"244 0 LINE",
+"159 64 OFFCURVE",
+"55 206 OFFCURVE",
+"55 300 QCURVE SMOOTH",
+"55 394 OFFCURVE",
+"159 536 OFFCURVE",
+"244 600 QCURVE",
+"313 600 LINE",
+"398 536 OFFCURVE",
+"501 394 OFFCURVE",
+"501 300 QCURVE SMOOTH",
+"501 206 OFFCURVE",
+"398 64 OFFCURVE",
+"313 0 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"316 97 LINE",
+"369 146 OFFCURVE",
+"418 239 OFFCURVE",
+"418 300 QCURVE SMOOTH",
+"418 360 OFFCURVE",
+"369 454 OFFCURVE",
+"316 503 QCURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"239 502 LINE",
+"187 453 OFFCURVE",
+"138 360 OFFCURVE",
+"138 300 QCURVE SMOOTH",
+"138 239 OFFCURVE",
+"187 147 OFFCURVE",
+"239 98 QCURVE"
+);
+}
+);
+width = 556;
+}
+);
+}
+);
+kerning = {
+"66F296CE-5C58-4A37-8D8A-6B97B2D70587" = {
+.notdef = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+CR.1 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+NULL.1 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+space = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C80 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C80.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C81 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C81.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C82 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C82.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C83 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C83.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C84 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C84.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C85 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C85.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C86 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C86.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C87 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C87.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C88 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C88.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C89 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C89.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C8A = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C8A.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C8B = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C8B.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C8C = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C8C.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C8D = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C8D.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C8E = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C8E.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C8F = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C8F.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C90 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C90.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C91 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C91.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C92 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C92.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C93 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C93.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C94 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C94.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C95 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C95.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C96 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C96.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C97 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C97.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C98 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C98.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C99 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C99.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C9A = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C9A.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C9B = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C9B.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C9C = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C9C.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C9D = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C9D.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C9E = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C9E.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C9F = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10C9F.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA0 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA0.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA1 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA1.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA2 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA2.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA3 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA3.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA4 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA4.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA5 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA5.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA6 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA6.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA7 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA7.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA8 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA8.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA9 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CA9.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CAA = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CAA.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CAB = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CAB.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CAC = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CAC.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CAD = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CAD.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CAE = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CAE.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CAF = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CAF.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CB0 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CB0.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CB1 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CB1.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CB2 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CB2.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CC0 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CC0.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CC1 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CC1.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CC2 = {
+uni10CC0 = -10;
+uni10CC0.ltr = -10;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC3 = 10;
+uni10CCC = -20;
+uni10CCC.ltr = -20;
+uni10CD2 = -10;
+uni10CD7 = -20;
+uni10CD7.ltr = -20;
+uni10CD9 = 20;
+uni10CE3 = -40;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 20;
+uni10CF2 = -20;
+uni10CF2.ltr = -20;
+};
+uni10CC2.ltr = {
+uni10CC0 = -10;
+uni10CC0.ltr = -10;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC3 = 10;
+uni10CCC = -20;
+uni10CCC.ltr = -20;
+uni10CD2 = -10;
+uni10CD7 = -20;
+uni10CD7.ltr = -20;
+uni10CD9 = 20;
+uni10CE3 = -40;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 20;
+uni10CF2 = -20;
+uni10CF2.ltr = -20;
+};
+uni10CC3 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CDC = -10;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CC3.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CC4 = {
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = -20;
+uni10CCD.ltr = -20;
+uni10CD6 = -20;
+uni10CD6.ltr = -20;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CE3 = -20;
+uni10CE4 = -20;
+uni10CE4.ltr = -20;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CC4.ltr = {
+uni10CE3 = -20;
+};
+uni10CC5 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CC5.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CC6 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CC6.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CC7 = {
+uni10CCD = -20;
+uni10CCD.ltr = -20;
+uni10CD6 = -20;
+uni10CD6.ltr = -20;
+uni10CE3 = -20;
+uni10CE4 = -20;
+uni10CE4.ltr = -20;
+uni10CE6 = -30;
+};
+uni10CC7.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CC8 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 30;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CC8.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CC9 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CC9.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CCA = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -20;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 20;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CCA.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CCB = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCA = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -20;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CCB.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CCC = {
+uni10CC2 = -10;
+uni10CC2.ltr = -10;
+uni10CD1 = -10;
+uni10CE6 = -30;
+uni10CE6.ltr = -30;
+uni10CE7 = -30;
+uni10CE8 = -10;
+uni10CE8.ltr = -10;
+uni10CE9 = -10;
+uni10CE9.ltr = -10;
+uni10CF0 = -30;
+uni10CF0.ltr = -30;
+};
+uni10CCC.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CCD = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CCD.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CCE = {
+uni10CCD = -20;
+uni10CCD.ltr = -20;
+uni10CD6 = -20;
+uni10CD6.ltr = -20;
+uni10CE4 = -20;
+uni10CE4.ltr = -20;
+};
+uni10CCE.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CCF = {
+uni10CE6 = -20;
+uni10CE6.ltr = -20;
+uni10CF0 = -20;
+uni10CF0.ltr = -20;
+};
+uni10CCF.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CD0 = {
+uni10CCA = -20;
+uni10CCD = -40;
+uni10CCD.ltr = -40;
+uni10CD3 = -30;
+uni10CD6 = -40;
+uni10CD6.ltr = -40;
+uni10CDC = -50;
+uni10CE3 = -90;
+uni10CE4 = -40;
+uni10CE4.ltr = -40;
+};
+uni10CD0.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CD1 = {
+uni10CC0 = -20;
+uni10CC0.ltr = -20;
+uni10CC1 = -20;
+uni10CC8 = 20;
+uni10CCA = -20;
+uni10CCB = -20;
+uni10CCC = -30;
+uni10CCC.ltr = -30;
+uni10CCD = -40;
+uni10CCD.ltr = -40;
+uni10CCE = -30;
+uni10CD0 = -20;
+uni10CD2 = -20;
+uni10CD3 = -30;
+uni10CD6 = -40;
+uni10CD6.ltr = -40;
+uni10CD7 = -30;
+uni10CD7.ltr = -30;
+uni10CD9 = 10;
+uni10CE1 = -20;
+uni10CE3 = -70;
+uni10CE4 = -40;
+uni10CE4.ltr = -40;
+uni10CF2 = -30;
+uni10CF2.ltr = -30;
+};
+uni10CD1.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CD2 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CD2.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CD3 = {
+uni10CD1 = -20;
+uni10CD9 = -30;
+uni10CE6 = -40;
+uni10CE6.ltr = -40;
+uni10CE7 = -30;
+uni10CF0 = -40;
+uni10CF0.ltr = -40;
+};
+uni10CD3.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CD4 = {
+uni10CC0 = -30;
+uni10CC0.ltr = -30;
+uni10CD0 = -10;
+uni10CD1 = -20;
+uni10CD2 = -30;
+uni10CD4 = -10;
+uni10CE6 = -70;
+uni10CE6.ltr = -70;
+uni10CE7 = -40;
+uni10CF0 = -70;
+uni10CF0.ltr = -70;
+};
+uni10CD4.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CD5 = {
+uni10CC1 = -20;
+uni10CCC = -30;
+uni10CCC.ltr = -30;
+uni10CD7 = -30;
+uni10CD7.ltr = -30;
+uni10CDC = -20;
+uni10CE3 = -40;
+uni10CF2 = -30;
+uni10CF2.ltr = -30;
+};
+uni10CD5.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CD6 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CD6.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CD7 = {
+uni10CC2 = -30;
+uni10CC2.ltr = -30;
+uni10CC4 = -10;
+uni10CC9 = -30;
+uni10CCD = -20;
+uni10CCD.ltr = -20;
+uni10CCF = -20;
+uni10CD0 = -30;
+uni10CD1 = -20;
+uni10CD5 = -30;
+uni10CD6 = -20;
+uni10CD6.ltr = -20;
+uni10CD9 = -30;
+uni10CE4 = -20;
+uni10CE4.ltr = -20;
+uni10CE6 = -40;
+uni10CE6.ltr = -40;
+uni10CE7 = -30;
+uni10CE8 = -30;
+uni10CE8.ltr = -30;
+uni10CE9 = -30;
+uni10CE9.ltr = -30;
+uni10CF0 = -40;
+uni10CF0.ltr = -40;
+};
+uni10CD7.ltr = {
+uni10CC2 = -30;
+uni10CC2.ltr = -30;
+uni10CC4 = -10;
+uni10CC9 = -30;
+uni10CCD = -20;
+uni10CCD.ltr = -20;
+uni10CCF = -20;
+uni10CD0 = -30;
+uni10CD1 = -20;
+uni10CD5 = -30;
+uni10CD6 = -20;
+uni10CD6.ltr = -20;
+uni10CD9 = -30;
+uni10CE4 = -20;
+uni10CE4.ltr = -20;
+uni10CE6 = -40;
+uni10CE6.ltr = -40;
+uni10CE7 = -30;
+uni10CE8 = -30;
+uni10CE8.ltr = -30;
+uni10CE9 = -30;
+uni10CE9.ltr = -30;
+uni10CF0 = -40;
+uni10CF0.ltr = -40;
+};
+uni10CD8 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CD8.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CD9 = {
+uni10CC2 = -30;
+uni10CC2.ltr = -30;
+uni10CC4 = -10;
+uni10CC9 = -30;
+uni10CCD = -20;
+uni10CCD.ltr = -20;
+uni10CCF = -20;
+uni10CD0 = -30;
+uni10CD1 = -20;
+uni10CD5 = -30;
+uni10CD6 = -20;
+uni10CD6.ltr = -20;
+uni10CD9 = -30;
+uni10CE4 = -20;
+uni10CE4.ltr = -20;
+uni10CE6 = -40;
+uni10CE6.ltr = -40;
+uni10CE7 = -30;
+uni10CE8 = -30;
+uni10CE8.ltr = -30;
+uni10CE9 = -30;
+uni10CE9.ltr = -30;
+uni10CF0 = -40;
+uni10CF0.ltr = -40;
+};
+uni10CD9.ltr = {
+uni10CC2 = -30;
+uni10CC2.ltr = -30;
+uni10CC4 = -10;
+uni10CC9 = -30;
+uni10CCD = -20;
+uni10CCD.ltr = -20;
+uni10CCF = -20;
+uni10CD0 = -30;
+uni10CD1 = -20;
+uni10CD5 = -30;
+uni10CD6 = -20;
+uni10CD6.ltr = -20;
+uni10CD9 = -30;
+uni10CE4 = -20;
+uni10CE4.ltr = -20;
+uni10CE6 = -40;
+uni10CE6.ltr = -40;
+uni10CE7 = -30;
+uni10CE8 = -30;
+uni10CE8.ltr = -30;
+uni10CE9 = -30;
+uni10CE9.ltr = -30;
+uni10CF0 = -40;
+uni10CF0.ltr = -40;
+};
+uni10CDA = {
+uni10CC2 = -30;
+uni10CC2.ltr = -30;
+uni10CC4 = -10;
+uni10CC9 = -30;
+uni10CCD = -20;
+uni10CCD.ltr = -20;
+uni10CCF = -20;
+uni10CD0 = -30;
+uni10CD1 = -20;
+uni10CD5 = -30;
+uni10CD6 = -20;
+uni10CD6.ltr = -20;
+uni10CD9 = -30;
+uni10CE4 = -20;
+uni10CE4.ltr = -20;
+uni10CE6 = -40;
+uni10CE6.ltr = -40;
+uni10CE7 = -30;
+uni10CE8 = -30;
+uni10CE8.ltr = -30;
+uni10CE9 = -30;
+uni10CE9.ltr = -30;
+uni10CF0 = -40;
+uni10CF0.ltr = -40;
+};
+uni10CDA.ltr = {
+uni10CC2 = -30;
+uni10CC2.ltr = -30;
+uni10CC4 = -10;
+uni10CC9 = -30;
+uni10CCD = -20;
+uni10CCD.ltr = -20;
+uni10CCF = -20;
+uni10CD0 = -30;
+uni10CD1 = -20;
+uni10CD5 = -30;
+uni10CD6 = -20;
+uni10CD6.ltr = -20;
+uni10CD9 = -30;
+uni10CE4 = -20;
+uni10CE4.ltr = -20;
+uni10CE6 = -40;
+uni10CE6.ltr = -40;
+uni10CE7 = -30;
+uni10CE8 = -30;
+uni10CE8.ltr = -30;
+uni10CE9 = -30;
+uni10CE9.ltr = -30;
+uni10CF0 = -40;
+uni10CF0.ltr = -40;
+};
+uni10CDB = {
+uni10CC2 = -30;
+uni10CC2.ltr = -30;
+uni10CC4 = -10;
+uni10CC9 = -30;
+uni10CCD = -20;
+uni10CCD.ltr = -20;
+uni10CCF = -20;
+uni10CD0 = -30;
+uni10CD1 = -20;
+uni10CD5 = -30;
+uni10CD6 = -20;
+uni10CD6.ltr = -20;
+uni10CD9 = -30;
+uni10CE4 = -20;
+uni10CE4.ltr = -20;
+uni10CE6 = -40;
+uni10CE6.ltr = -40;
+uni10CE7 = -30;
+uni10CE8 = -30;
+uni10CE8.ltr = -30;
+uni10CE9 = -30;
+uni10CE9.ltr = -30;
+uni10CF0 = -40;
+uni10CF0.ltr = -40;
+};
+uni10CDB.ltr = {
+uni10CC2 = -30;
+uni10CC2.ltr = -30;
+uni10CC4 = -10;
+uni10CC9 = -30;
+uni10CCD = -20;
+uni10CCD.ltr = -20;
+uni10CCF = -20;
+uni10CD0 = -30;
+uni10CD1 = -20;
+uni10CD5 = -30;
+uni10CD6 = -20;
+uni10CD6.ltr = -20;
+uni10CD9 = -30;
+uni10CE4 = -20;
+uni10CE4.ltr = -20;
+uni10CE6 = -40;
+uni10CE6.ltr = -40;
+uni10CE7 = -30;
+uni10CE8 = -30;
+uni10CE8.ltr = -30;
+uni10CE9 = -30;
+uni10CE9.ltr = -30;
+uni10CF0 = -40;
+uni10CF0.ltr = -40;
+};
+uni10CDC = {
+uni10CC2 = -30;
+uni10CC2.ltr = -30;
+uni10CC4 = -10;
+uni10CC9 = -30;
+uni10CCD = -20;
+uni10CCD.ltr = -20;
+uni10CCF = -20;
+uni10CD0 = -30;
+uni10CD1 = -20;
+uni10CD5 = -30;
+uni10CD6 = -20;
+uni10CD6.ltr = -20;
+uni10CD9 = -30;
+uni10CE4 = -20;
+uni10CE4.ltr = -20;
+uni10CE6 = -40;
+uni10CE6.ltr = -40;
+uni10CE7 = -30;
+uni10CE8 = -30;
+uni10CE8.ltr = -30;
+uni10CE9 = -30;
+uni10CE9.ltr = -30;
+uni10CF0 = -40;
+uni10CF0.ltr = -40;
+};
+uni10CDC.ltr = {
+uni10CC2 = -30;
+uni10CC2.ltr = -30;
+uni10CC4 = -10;
+uni10CC9 = -30;
+uni10CCD = -20;
+uni10CCD.ltr = -20;
+uni10CCF = -20;
+uni10CD0 = -30;
+uni10CD1 = -20;
+uni10CD5 = -30;
+uni10CD6 = -20;
+uni10CD6.ltr = -20;
+uni10CD9 = -30;
+uni10CE4 = -20;
+uni10CE4.ltr = -20;
+uni10CE6 = -40;
+uni10CE6.ltr = -40;
+uni10CE7 = -30;
+uni10CE8 = -30;
+uni10CE8.ltr = -30;
+uni10CE9 = -30;
+uni10CE9.ltr = -30;
+uni10CF0 = -40;
+uni10CF0.ltr = -40;
+};
+uni10CDD = {
+uni10CE3 = -20;
+uni10CE6 = -20;
+uni10CE6.ltr = -20;
+uni10CE7 = -20;
+uni10CF0 = -20;
+uni10CF0.ltr = -20;
+};
+uni10CDD.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CDE = {
+uni10CC0 = -10;
+uni10CC0.ltr = -10;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC3 = 10;
+uni10CCC = -20;
+uni10CCC.ltr = -20;
+uni10CD2 = -10;
+uni10CD7 = -20;
+uni10CD7.ltr = -20;
+uni10CD9 = 20;
+uni10CE3 = -40;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 20;
+uni10CF2 = -20;
+uni10CF2.ltr = -20;
+};
+uni10CDE.ltr = {
+uni10CC0 = -10;
+uni10CC0.ltr = -10;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC3 = 10;
+uni10CCC = -20;
+uni10CCC.ltr = -20;
+uni10CD2 = -10;
+uni10CD7 = -20;
+uni10CD7.ltr = -20;
+uni10CD9 = 20;
+uni10CE3 = -40;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 20;
+uni10CF2 = -20;
+uni10CF2.ltr = -20;
+};
+uni10CDF = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CDF.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CE0 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CE0.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CE1 = {
+uni10CE6 = -20;
+uni10CE6.ltr = -20;
+uni10CF0 = -20;
+uni10CF0.ltr = -20;
+};
+uni10CE1.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CE2 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CE2.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CE3 = {
+uni10CC2 = -40;
+uni10CC2.ltr = -40;
+uni10CC7 = -2;
+uni10CC9 = -20;
+uni10CCA = -30;
+uni10CCD = -50;
+uni10CCD.ltr = -50;
+uni10CD5 = -40;
+uni10CD6 = -50;
+uni10CD6.ltr = -50;
+uni10CD9 = -30;
+uni10CE4 = -50;
+uni10CE4.ltr = -50;
+uni10CE6 = -20;
+uni10CE6.ltr = -20;
+uni10CE8 = -40;
+uni10CE8.ltr = -40;
+uni10CE9 = -40;
+uni10CE9.ltr = -40;
+uni10CF0 = -20;
+uni10CF0.ltr = -20;
+};
+uni10CE3.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CE4 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CE4.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CE5 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CE5.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CE6 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CE6.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CE7 = {
+uni10CC0 = -20;
+uni10CC0.ltr = -20;
+uni10CC7 = -60;
+uni10CC9 = -20;
+uni10CCC = -30;
+uni10CCC.ltr = -30;
+uni10CCD = -70;
+uni10CCD.ltr = -70;
+uni10CCE = -40;
+uni10CD0 = -40;
+uni10CD2 = -20;
+uni10CD3 = -30;
+uni10CD6 = -70;
+uni10CD6.ltr = -70;
+uni10CD7 = -30;
+uni10CD7.ltr = -30;
+uni10CDC = -60;
+uni10CDF = -40;
+uni10CE3 = -70;
+uni10CE4 = -70;
+uni10CE4.ltr = -70;
+uni10CF2 = -30;
+uni10CF2.ltr = -30;
+};
+uni10CE7.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CE8 = {
+uni10CC0 = -10;
+uni10CC0.ltr = -10;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC3 = 10;
+uni10CCC = -20;
+uni10CCC.ltr = -20;
+uni10CD2 = -10;
+uni10CD7 = -20;
+uni10CD7.ltr = -20;
+uni10CD9 = 20;
+uni10CE3 = -40;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 20;
+uni10CF2 = -20;
+uni10CF2.ltr = -20;
+};
+uni10CE8.ltr = {
+uni10CC0 = -10;
+uni10CC0.ltr = -10;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC3 = 10;
+uni10CCC = -20;
+uni10CCC.ltr = -20;
+uni10CD2 = -10;
+uni10CD7 = -20;
+uni10CD7.ltr = -20;
+uni10CD9 = 20;
+uni10CE3 = -40;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 20;
+uni10CF2 = -20;
+uni10CF2.ltr = -20;
+};
+uni10CE9 = {
+uni10CC0 = -10;
+uni10CC0.ltr = -10;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC3 = 10;
+uni10CCC = -20;
+uni10CCC.ltr = -20;
+uni10CD2 = -10;
+uni10CD7 = -20;
+uni10CD7.ltr = -20;
+uni10CD9 = 20;
+uni10CE3 = -40;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 20;
+uni10CF2 = -20;
+uni10CF2.ltr = -20;
+};
+uni10CE9.ltr = {
+uni10CC0 = -10;
+uni10CC0.ltr = -10;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC3 = 10;
+uni10CCC = -20;
+uni10CCC.ltr = -20;
+uni10CD2 = -10;
+uni10CD7 = -20;
+uni10CD7.ltr = -20;
+uni10CD9 = 20;
+uni10CE3 = -40;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 20;
+uni10CF2 = -20;
+uni10CF2.ltr = -20;
+};
+uni10CEA = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CEA.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CEB = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CEB.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CEC = {
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC5 = 10;
+uni10CCA = 10;
+uni10CCD = 10;
+uni10CCD.ltr = 10;
+uni10CD6 = 10;
+uni10CD6.ltr = 10;
+uni10CE4 = 10;
+uni10CE4.ltr = 10;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+};
+uni10CEC.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CED = {
+uni10CC2 = -20;
+uni10CC2.ltr = -20;
+uni10CE6 = -50;
+uni10CE6.ltr = -50;
+uni10CE7 = -20;
+uni10CE8 = -20;
+uni10CE8.ltr = -20;
+uni10CE9 = -20;
+uni10CE9.ltr = -20;
+uni10CF0 = -50;
+uni10CF0.ltr = -50;
+};
+uni10CED.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CEE = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CEE.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CEF = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CEF.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CF0 = {
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC7 = -30;
+uni10CCC = -30;
+uni10CCC.ltr = -30;
+uni10CCD = -80;
+uni10CCD.ltr = -80;
+uni10CCE = -50;
+uni10CD3 = -20;
+uni10CD6 = -80;
+uni10CD6.ltr = -80;
+uni10CD7 = -30;
+uni10CD7.ltr = -30;
+uni10CDC = -80;
+uni10CDF = -30;
+uni10CE3 = -60;
+uni10CE4 = -80;
+uni10CE4.ltr = -80;
+uni10CE6 = 20;
+uni10CE6.ltr = 20;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CF0 = 20;
+uni10CF0.ltr = 20;
+uni10CF2 = -30;
+uni10CF2.ltr = -30;
+};
+uni10CF0.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CF1 = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CF1.ltr = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CF2 = {
+uni10CC2 = -30;
+uni10CC2.ltr = -30;
+uni10CC4 = -10;
+uni10CC9 = -30;
+uni10CCD = -20;
+uni10CCD.ltr = -20;
+uni10CCF = -20;
+uni10CD0 = -30;
+uni10CD1 = -20;
+uni10CD5 = -30;
+uni10CD6 = -20;
+uni10CD6.ltr = -20;
+uni10CD9 = -30;
+uni10CE4 = -20;
+uni10CE4.ltr = -20;
+uni10CE6 = -40;
+uni10CE6.ltr = -40;
+uni10CE7 = -30;
+uni10CE8 = -30;
+uni10CE8.ltr = -30;
+uni10CE9 = -30;
+uni10CE9.ltr = -30;
+uni10CF0 = -40;
+uni10CF0.ltr = -40;
+};
+uni10CF2.ltr = {
+uni10CC2 = -30;
+uni10CC2.ltr = -30;
+uni10CC4 = -10;
+uni10CC9 = -30;
+uni10CCD = -20;
+uni10CCD.ltr = -20;
+uni10CCF = -20;
+uni10CD0 = -30;
+uni10CD1 = -20;
+uni10CD5 = -30;
+uni10CD6 = -20;
+uni10CD6.ltr = -20;
+uni10CD9 = -30;
+uni10CE4 = -20;
+uni10CE4.ltr = -20;
+uni10CE6 = -40;
+uni10CE6.ltr = -40;
+uni10CE7 = -30;
+uni10CE8 = -30;
+uni10CE8.ltr = -30;
+uni10CE9 = -30;
+uni10CE9.ltr = -30;
+uni10CF0 = -40;
+uni10CF0.ltr = -40;
+};
+uni10CFA = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CFB = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CFC = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CFD = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CFE = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+uni10CFF = {
+uni10CC0 = -40;
+uni10CC0.ltr = -40;
+uni10CC1 = -30;
+uni10CC2 = 20;
+uni10CC2.ltr = 20;
+uni10CC4 = -30;
+uni10CC7 = -10;
+uni10CC9 = -20;
+uni10CCB = 10;
+uni10CCC = -10;
+uni10CCC.ltr = -10;
+uni10CCD = 40;
+uni10CCD.ltr = 40;
+uni10CCE = 20;
+uni10CD0 = -30;
+uni10CD1 = -50;
+uni10CD2 = -30;
+uni10CD4 = -40;
+uni10CD6 = 40;
+uni10CD6.ltr = 40;
+uni10CD7 = -10;
+uni10CD7.ltr = -10;
+uni10CD9 = 20;
+uni10CE3 = -30;
+uni10CE4 = 40;
+uni10CE4.ltr = 40;
+uni10CE6 = -60;
+uni10CE6.ltr = -60;
+uni10CE7 = -80;
+uni10CE8 = 20;
+uni10CE8.ltr = 20;
+uni10CE9 = 20;
+uni10CE9.ltr = 20;
+uni10CEC = 10;
+uni10CED = -40;
+uni10CF0 = -60;
+uni10CF0.ltr = -60;
+uni10CF2 = -10;
+uni10CF2.ltr = -10;
+};
+};
+};
+manufacturer = "Monotype Imaging Inc.";
+manufacturerURL = "http://www.google.com/get/noto/";
+unitsPerEm = 1000;
+userData = {
+GSDimensionPlugin.Dimensions = {
+"66F296CE-5C58-4A37-8D8A-6B97B2D70587" = {
+};
+};
+};
+versionMajor = 2;
+versionMinor = 3;
+}

--- a/src/NotoSansOldHungarian/NotoSansOldHungarian.glyphs
+++ b/src/NotoSansOldHungarian/NotoSansOldHungarian.glyphs
@@ -5048,29 +5048,33 @@ paths = (
 {
 closed = 1;
 nodes = (
-"104 0 LINE",
-"267 245 LINE",
-"422 0 LINE",
-"569 0 LINE",
-"569 600 LINE",
-"419 600 LINE",
-"270 363 LINE",
-"121 600 LINE",
-"22 600 LINE",
-"217 303 LINE",
+"111 0 LINE",
+"271 253 LINE",
+"434 0 LINE",
+"528 0 LINE",
+"321 311 LINE",
+"346 348 LINE",
+"548 246 LINE",
+"616 302 LINE",
+"537 600 LINE",
+"417 600 LINE",
+"268 371 LINE",
+"119 600 LINE",
+"25 600 LINE",
+"217 313 LINE",
 "10 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"321 305 LINE",
-"482 552 LINE",
-"482 61 LINE"
+"387 408 LINE",
+"473 536 LINE",
+"525 342 LINE"
 );
 }
 );
-width = 664;
+width = 646;
 }
 );
 leftKerningGroup = uni10CC2;
@@ -12580,29 +12584,33 @@ paths = (
 {
 closed = 1;
 nodes = (
-"242 0 LINE",
-"397 245 LINE",
-"560 0 LINE",
-"654 0 LINE",
-"447 303 LINE",
-"642 600 LINE",
-"543 600 LINE",
-"394 363 LINE",
-"245 600 LINE",
-"95 600 LINE",
-"95 0 LINE"
+"212 0 LINE",
+"375 253 LINE",
+"535 0 LINE",
+"636 0 LINE",
+"429 313 LINE",
+"621 600 LINE",
+"527 600 LINE",
+"378 371 LINE",
+"229 600 LINE",
+"109 600 LINE",
+"30 302 LINE",
+"98 246 LINE",
+"300 348 LINE",
+"325 311 LINE",
+"118 0 LINE"
 );
 },
 {
 closed = 1;
 nodes = (
-"182 552 LINE",
-"343 305 LINE",
-"182 61 LINE"
+"173 536 LINE",
+"259 408 LINE",
+"121 342 LINE"
 );
 }
 );
-width = 664;
+width = 646;
 }
 );
 leftKerningGroup = uni10CC2;


### PR DESCRIPTION
This font source follows the Old Hungarian script adopted by Unicode standard 8.0.0 except that it has glyphs with ltr direction, too.
The specification downloadable from page http://unicode.org/charts/PDF/U10C80.pdf
We hardly need this compact font, for UI use only.
We hardly need retained in its original form, without any modifications in the future which has conflict with the document http://unicode.org/charts/PDF/U10C80.pdf and we hardly need, that no more characters to add  to this font, like ligatures.