### PR TITLE
NotoKufiArabic Fixes

### DIFF
--- a/src/NotoKufiArabic.glyphs
+++ b/src/NotoKufiArabic.glyphs
@@ -1,9 +1,19 @@
 {
 .appVersion = "1350";
 DisplayStrings = (
-"/lamVabove_alef-ar.fina",
-"/lam_alefMadda-ar.fina",
-"/lamVaboveMadda_alef-ar.fina"
+"/madda-ar/lam_alef-ar.isol/lam_alef-ar.isol/lamVaboveMadda_alef-ar.isol",
+"/lam_alefHamzaabove-ar",
+"/madda-ar",
+"/smallv.arabic",
+"/wawSmall-ar",
+"/noonRing-ar.init",
+"/noonRing-ar.medi",
+"/noonRing-ar.fina",
+"/sindhipostpositionmen-ar",
+"/sindhiampersand-ar",
+"/shadda_fathatan-ar",
+"/rehStroke-ar.fina",
+"/rehStroke-ar"
 );
 copyright = "Copyright 2019-2020 Google LLC. All Rights Reserved.";
 customParameters = (
@@ -63,7 +73,7 @@ Tag = wght;
 );
 }
 );
-date = "2021-01-06 17:43:56 +0000";
+date = "2021-01-08 17:57:47 +0000";
 designer = "Monotype Design Team, David Williams";
 designerURL = "http://www.monotype.com/studio";
 familyName = "Noto Kufi Arabic";
@@ -92,12 +102,12 @@ name = locl;
 },
 {
 automatic = 1;
-code = "sub behDotless-ar by behDotless-ar.init;\012sub beh-ar by beh-ar.init;\012sub peh-ar by peh-ar.init;\012sub beeh-ar by beeh-ar.init;\012sub beheh-ar by beheh-ar.init;\012sub alefMaksura-ar by alefMaksura-ar.init;\012sub teh-ar by teh-ar.init;\012sub tehRing-ar by tehRing-ar.init;\012sub tehThreedotsdown-ar by tehThreedotsdown-ar.init;\012sub theh-ar by theh-ar.init;\012sub tteh-ar by tteh-ar.init;\012sub tteheh-ar by tteheh-ar.init;\012sub teheh-ar by teheh-ar.init;\012sub behThreedotshorizontalbelow-ar by behThreedotshorizontalbelow-ar.init;\012sub behThreedotsupabove-ar by behThreedotsupabove-ar.init;\012sub behThreedotsupbelow-ar by behThreedotsupbelow-ar.init;\012sub tehThreedotsupbelow-ar by tehThreedotsupbelow-ar.init;\012sub behTwodotsbelowDotabove-ar by behTwodotsbelowDotabove-ar.init;\012sub behVinvertedbelow-ar by behVinvertedbelow-ar.init;\012sub behVabove-ar by behVabove-ar.init;\012sub jeem-ar by jeem-ar.init;\012sub tcheh-ar by tcheh-ar.init;\012sub tcheheh-ar by tcheheh-ar.init;\012sub tchehDotabove-ar by tchehDotabove-ar.init;\012sub nyeh-ar by nyeh-ar.init;\012sub dyeh-ar by dyeh-ar.init;\012sub hah-ar by hah-ar.init;\012sub hahHamzaabove-ar by hahHamzaabove-ar.init;\012sub hahTwodotsverticalabove-ar by hahTwodotsverticalabove-ar.init;\012sub hahTwodotshorizontalabove-ar by hahTwodotshorizontalabove-ar.init;\012sub hahThreedotsabove-ar by hahThreedotsabove-ar.init;\012sub hahThreedotsupbelow-ar by hahThreedotsupbelow-ar.init;\012sub khah-ar by khah-ar.init;\012sub seen-ar by seen-ar.init;\012sub seenDotbelowDotabove-ar by seenDotbelowDotabove-ar.init;\012sub seenThreedotsbelow-ar by seenThreedotsbelow-ar.init;\012sub sheen-ar by sheen-ar.init;\012sub sheenDotbelow-ar by sheenDotbelow-ar.init;\012sub sheenThreedotsbelow-ar by sheenThreedotsbelow-ar.init;\012sub sad-ar by sad-ar.init;\012sub sadTwodotsbelow-ar by sadTwodotsbelow-ar.init;\012sub sadThreedots-ar by sadThreedots-ar.init;\012sub dad-ar by dad-ar.init;\012sub dadDotbelow-ar by dadDotbelow-ar.init;\012sub tah-ar by tah-ar.init;\012sub tahThreedots-ar by tahThreedots-ar.init;\012sub zah-ar by zah-ar.init;\012sub ain-ar by ain-ar.init;\012sub ainThreedots-ar by ainThreedots-ar.init;\012sub ghain-ar by ghain-ar.init;\012sub ghainDotbelow-ar by ghainDotbelow-ar.init;\012sub feh-ar by feh-ar.init;\012sub veh-ar by veh-ar.init;\012sub fehDotmovedbelow-ar by fehDotmovedbelow-ar.init;\012sub fehDotbelow-ar by fehDotbelow-ar.init;\012sub fehThreedotsbelow-ar by fehThreedotsbelow-ar.init;\012sub peheh-ar by peheh-ar.init;\012sub qafDotless-ar by qafDotless-ar.init;\012sub qaf-ar by qaf-ar.init;\012sub kaf-ar by kaf-ar.init;\012sub keheh-ar by keheh-ar.init;\012sub kehehDotabove-ar by kehehDotabove-ar.init;\012sub kehehThreedotsabove-ar by kehehThreedotsabove-ar.init;\012sub kehehThreedotsupbelow-ar by kehehThreedotsupbelow-ar.init;\012sub gaf-ar by gaf-ar.init;\012sub gafRing-ar by gafRing-ar.init;\012sub gafThreedots-ar by gafThreedots-ar.init;\012sub kafswash-ar by kafswash-ar.init;\012sub kafRing-ar by kafRing-ar.init;\012sub kafDotabove-ar by kafDotabove-ar.init;\012sub kafThreedotsbelow-ar by kafThreedotsbelow-ar.init;\012sub gafTwodotsbelow-ar by gafTwodotsbelow-ar.init;\012sub ng-ar by ng-ar.init;\012sub ngoeh-ar by ngoeh-ar.init;\012sub gueh-ar by gueh-ar.init;\012sub lam-ar by lam-ar.init;\012sub lamVabove-ar by lamVabove-ar.init;\012sub lamDotabove-ar by lamDotabove-ar.init;\012sub lamThreedotsabove-ar by lamThreedotsabove-ar.init;\012sub lamThreedotsbelow-ar by lamThreedotsbelow-ar.init;\012sub meem-ar by meem-ar.init;\012sub noon-ar by noon-ar.init;\012sub noonDotbelow-ar by noonDotbelow-ar.init;\012sub noonRing-ar by noonRing-ar.init;\012sub noonThreedotsabove-ar by noonThreedotsabove-ar.init;\012sub heh-ar by heh-ar.init;\012sub hehgoal-ar by hehgoal-ar.init;\012sub hehDoachashmee-ar by hehDoachashmee-ar.init;\012sub hehVinvertedabove-ar by hehVinvertedabove-ar.init;\012sub yeh-ar by yeh-ar.init;\012sub yehHamzaabove-ar by yehHamzaabove-ar.init;\012sub yehVabove-ar by yehVabove-ar.init;\012sub yeh-farsi by yeh-farsi.init;\012sub e-ar by e-ar.init;\012sub yehThreedotsbelow-ar by yehThreedotsbelow-ar.init;\012sub seenFourdotsabove-ar by seenFourdotsabove-ar.init;\012sub ainTwodotshorizontalabove-ar by ainTwodotshorizontalabove-ar.init;\012sub ainThreedotsdownabove-ar by ainThreedotsdownabove-ar.init;\012sub ainTwodotsverticalabove-ar by ainTwodotsverticalabove-ar.init;\012sub fehTwodotsbelow-ar by fehTwodotsbelow-ar.init;\012sub fehThreedotsupbelow-ar by fehThreedotsupbelow-ar.init;\012sub meemDotabove-ar by meemDotabove-ar.init;\012sub meemDotbelow-ar by meemDotbelow-ar.init;\012sub noonTwodotsbelow-ar by noonTwodotsbelow-ar.init;\012sub noonTahabove-ar by noonTahabove-ar.init;\012sub noonVabove-ar by noonVabove-ar.init;\012sub lamBar-ar by lamBar-ar.init;\012sub seenTwodotshorizontalabove-ar by seenTwodotshorizontalabove-ar.init;\012";
+code = "sub behDotless-ar by behDotless-ar.init;\012sub beh-ar by beh-ar.init;\012sub peh-ar by peh-ar.init;\012sub beeh-ar by beeh-ar.init;\012sub beheh-ar by beheh-ar.init;\012sub alefMaksura-ar by alefMaksura-ar.init;\012sub teh-ar by teh-ar.init;\012sub tehRing-ar by tehRing-ar.init;\012sub tehThreedotsdown-ar by tehThreedotsdown-ar.init;\012sub theh-ar by theh-ar.init;\012sub tteh-ar by tteh-ar.init;\012sub tteheh-ar by tteheh-ar.init;\012sub teheh-ar by teheh-ar.init;\012sub behThreedotshorizontalbelow-ar by behThreedotshorizontalbelow-ar.init;\012sub behThreedotsupabove-ar by behThreedotsupabove-ar.init;\012sub behThreedotsupbelow-ar by behThreedotsupbelow-ar.init;\012sub tehThreedotsupbelow-ar by tehThreedotsupbelow-ar.init;\012sub behTwodotsbelowDotabove-ar by behTwodotsbelowDotabove-ar.init;\012sub behVinvertedbelow-ar by behVinvertedbelow-ar.init;\012sub behVabove-ar by behVabove-ar.init;\012sub jeem-ar by jeem-ar.init;\012sub tcheh-ar by tcheh-ar.init;\012sub tcheheh-ar by tcheheh-ar.init;\012sub tchehDotabove-ar by tchehDotabove-ar.init;\012sub nyeh-ar by nyeh-ar.init;\012sub dyeh-ar by dyeh-ar.init;\012sub hah-ar by hah-ar.init;\012sub hahHamzaabove-ar by hahHamzaabove-ar.init;\012sub hahTwodotsverticalabove-ar by hahTwodotsverticalabove-ar.init;\012sub hahTwodotshorizontalabove-ar by hahTwodotshorizontalabove-ar.init;\012sub hahThreedotsabove-ar by hahThreedotsabove-ar.init;\012sub hahThreedotsupbelow-ar by hahThreedotsupbelow-ar.init;\012sub khah-ar by khah-ar.init;\012sub seen-ar by seen-ar.init;\012sub seenDotbelowDotabove-ar by seenDotbelowDotabove-ar.init;\012sub seenThreedotsbelow-ar by seenThreedotsbelow-ar.init;\012sub sheen-ar by sheen-ar.init;\012sub sheenDotbelow-ar by sheenDotbelow-ar.init;\012sub sheenThreedotsbelow-ar by sheenThreedotsbelow-ar.init;\012sub sad-ar by sad-ar.init;\012sub sadTwodotsbelow-ar by sadTwodotsbelow-ar.init;\012sub sadThreedots-ar by sadThreedots-ar.init;\012sub dad-ar by dad-ar.init;\012sub dadDotbelow-ar by dadDotbelow-ar.init;\012sub tah-ar by tah-ar.init;\012sub tahThreedots-ar by tahThreedots-ar.init;\012sub zah-ar by zah-ar.init;\012sub ain-ar by ain-ar.init;\012sub ainThreedots-ar by ainThreedots-ar.init;\012sub ghain-ar by ghain-ar.init;\012sub ghainDotbelow-ar by ghainDotbelow-ar.init;\012sub feh-ar by feh-ar.init;\012sub veh-ar by veh-ar.init;\012sub fehDotmovedbelow-ar by fehDotmovedbelow-ar.init;\012sub fehDotbelow-ar by fehDotbelow-ar.init;\012sub fehThreedotsbelow-ar by fehThreedotsbelow-ar.init;\012sub peheh-ar by peheh-ar.init;\012sub qafDotless-ar by qafDotless-ar.init;\012sub qaf-ar by qaf-ar.init;\012sub qafThreedotsabove-ar by qafThreedotsabove-ar.init;\012sub kaf-ar by kaf-ar.init;\012sub keheh-ar by keheh-ar.init;\012sub kehehDotabove-ar by kehehDotabove-ar.init;\012sub kehehThreedotsabove-ar by kehehThreedotsabove-ar.init;\012sub kehehThreedotsupbelow-ar by kehehThreedotsupbelow-ar.init;\012sub gaf-ar by gaf-ar.init;\012sub gafRing-ar by gafRing-ar.init;\012sub gafThreedots-ar by gafThreedots-ar.init;\012sub kafswash-ar by kafswash-ar.init;\012sub kafRing-ar by kafRing-ar.init;\012sub kafDotabove-ar by kafDotabove-ar.init;\012sub kafThreedotsbelow-ar by kafThreedotsbelow-ar.init;\012sub gafTwodotsbelow-ar by gafTwodotsbelow-ar.init;\012sub ng-ar by ng-ar.init;\012sub ngoeh-ar by ngoeh-ar.init;\012sub gueh-ar by gueh-ar.init;\012sub lam-ar by lam-ar.init;\012sub lamVabove-ar by lamVabove-ar.init;\012sub lamDotabove-ar by lamDotabove-ar.init;\012sub lamThreedotsabove-ar by lamThreedotsabove-ar.init;\012sub lamThreedotsbelow-ar by lamThreedotsbelow-ar.init;\012sub meem-ar by meem-ar.init;\012sub noon-ar by noon-ar.init;\012sub noonDotbelow-ar by noonDotbelow-ar.init;\012sub noonRing-ar by noonRing-ar.init;\012sub noonThreedotsabove-ar by noonThreedotsabove-ar.init;\012sub heh-ar by heh-ar.init;\012sub hehgoal-ar by hehgoal-ar.init;\012sub hehDoachashmee-ar by hehDoachashmee-ar.init;\012sub hehVinvertedabove-ar by hehVinvertedabove-ar.init;\012sub yeh-ar by yeh-ar.init;\012sub yehHamzaabove-ar by yehHamzaabove-ar.init;\012sub yehVabove-ar by yehVabove-ar.init;\012sub yeh-farsi by yeh-farsi.init;\012sub e-ar by e-ar.init;\012sub yehThreedotsbelow-ar by yehThreedotsbelow-ar.init;\012sub seenFourdotsabove-ar by seenFourdotsabove-ar.init;\012sub ainTwodotshorizontalabove-ar by ainTwodotshorizontalabove-ar.init;\012sub ainThreedotsdownabove-ar by ainThreedotsdownabove-ar.init;\012sub ainTwodotsverticalabove-ar by ainTwodotsverticalabove-ar.init;\012sub fehTwodotsbelow-ar by fehTwodotsbelow-ar.init;\012sub fehThreedotsupbelow-ar by fehThreedotsupbelow-ar.init;\012sub meemDotabove-ar by meemDotabove-ar.init;\012sub meemDotbelow-ar by meemDotbelow-ar.init;\012sub noonTwodotsbelow-ar by noonTwodotsbelow-ar.init;\012sub noonTahabove-ar by noonTahabove-ar.init;\012sub noonVabove-ar by noonVabove-ar.init;\012sub lamBar-ar by lamBar-ar.init;\012sub seenTwodotshorizontalabove-ar by seenTwodotshorizontalabove-ar.init;\012";
 name = init;
 },
 {
 automatic = 1;
-code = "sub behDotless-ar by behDotless-ar.medi;\012sub beh-ar by beh-ar.medi;\012sub peh-ar by peh-ar.medi;\012sub beeh-ar by beeh-ar.medi;\012sub beheh-ar by beheh-ar.medi;\012sub alefMaksura-ar by alefMaksura-ar.medi;\012sub teh-ar by teh-ar.medi;\012sub tehRing-ar by tehRing-ar.medi;\012sub tehThreedotsdown-ar by tehThreedotsdown-ar.medi;\012sub theh-ar by theh-ar.medi;\012sub tteh-ar by tteh-ar.medi;\012sub tteheh-ar by tteheh-ar.medi;\012sub teheh-ar by teheh-ar.medi;\012sub behThreedotshorizontalbelow-ar by behThreedotshorizontalbelow-ar.medi;\012sub behThreedotsupabove-ar by behThreedotsupabove-ar.medi;\012sub behThreedotsupbelow-ar by behThreedotsupbelow-ar.medi;\012sub tehThreedotsupbelow-ar by tehThreedotsupbelow-ar.medi;\012sub behTwodotsbelowDotabove-ar by behTwodotsbelowDotabove-ar.medi;\012sub behVinvertedbelow-ar by behVinvertedbelow-ar.medi;\012sub behVabove-ar by behVabove-ar.medi;\012sub jeem-ar by jeem-ar.medi;\012sub tcheh-ar by tcheh-ar.medi;\012sub tcheheh-ar by tcheheh-ar.medi;\012sub tchehDotabove-ar by tchehDotabove-ar.medi;\012sub nyeh-ar by nyeh-ar.medi;\012sub dyeh-ar by dyeh-ar.medi;\012sub hah-ar by hah-ar.medi;\012sub hahHamzaabove-ar by hahHamzaabove-ar.medi;\012sub hahTwodotsverticalabove-ar by hahTwodotsverticalabove-ar.medi;\012sub hahTwodotshorizontalabove-ar by hahTwodotshorizontalabove-ar.medi;\012sub hahThreedotsabove-ar by hahThreedotsabove-ar.medi;\012sub hahThreedotsupbelow-ar by hahThreedotsupbelow-ar.medi;\012sub khah-ar by khah-ar.medi;\012sub seen-ar by seen-ar.medi;\012sub seenDotbelowDotabove-ar by seenDotbelowDotabove-ar.medi;\012sub seenThreedotsbelow-ar by seenThreedotsbelow-ar.medi;\012sub sheen-ar by sheen-ar.medi;\012sub sheenDotbelow-ar by sheenDotbelow-ar.medi;\012sub sheenThreedotsbelow-ar by sheenThreedotsbelow-ar.medi;\012sub sad-ar by sad-ar.medi;\012sub sadTwodotsbelow-ar by sadTwodotsbelow-ar.medi;\012sub sadThreedots-ar by sadThreedots-ar.medi;\012sub dad-ar by dad-ar.medi;\012sub dadDotbelow-ar by dadDotbelow-ar.medi;\012sub tah-ar by tah-ar.medi;\012sub tahThreedots-ar by tahThreedots-ar.medi;\012sub zah-ar by zah-ar.medi;\012sub ain-ar by ain-ar.medi;\012sub ainThreedots-ar by ainThreedots-ar.medi;\012sub ghain-ar by ghain-ar.medi;\012sub ghainDotbelow-ar by ghainDotbelow-ar.medi;\012sub feh-ar by feh-ar.medi;\012sub veh-ar by veh-ar.medi;\012sub fehDotmovedbelow-ar by fehDotmovedbelow-ar.medi;\012sub fehDotbelow-ar by fehDotbelow-ar.medi;\012sub fehThreedotsbelow-ar by fehThreedotsbelow-ar.medi;\012sub peheh-ar by peheh-ar.medi;\012sub qafDotless-ar by qafDotless-ar.medi;\012sub qaf-ar by qaf-ar.medi;\012sub kaf-ar by kaf-ar.medi;\012sub keheh-ar by keheh-ar.medi;\012sub kehehDotabove-ar by kehehDotabove-ar.medi;\012sub kehehThreedotsabove-ar by kehehThreedotsabove-ar.medi;\012sub kehehThreedotsupbelow-ar by kehehThreedotsupbelow-ar.medi;\012sub gaf-ar by gaf-ar.medi;\012sub gafRing-ar by gafRing-ar.medi;\012sub gafThreedots-ar by gafThreedots-ar.medi;\012sub kafswash-ar by kafswash-ar.medi;\012sub kafRing-ar by kafRing-ar.medi;\012sub kafDotabove-ar by kafDotabove-ar.medi;\012sub kafThreedotsbelow-ar by kafThreedotsbelow-ar.medi;\012sub gafTwodotsbelow-ar by gafTwodotsbelow-ar.medi;\012sub ng-ar by ng-ar.medi;\012sub ngoeh-ar by ngoeh-ar.medi;\012sub gueh-ar by gueh-ar.medi;\012sub lam-ar by lam-ar.medi;\012sub lamVabove-ar by lamVabove-ar.medi;\012sub lamDotabove-ar by lamDotabove-ar.medi;\012sub lamThreedotsabove-ar by lamThreedotsabove-ar.medi;\012sub lamThreedotsbelow-ar by lamThreedotsbelow-ar.medi;\012sub meem-ar by meem-ar.medi;\012sub noon-ar by noon-ar.medi;\012sub noonDotbelow-ar by noonDotbelow-ar.medi;\012sub noonRing-ar by noonRing-ar.medi;\012sub noonThreedotsabove-ar by noonThreedotsabove-ar.medi;\012sub heh-ar by heh-ar.medi;\012sub hehgoal-ar by hehgoal-ar.medi;\012sub hehDoachashmee-ar by hehDoachashmee-ar.medi;\012sub hehVinvertedabove-ar by hehVinvertedabove-ar.medi;\012sub yeh-ar by yeh-ar.medi;\012sub yehHamzaabove-ar by yehHamzaabove-ar.medi;\012sub yehVabove-ar by yehVabove-ar.medi;\012sub yeh-farsi by yeh-farsi.medi;\012sub e-ar by e-ar.medi;\012sub yehThreedotsbelow-ar by yehThreedotsbelow-ar.medi;\012sub seenFourdotsabove-ar by seenFourdotsabove-ar.medi;\012sub ainTwodotshorizontalabove-ar by ainTwodotshorizontalabove-ar.medi;\012sub ainThreedotsdownabove-ar by ainThreedotsdownabove-ar.medi;\012sub ainTwodotsverticalabove-ar by ainTwodotsverticalabove-ar.medi;\012sub fehTwodotsbelow-ar by fehTwodotsbelow-ar.medi;\012sub fehThreedotsupbelow-ar by fehThreedotsupbelow-ar.medi;\012sub meemDotabove-ar by meemDotabove-ar.medi;\012sub meemDotbelow-ar by meemDotbelow-ar.medi;\012sub noonTwodotsbelow-ar by noonTwodotsbelow-ar.medi;\012sub noonTahabove-ar by noonTahabove-ar.medi;\012sub noonVabove-ar by noonVabove-ar.medi;\012sub lamBar-ar by lamBar-ar.medi;\012sub seenTwodotshorizontalabove-ar by seenTwodotshorizontalabove-ar.medi;\012";
+code = "sub behDotless-ar by behDotless-ar.medi;\012sub beh-ar by beh-ar.medi;\012sub peh-ar by peh-ar.medi;\012sub beeh-ar by beeh-ar.medi;\012sub beheh-ar by beheh-ar.medi;\012sub alefMaksura-ar by alefMaksura-ar.medi;\012sub teh-ar by teh-ar.medi;\012sub tehRing-ar by tehRing-ar.medi;\012sub tehThreedotsdown-ar by tehThreedotsdown-ar.medi;\012sub theh-ar by theh-ar.medi;\012sub tteh-ar by tteh-ar.medi;\012sub tteheh-ar by tteheh-ar.medi;\012sub teheh-ar by teheh-ar.medi;\012sub behThreedotshorizontalbelow-ar by behThreedotshorizontalbelow-ar.medi;\012sub behThreedotsupabove-ar by behThreedotsupabove-ar.medi;\012sub behThreedotsupbelow-ar by behThreedotsupbelow-ar.medi;\012sub tehThreedotsupbelow-ar by tehThreedotsupbelow-ar.medi;\012sub behTwodotsbelowDotabove-ar by behTwodotsbelowDotabove-ar.medi;\012sub behVinvertedbelow-ar by behVinvertedbelow-ar.medi;\012sub behVabove-ar by behVabove-ar.medi;\012sub jeem-ar by jeem-ar.medi;\012sub tcheh-ar by tcheh-ar.medi;\012sub tcheheh-ar by tcheheh-ar.medi;\012sub tchehDotabove-ar by tchehDotabove-ar.medi;\012sub nyeh-ar by nyeh-ar.medi;\012sub dyeh-ar by dyeh-ar.medi;\012sub hah-ar by hah-ar.medi;\012sub hahHamzaabove-ar by hahHamzaabove-ar.medi;\012sub hahTwodotsverticalabove-ar by hahTwodotsverticalabove-ar.medi;\012sub hahTwodotshorizontalabove-ar by hahTwodotshorizontalabove-ar.medi;\012sub hahThreedotsabove-ar by hahThreedotsabove-ar.medi;\012sub hahThreedotsupbelow-ar by hahThreedotsupbelow-ar.medi;\012sub khah-ar by khah-ar.medi;\012sub seen-ar by seen-ar.medi;\012sub seenDotbelowDotabove-ar by seenDotbelowDotabove-ar.medi;\012sub seenThreedotsbelow-ar by seenThreedotsbelow-ar.medi;\012sub sheen-ar by sheen-ar.medi;\012sub sheenDotbelow-ar by sheenDotbelow-ar.medi;\012sub sheenThreedotsbelow-ar by sheenThreedotsbelow-ar.medi;\012sub sad-ar by sad-ar.medi;\012sub sadTwodotsbelow-ar by sadTwodotsbelow-ar.medi;\012sub sadThreedots-ar by sadThreedots-ar.medi;\012sub dad-ar by dad-ar.medi;\012sub dadDotbelow-ar by dadDotbelow-ar.medi;\012sub tah-ar by tah-ar.medi;\012sub tahThreedots-ar by tahThreedots-ar.medi;\012sub zah-ar by zah-ar.medi;\012sub ain-ar by ain-ar.medi;\012sub ainThreedots-ar by ainThreedots-ar.medi;\012sub ghain-ar by ghain-ar.medi;\012sub ghainDotbelow-ar by ghainDotbelow-ar.medi;\012sub feh-ar by feh-ar.medi;\012sub veh-ar by veh-ar.medi;\012sub fehDotmovedbelow-ar by fehDotmovedbelow-ar.medi;\012sub fehDotbelow-ar by fehDotbelow-ar.medi;\012sub fehThreedotsbelow-ar by fehThreedotsbelow-ar.medi;\012sub peheh-ar by peheh-ar.medi;\012sub qafDotless-ar by qafDotless-ar.medi;\012sub qaf-ar by qaf-ar.medi;\012sub qafThreedotsabove-ar by qafThreedotsabove-ar.medi;\012sub kaf-ar by kaf-ar.medi;\012sub keheh-ar by keheh-ar.medi;\012sub kehehDotabove-ar by kehehDotabove-ar.medi;\012sub kehehThreedotsabove-ar by kehehThreedotsabove-ar.medi;\012sub kehehThreedotsupbelow-ar by kehehThreedotsupbelow-ar.medi;\012sub gaf-ar by gaf-ar.medi;\012sub gafRing-ar by gafRing-ar.medi;\012sub gafThreedots-ar by gafThreedots-ar.medi;\012sub kafswash-ar by kafswash-ar.medi;\012sub kafRing-ar by kafRing-ar.medi;\012sub kafDotabove-ar by kafDotabove-ar.medi;\012sub kafThreedotsbelow-ar by kafThreedotsbelow-ar.medi;\012sub gafTwodotsbelow-ar by gafTwodotsbelow-ar.medi;\012sub ng-ar by ng-ar.medi;\012sub ngoeh-ar by ngoeh-ar.medi;\012sub gueh-ar by gueh-ar.medi;\012sub lam-ar by lam-ar.medi;\012sub lamVabove-ar by lamVabove-ar.medi;\012sub lamDotabove-ar by lamDotabove-ar.medi;\012sub lamThreedotsabove-ar by lamThreedotsabove-ar.medi;\012sub lamThreedotsbelow-ar by lamThreedotsbelow-ar.medi;\012sub meem-ar by meem-ar.medi;\012sub noon-ar by noon-ar.medi;\012sub noonDotbelow-ar by noonDotbelow-ar.medi;\012sub noonRing-ar by noonRing-ar.medi;\012sub noonThreedotsabove-ar by noonThreedotsabove-ar.medi;\012sub heh-ar by heh-ar.medi;\012sub hehgoal-ar by hehgoal-ar.medi;\012sub hehDoachashmee-ar by hehDoachashmee-ar.medi;\012sub hehVinvertedabove-ar by hehVinvertedabove-ar.medi;\012sub yeh-ar by yeh-ar.medi;\012sub yehHamzaabove-ar by yehHamzaabove-ar.medi;\012sub yehVabove-ar by yehVabove-ar.medi;\012sub yeh-farsi by yeh-farsi.medi;\012sub e-ar by e-ar.medi;\012sub yehThreedotsbelow-ar by yehThreedotsbelow-ar.medi;\012sub seenFourdotsabove-ar by seenFourdotsabove-ar.medi;\012sub ainTwodotshorizontalabove-ar by ainTwodotshorizontalabove-ar.medi;\012sub ainThreedotsdownabove-ar by ainThreedotsdownabove-ar.medi;\012sub ainTwodotsverticalabove-ar by ainTwodotsverticalabove-ar.medi;\012sub fehTwodotsbelow-ar by fehTwodotsbelow-ar.medi;\012sub fehThreedotsupbelow-ar by fehThreedotsupbelow-ar.medi;\012sub meemDotabove-ar by meemDotabove-ar.medi;\012sub meemDotbelow-ar by meemDotbelow-ar.medi;\012sub noonTwodotsbelow-ar by noonTwodotsbelow-ar.medi;\012sub noonTahabove-ar by noonTahabove-ar.medi;\012sub noonVabove-ar by noonVabove-ar.medi;\012sub lamBar-ar by lamBar-ar.medi;\012sub seenTwodotshorizontalabove-ar by seenTwodotshorizontalabove-ar.medi;\012";
 name = medi;
 },
 {
@@ -110,7 +120,7 @@ code = "lookup rlig_arab_0 {\012	lookupflag IgnoreMarks RightToLeft;\012	script 
 name = rlig;
 },
 {
-code = "lookup dlig_RTL {\012lookupflag IgnoreMarks RightToLeft;\012	sub lamBar-ar.init alef-ar.fina by lamBar_alef-ar.isol;\012	sub lamBar-ar.medi alef-ar.fina by lamBar_alef-ar.fina;\012	sub lamDotabove-ar.init alef-ar.fina by lamDotabove_alef-ar.isol;\012	sub lamDotabove-ar.medi alef-ar.fina by lamDotabove_alef-ar.fina;\012	sub lamThreedotsabove-ar.init alef-ar.fina by lamThreedotsabove_alef-ar.isol;\012	sub lamThreedotsabove-ar.medi alef-ar.fina by lamThreedotsabove_alef-ar.fina;\012	sub lamThreedotsbelow-ar.init alef-ar.fina by lamThreedotsbelow_alef-ar.isol;\012	sub lamThreedotsbelow-ar.medi alef-ar.fina by lamThreedotsbelow_alef-ar.fina;\012	sub lamVabove-ar.init alef-ar.fina by lamVabove_alef-ar.isol;\012	sub lamVabove-ar.medi alef-ar.fina by lamVabove_alef-ar.fina;\012	sub lam-ar.init alef-ar.fina by lam_alef-ar.isol;\012	sub lamVabove-ar.init alef-ar.fina by lamVabove_alef-ar.isol;\012	sub lam-ar.init alefHamzaabove-ar.fina by lam_alefHamzaabove-ar.isol;\012	sub lam-ar.init alefHamzabelow-ar.fina by lam_alefHamzabelow-ar.isol;\012	sub lam-ar.init alefMadda-ar.fina by lam_alefMadda-ar.isol;\012	sub lam-ar.init alefWasla-ar.fina by lam_alefWasla-ar.isol;\012	sub lam-ar.init alefWavyhamzaabove-ar.fina by lam_alefWavyhamzaabove-ar.isol;\012	sub lam-ar.medi alefWavyhamzaabove-ar.fina by lam_alefWavyhamzaabove-ar.fina;\012	sub lam-ar.init alefWavyhamzabelow-ar.fina by lam_alefWavyhamzabelow-ar.isol;\012	sub lam-ar.medi alefWavyhamzabelow-ar.fina by lam_alefWavyhamzabelow-ar.fina;\012	sub lam-ar.init highhamzaAlef-ar.fina by lam_highhamzaAlef-ar.isol;\012	sub lam-ar.medi highhamzaAlef-ar.fina by lam_highhamzaAlef-ar.fina;\012	sub alef-ar lam-ar.init lam-ar.medi heh-ar.fina by allah-ar;\012} dlig_RTL;\012";
+code = "lookup dlig_RTL {\012lookupflag IgnoreMarks RightToLeft;\012	sub lamBar-ar.init alef-ar.fina by lamBar_alef-ar.isol;\012	sub lamBar-ar.medi alef-ar.fina by lamBar_alef-ar.fina;\012	sub lamDotabove-ar.init alef-ar.fina by lamDotabove_alef-ar.isol;\012	sub lamDotabove-ar.medi alef-ar.fina by lamDotabove_alef-ar.fina;\012	sub lamThreedotsabove-ar.init alef-ar.fina by lamThreedotsabove_alef-ar.isol;\012	sub lamThreedotsabove-ar.medi alef-ar.fina by lamThreedotsabove_alef-ar.fina;\012	sub lamThreedotsbelow-ar.init alef-ar.fina by lamThreedotsbelow_alef-ar.isol;\012	sub lamThreedotsbelow-ar.medi alef-ar.fina by lamThreedotsbelow_alef-ar.fina;\012	sub lamVabove-ar.init alef-ar.fina by lamVabove_alef-ar.isol;\012	sub lamVabove-ar.medi alef-ar.fina by lamVabove_alef-ar.fina;\012	sub lam-ar.init alef-ar.fina by lam_alef-ar.isol;\012	sub lamVabove-ar.init alef-ar.fina by lamVabove_alef-ar.isol;\012	sub lam-ar.init alefHamzaabove-ar.fina by lam_alefHamzaabove-ar.isol;\012	sub lamVabove-ar.init alefMadda-ar.fina by lamVaboveMadda_alef-ar.isol;\012	sub lam-ar.init alefHamzabelow-ar.fina by lam_alefHamzabelow-ar.isol;\012	sub lam-ar.init alefMadda-ar.fina by lam_alefMadda-ar.isol;\012	sub lam-ar.init alefWasla-ar.fina by lam_alefWasla-ar.isol;\012	sub lam-ar.init alefWavyhamzaabove-ar.fina by lam_alefWavyhamzaabove-ar.isol;\012	sub lam-ar.medi alefWavyhamzaabove-ar.fina by lam_alefWavyhamzaabove-ar.fina;\012	sub lam-ar.init alefWavyhamzabelow-ar.fina by lam_alefWavyhamzabelow-ar.isol;\012	sub lam-ar.medi alefWavyhamzabelow-ar.fina by lam_alefWavyhamzabelow-ar.fina;\012	sub lam-ar.init highhamzaAlef-ar.fina by lam_highhamzaAlef-ar.isol;\012	sub lam-ar.medi highhamzaAlef-ar.fina by lam_highhamzaAlef-ar.fina;\012	sub alef-ar lam-ar.init lam-ar.medi heh-ar.fina by allah-ar;\012} dlig_RTL;\012";
 name = dlig;
 }
 );
@@ -24721,7 +24731,7 @@ note = uni06EF.fina;
 },
 {
 glyphname = "rehStroke-ar";
-lastChange = "2019-10-18 16:22:37 +0000";
+lastChange = "2021-01-08 18:17:09 +0000";
 layers = (
 {
 anchors = (
@@ -24749,18 +24759,18 @@ nodes = (
 "271 -216 OFFCURVE",
 "299 -148 CURVE",
 "386 -148 LINE",
-"386 -51 LINE",
-"323 -51 LINE",
-"324 -39 OFFCURVE",
+"386 -61 LINE",
+"323 -61 LINE",
+"324 -49 OFFCURVE",
 "324 -28 OFFCURVE",
 "325 -16 CURVE",
 "325 495 LINE",
 "176 495 LINE",
 "176 -18 LINE SMOOTH",
 "176 -29.333 OFFCURVE",
-"175 -40.333 OFFCURVE",
-"173 -51 CURVE",
-"34 -51 LINE"
+"175 -50 OFFCURVE",
+"173 -61 CURVE",
+"34 -61 LINE"
 );
 }
 );
@@ -24884,18 +24894,18 @@ nodes = (
 "310 -222 OFFCURVE",
 "340 -148 CURVE",
 "433 -148 LINE",
-"433 -24 LINE",
-"368 -24 LINE",
-"368 -12 OFFCURVE",
-"367 -4 OFFCURVE",
+"433 -44 LINE",
+"368 -44 LINE",
+"368 -32 OFFCURVE",
+"368 -4 OFFCURVE",
 "368 3 CURVE SMOOTH",
 "368 502 LINE",
 "177 502 LINE",
 "176 3 LINE SMOOTH",
 "176 -7 OFFCURVE",
-"175 -16 OFFCURVE",
-"174 -24 CURVE",
-"34 -24 LINE"
+"175 -36 OFFCURVE",
+"174 -44 CURVE",
+"34 -44 LINE"
 );
 }
 );
@@ -24907,7 +24917,7 @@ unicode = 075B;
 },
 {
 glyphname = "rehStroke-ar.fina";
-lastChange = "2019-10-23 10:38:08 +0000";
+lastChange = "2021-01-08 18:16:39 +0000";
 layers = (
 {
 anchors = (
@@ -24929,9 +24939,9 @@ nodes = (
 "204 495 LINE",
 "204 -18 LINE SMOOTH",
 "204 -29.333 OFFCURVE",
-"203 -40.333 OFFCURVE",
-"201 -51 CURVE",
-"62 -51 LINE",
+"203 -50 OFFCURVE",
+"201 -61 CURVE",
+"62 -61 LINE",
 "62 -148 LINE",
 "167 -148 LINE",
 "145.667 -184.667 OFFCURVE",
@@ -24942,9 +24952,9 @@ nodes = (
 "297.667 -220 OFFCURVE",
 "327 -148 CURVE",
 "414 -148 LINE",
-"414 -51 LINE",
-"351 -51 LINE",
-"352 -39 OFFCURVE",
+"414 -61 LINE",
+"351 -61 LINE",
+"352 -49 OFFCURVE",
 "352 -28 OFFCURVE",
 "353 -16 CURVE",
 "353 0 LINE",
@@ -25094,9 +25104,9 @@ nodes = (
 "237 502 LINE",
 "236 3 LINE SMOOTH",
 "236 -7 OFFCURVE",
-"235 -16 OFFCURVE",
-"234 -24 CURVE",
-"94 -24 LINE",
+"235 -36 OFFCURVE",
+"234 -44 CURVE",
+"94 -44 LINE",
 "94 -148 LINE",
 "194 -148 LINE",
 "171 -188 OFFCURVE",
@@ -25107,10 +25117,10 @@ nodes = (
 "368 -229 OFFCURVE",
 "400 -148 CURVE",
 "493 -148 LINE",
-"493 -24 LINE",
-"428 -24 LINE",
-"428 -14 OFFCURVE",
-"427 -6 OFFCURVE",
+"493 -44 LINE",
+"428 -44 LINE",
+"428 -34 OFFCURVE",
+"428 12 OFFCURVE",
 "428 3 CURVE SMOOTH",
 "428 0 LINE",
 "562 0 LINE SMOOTH",
@@ -41318,6 +41328,220 @@ width = 1064;
 note = uni06A8.fina;
 },
 {
+glyphname = "qafThreedotsabove-ar.medi";
+lastChange = "2021-01-06 06:55:43 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{340, -78}";
+},
+{
+name = top;
+position = "{391, 930}";
+}
+);
+components = (
+{
+alignment = -1;
+name = "qafDotless-ar.medi";
+},
+{
+alignment = -1;
+name = threedots.above;
+transform = "{1, 0, 0, 1, 384, 0}";
+}
+);
+layerId = "307C4A58-79B8-4138-817C-FBEE21722E1A";
+width = 680;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{301, -78}";
+},
+{
+name = top;
+position = "{341, 890}";
+}
+);
+components = (
+{
+alignment = -1;
+name = "qafDotless-ar.medi";
+},
+{
+alignment = -1;
+name = threedots.above;
+transform = "{1, 0, 0, 1, 337, 0}";
+}
+);
+layerId = "15908E2C-AB74-4DC1-B0E7-8741EE8F4DA5";
+width = 601;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{300, -78}";
+},
+{
+name = top;
+position = "{307, 754}";
+}
+);
+components = (
+{
+alignment = -1;
+name = "qafDotless-ar.medi";
+},
+{
+alignment = -1;
+name = threedots.above;
+transform = "{1, 0, 0, 1, 310, 0}";
+}
+);
+layerId = "410295A1-92BC-4707-ABFC-13885E60878B";
+width = 522;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{366, -78}";
+},
+{
+name = top;
+position = "{431, 950}";
+}
+);
+components = (
+{
+alignment = -1;
+name = "qafDotless-ar.medi";
+},
+{
+alignment = -1;
+name = threedots.above;
+transform = "{1, 0, 0, 1, 415, 0}";
+}
+);
+layerId = "DCD2D043-4E01-4B5D-9248-443A06E88532";
+width = 733;
+}
+);
+note = uni0642.medi;
+},
+{
+glyphname = "qafThreedotsabove-ar.init";
+lastChange = "2021-01-06 06:57:44 +0000";
+layers = (
+{
+anchors = (
+{
+name = bottom;
+position = "{323, -78}";
+},
+{
+name = top;
+position = "{369, 905}";
+}
+);
+components = (
+{
+alignment = -1;
+name = "qafDotless-ar.init";
+},
+{
+alignment = -1;
+name = threedots.above;
+transform = "{1, 0, 0, 1, 362, 0}";
+}
+);
+layerId = "307C4A58-79B8-4138-817C-FBEE21722E1A";
+width = 645;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{293, -78}";
+},
+{
+name = top;
+position = "{333, 856}";
+}
+);
+components = (
+{
+alignment = -1;
+name = "qafDotless-ar.init";
+},
+{
+alignment = -1;
+name = threedots.above;
+transform = "{1, 0, 0, 1, 337, 0}";
+}
+);
+layerId = "15908E2C-AB74-4DC1-B0E7-8741EE8F4DA5";
+width = 585;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{310, -78}";
+},
+{
+name = top;
+position = "{320, 719}";
+}
+);
+components = (
+{
+alignment = -1;
+name = "qafDotless-ar.init";
+},
+{
+alignment = -1;
+name = threedots.above;
+transform = "{1, 0, 0, 1, 312, 0}";
+}
+);
+layerId = "410295A1-92BC-4707-ABFC-13885E60878B";
+width = 525;
+},
+{
+anchors = (
+{
+name = bottom;
+position = "{343, -78}";
+},
+{
+name = top;
+position = "{400, 962}";
+}
+);
+components = (
+{
+alignment = -1;
+name = "qafDotless-ar.init";
+},
+{
+alignment = -1;
+name = threedots.above;
+transform = "{1, 0, 0, 1, 379, 0}";
+}
+);
+layerId = "DCD2D043-4E01-4B5D-9248-443A06E88532";
+width = 685;
+}
+);
+note = uni0642.init;
+},
+{
 glyphname = "kaf-ar";
 lastChange = "2019-10-21 15:52:47 +0000";
 layers = (
@@ -56121,13 +56345,13 @@ note = uni06BB.fina;
 },
 {
 glyphname = "noonRing-ar";
-lastChange = "2019-10-23 18:59:16 +0000";
+lastChange = "2021-01-04 03:25:44 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{356, -437}";
+position = "{356, -477}";
 },
 {
 name = top;
@@ -56142,7 +56366,7 @@ name = "noonghunna-ar";
 {
 alignment = -1;
 name = "sukun-ar";
-transform = "{1, 0, 0, 1, 366, -1205}";
+transform = "{1, 0, 0, 1, 366, -1245}";
 },
 {
 alignment = -1;
@@ -56157,7 +56381,7 @@ width = 761;
 anchors = (
 {
 name = bottom;
-position = "{306, -430}";
+position = "{306, -470}";
 },
 {
 name = top;
@@ -56172,7 +56396,7 @@ name = "noonghunna-ar";
 {
 alignment = -1;
 name = "sukun-ar";
-transform = "{1, 0, 0, 1, 311, -1215}";
+transform = "{1, 0, 0, 1, 311, -1255}";
 },
 {
 alignment = -1;
@@ -56217,7 +56441,7 @@ width = 583;
 anchors = (
 {
 name = bottom;
-position = "{396, -418}";
+position = "{396, -458}";
 },
 {
 name = top;
@@ -56232,7 +56456,7 @@ name = "noonghunna-ar";
 {
 alignment = -1;
 name = "sukun-ar";
-transform = "{1, 0, 0, 1, 403, -1198}";
+transform = "{1, 0, 0, 1, 403, -1238}";
 },
 {
 alignment = -1;
@@ -56249,13 +56473,13 @@ unicode = 06BC;
 },
 {
 glyphname = "noonRing-ar.fina";
-lastChange = "2019-10-22 14:23:29 +0000";
+lastChange = "2021-01-04 03:26:15 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{356, -437}";
+position = "{356, -477}";
 },
 {
 name = top;
@@ -56270,7 +56494,7 @@ name = "noonghunna-ar.fina";
 {
 alignment = -1;
 name = "sukun-ar";
-transform = "{1, 0, 0, 1, 366, -1205}";
+transform = "{1, 0, 0, 1, 366, -1245}";
 },
 {
 alignment = -1;
@@ -56285,7 +56509,7 @@ width = 800;
 anchors = (
 {
 name = bottom;
-position = "{306, -430}";
+position = "{310, -469}";
 },
 {
 name = top;
@@ -56300,7 +56524,7 @@ name = "noonghunna-ar.fina";
 {
 alignment = -1;
 name = "sukun-ar";
-transform = "{1, 0, 0, 1, 311, -1215}";
+transform = "{1, 0, 0, 1, 311, -1245}";
 },
 {
 alignment = -1;
@@ -56330,7 +56554,7 @@ name = "noonghunna-ar.fina";
 {
 alignment = -1;
 name = "sukun-ar";
-transform = "{1, 0, 0, 1, 256, -1226}";
+transform = "{1, 0, 0, 1, 256, -1236}";
 },
 {
 alignment = -1;
@@ -56345,7 +56569,7 @@ width = 584;
 anchors = (
 {
 name = bottom;
-position = "{399, -422}";
+position = "{399, -462}";
 },
 {
 name = top;
@@ -56360,7 +56584,7 @@ name = "noonghunna-ar.fina";
 {
 alignment = -1;
 name = "sukun-ar";
-transform = "{1, 0, 0, 1, 403, -1198}";
+transform = "{1, 0, 0, 1, 403, -1238}";
 },
 {
 alignment = -1;
@@ -56376,13 +56600,13 @@ note = uni06BC.fina;
 },
 {
 glyphname = "noonRing-ar.medi";
-lastChange = "2019-10-22 17:12:10 +0000";
+lastChange = "2021-01-04 03:24:46 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{180, -206}";
+position = "{180, -246}";
 },
 {
 name = top;
@@ -56402,7 +56626,7 @@ transform = "{1, 0, 0, 1, 184, 0}";
 {
 alignment = -1;
 name = "sukun-ar";
-transform = "{1, 0, 0, 1, 187, -964}";
+transform = "{1, 0, 0, 1, 187, -1004}";
 }
 );
 layerId = "307C4A58-79B8-4138-817C-FBEE21722E1A";
@@ -56412,7 +56636,7 @@ width = 394;
 anchors = (
 {
 name = bottom;
-position = "{171, -200}";
+position = "{171, -240}";
 },
 {
 name = top;
@@ -56432,7 +56656,7 @@ transform = "{1, 0, 0, 1, 168, 0}";
 {
 alignment = -1;
 name = "sukun-ar";
-transform = "{1, 0, 0, 1, 169, -976}";
+transform = "{1, 0, 0, 1, 169, -1016}";
 }
 );
 layerId = "15908E2C-AB74-4DC1-B0E7-8741EE8F4DA5";
@@ -56462,7 +56686,7 @@ transform = "{1, 0, 0, 1, 160, 0}";
 {
 alignment = -1;
 name = "sukun-ar";
-transform = "{1, 0, 0, 1, 151, -986}";
+transform = "{1, 0, 0, 1, 151, -996}";
 }
 );
 layerId = "410295A1-92BC-4707-ABFC-13885E60878B";
@@ -56472,7 +56696,7 @@ width = 268;
 anchors = (
 {
 name = bottom;
-position = "{186, -190}";
+position = "{186, -230}";
 },
 {
 name = top;
@@ -56492,7 +56716,7 @@ transform = "{1, 0, 0, 1, 195, 0}";
 {
 alignment = -1;
 name = "sukun-ar";
-transform = "{1, 0, 0, 1, 199, -956}";
+transform = "{1, 0, 0, 1, 199, -996}";
 }
 );
 layerId = "DCD2D043-4E01-4B5D-9248-443A06E88532";
@@ -56503,13 +56727,13 @@ note = uni06BC.medi;
 },
 {
 glyphname = "noonRing-ar.init";
-lastChange = "2019-10-22 15:48:37 +0000";
+lastChange = "2021-01-04 03:25:16 +0000";
 layers = (
 {
 anchors = (
 {
 name = bottom;
-position = "{180, -206}";
+position = "{150, -246}";
 },
 {
 name = top;
@@ -56529,7 +56753,7 @@ transform = "{1, 0, 0, 1, 184, 0}";
 {
 alignment = -1;
 name = "sukun-ar";
-transform = "{1, 0, 0, 1, 136, -964}";
+transform = "{1, 0, 0, 1, 136, -1004}";
 }
 );
 layerId = "307C4A58-79B8-4138-817C-FBEE21722E1A";
@@ -56539,7 +56763,7 @@ width = 354;
 anchors = (
 {
 name = bottom;
-position = "{114, -192}";
+position = "{114, -222}";
 },
 {
 name = top;
@@ -56559,7 +56783,7 @@ transform = "{1, 0, 0, 1, 168, 0}";
 {
 alignment = -1;
 name = "sukun-ar";
-transform = "{1, 0, 0, 1, 119, -976}";
+transform = "{1, 0, 0, 1, 119, -1006}";
 }
 );
 layerId = "15908E2C-AB74-4DC1-B0E7-8741EE8F4DA5";
@@ -56589,7 +56813,7 @@ transform = "{1, 0, 0, 1, 157, 0}";
 {
 alignment = -1;
 name = "sukun-ar";
-transform = "{1, 0, 0, 1, 102, -986}";
+transform = "{1, 0, 0, 1, 102, -996}";
 }
 );
 layerId = "410295A1-92BC-4707-ABFC-13885E60878B";
@@ -56599,7 +56823,7 @@ width = 278;
 anchors = (
 {
 name = bottom;
-position = "{151, -168}";
+position = "{151, -208}";
 },
 {
 name = top;
@@ -56619,7 +56843,7 @@ transform = "{1, 0, 0, 1, 195, 0}";
 {
 alignment = -1;
 name = "sukun-ar";
-transform = "{1, 0, 0, 1, 157, -956}";
+transform = "{1, 0, 0, 1, 157, -996}";
 }
 );
 layerId = "DCD2D043-4E01-4B5D-9248-443A06E88532";
@@ -77654,7 +77878,7 @@ note = uni06440627.fina;
 },
 {
 glyphname = "lam_alefHamzaabove-ar";
-lastChange = "2020-12-29 02:50:13 +0000";
+lastChange = "2021-01-03 22:06:01 +0000";
 layers = (
 {
 anchors = (
@@ -77672,7 +77896,7 @@ position = "{357, 0}";
 },
 {
 name = top_1;
-position = "{517, 832}";
+position = "{535, 890}";
 },
 {
 name = top_2;
@@ -77708,7 +77932,7 @@ position = "{337, 0}";
 },
 {
 name = top_1;
-position = "{522, 835}";
+position = "{535, 890}";
 },
 {
 name = top_2;
@@ -77744,7 +77968,7 @@ position = "{317, 0}";
 },
 {
 name = top_1;
-position = "{527, 838}";
+position = "{535, 890}";
 },
 {
 name = top_2;
@@ -77780,7 +78004,7 @@ position = "{370, 0}";
 },
 {
 name = top_1;
-position = "{558, 830}";
+position = "{535, 890}";
 },
 {
 name = top_2;
@@ -77806,7 +78030,7 @@ unicode = FEF7;
 },
 {
 glyphname = "lam_alefHamzaabove-ar.isol";
-lastChange = "2019-10-17 13:09:36 +0000";
+lastChange = "2021-01-02 07:35:22 +0000";
 layers = (
 {
 anchors = (
@@ -77896,7 +78120,7 @@ position = "{317, 0}";
 },
 {
 name = top_1;
-position = "{527, 838}";
+position = "{530, 840}";
 },
 {
 name = top_2;
@@ -79181,7 +79405,7 @@ note = uni06440622.isol;
 },
 {
 glyphname = "lam_alefMadda-ar.fina";
-lastChange = "2019-10-17 13:10:40 +0000";
+lastChange = "2021-01-02 07:48:32 +0000";
 layers = (
 {
 anchors = (
@@ -79944,7 +80168,7 @@ note = uni06440671.fina;
 },
 {
 glyphname = "lamVabove_alef-ar.isol";
-lastChange = "2019-10-17 13:11:07 +0000";
+lastChange = "2021-01-02 07:49:18 +0000";
 layers = (
 {
 anchors = (
@@ -79961,8 +80185,12 @@ name = caret_1;
 position = "{357, 0}";
 },
 {
+name = top;
+position = "{530, 1064}";
+},
+{
 name = top_1;
-position = "{549, 1072}";
+position = "{562, 1072}";
 },
 {
 name = top_2;
@@ -79996,6 +80224,10 @@ position = "{224, -78}";
 {
 name = caret_1;
 position = "{337, 0}";
+},
+{
+name = top;
+position = "{509, 1064}";
 },
 {
 name = top_1;
@@ -80035,6 +80267,10 @@ name = caret_1;
 position = "{317, 0}";
 },
 {
+name = top;
+position = "{503, 1064}";
+},
+{
 name = top_1;
 position = "{495, 1068}";
 },
@@ -80072,6 +80308,10 @@ name = caret_1;
 position = "{370, 0}";
 },
 {
+name = top;
+position = "{578, 1064}";
+},
+{
 name = top_1;
 position = "{557, 1073}";
 },
@@ -80099,7 +80339,7 @@ note = uni06B50627.isol;
 },
 {
 glyphname = "lamVabove_alef-ar.fina";
-lastChange = "2019-10-17 13:19:35 +0000";
+lastChange = "2021-01-02 07:54:15 +0000";
 layers = (
 {
 anchors = (
@@ -82400,7 +82640,7 @@ unicode = FDF2;
 },
 {
 glyphname = "wawSmall-ar";
-lastChange = "2019-10-17 13:19:16 +0000";
+lastChange = "2021-01-04 03:17:11 +0000";
 layers = (
 {
 layerId = "307C4A58-79B8-4138-817C-FBEE21722E1A";
@@ -82408,43 +82648,43 @@ paths = (
 {
 closed = 1;
 nodes = (
-"170.333 485 OFFCURVE",
-"211 520 OFFCURVE",
-"211 580 CURVE SMOOTH",
-"211 779 LINE",
-"150 779 LINE SMOOTH",
-"71.333 779 OFFCURVE",
-"23 737.667 OFFCURVE",
-"23 675 CURVE SMOOTH",
-"23 611 OFFCURVE",
-"58.667 581 OFFCURVE",
-"112 581 CURVE SMOOTH",
-"151 581 LINE",
-"151 579 LINE SMOOTH",
-"151 548.333 OFFCURVE",
-"135.333 533 OFFCURVE",
-"104 533 CURVE SMOOTH",
-"81.333 533 OFFCURVE",
-"61 538 OFFCURVE",
-"43 548 CURVE",
-"20 505 LINE",
-"46.667 489 OFFCURVE",
-"69 485 OFFCURVE",
-"105 485 CURVE SMOOTH"
+"170 -15 OFFCURVE",
+"211 20 OFFCURVE",
+"211 80 CURVE SMOOTH",
+"211 279 LINE",
+"150 279 LINE SMOOTH",
+"71 279 OFFCURVE",
+"23 238 OFFCURVE",
+"23 175 CURVE SMOOTH",
+"23 111 OFFCURVE",
+"59 81 OFFCURVE",
+"112 81 CURVE SMOOTH",
+"151 81 LINE",
+"151 79 LINE SMOOTH",
+"151 48 OFFCURVE",
+"135 33 OFFCURVE",
+"104 33 CURVE SMOOTH",
+"81 33 OFFCURVE",
+"61 38 OFFCURVE",
+"43 48 CURVE",
+"20 5 LINE",
+"47 -11 OFFCURVE",
+"69 -15 OFFCURVE",
+"105 -15 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"124 629 LINE SMOOTH",
-"97.333 629 OFFCURVE",
-"84 644.667 OFFCURVE",
-"84 676 CURVE SMOOTH",
-"84 709.333 OFFCURVE",
-"102 731 OFFCURVE",
-"138 731 CURVE SMOOTH",
-"151 731 LINE",
-"151 629 LINE"
+"124 129 LINE SMOOTH",
+"97 129 OFFCURVE",
+"84 145 OFFCURVE",
+"84 176 CURVE SMOOTH",
+"84 209 OFFCURVE",
+"102 231 OFFCURVE",
+"138 231 CURVE SMOOTH",
+"151 231 LINE",
+"151 129 LINE"
 );
 }
 );
@@ -82459,43 +82699,43 @@ paths = (
 {
 closed = 1;
 nodes = (
-"153.333 485 OFFCURVE",
-"185 518.667 OFFCURVE",
-"185 572 CURVE SMOOTH",
-"185 775 LINE",
-"132 775 LINE SMOOTH",
-"65.333 775 OFFCURVE",
-"23 735.667 OFFCURVE",
-"23 673 CURVE SMOOTH",
-"23 609 OFFCURVE",
-"58.667 581 OFFCURVE",
-"112 581 CURVE SMOOTH",
-"151 581 LINE",
-"151 570 LINE SMOOTH",
-"151 538 OFFCURVE",
-"130.333 517 OFFCURVE",
-"93 517 CURVE SMOOTH",
-"72.333 517 OFFCURVE",
-"53.333 522.333 OFFCURVE",
-"36 533 CURVE",
-"20 506 LINE",
-"40 492 OFFCURVE",
-"64 485 OFFCURVE",
-"92 485 CURVE SMOOTH"
+"153 -15 OFFCURVE",
+"185 19 OFFCURVE",
+"185 72 CURVE SMOOTH",
+"185 275 LINE",
+"132 275 LINE SMOOTH",
+"65 275 OFFCURVE",
+"23 236 OFFCURVE",
+"23 173 CURVE SMOOTH",
+"23 109 OFFCURVE",
+"59 81 OFFCURVE",
+"112 81 CURVE SMOOTH",
+"151 81 LINE",
+"151 70 LINE SMOOTH",
+"151 38 OFFCURVE",
+"130 17 OFFCURVE",
+"93 17 CURVE SMOOTH",
+"72 17 OFFCURVE",
+"53 22 OFFCURVE",
+"36 33 CURVE",
+"20 6 LINE",
+"40 -8 OFFCURVE",
+"64 -15 OFFCURVE",
+"92 -15 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"113 613 LINE SMOOTH",
-"75.667 613 OFFCURVE",
-"58 630.333 OFFCURVE",
-"58 673 CURVE SMOOTH",
-"58 715.667 OFFCURVE",
-"82.333 744 OFFCURVE",
-"133 744 CURVE SMOOTH",
-"151 744 LINE",
-"151 613 LINE"
+"113 113 LINE SMOOTH",
+"76 113 OFFCURVE",
+"58 130 OFFCURVE",
+"58 173 CURVE SMOOTH",
+"58 216 OFFCURVE",
+"82 244 OFFCURVE",
+"133 244 CURVE SMOOTH",
+"151 244 LINE",
+"151 113 LINE"
 );
 }
 );
@@ -82510,43 +82750,43 @@ paths = (
 {
 closed = 1;
 nodes = (
-"136 485 OFFCURVE",
-"159 517 OFFCURVE",
-"159 564 CURVE SMOOTH",
-"159 771 LINE",
-"128 771 LINE SMOOTH",
-"61 771 OFFCURVE",
-"23 732 OFFCURVE",
-"23 671 CURVE SMOOTH",
-"23 607 OFFCURVE",
-"59 581 OFFCURVE",
-"112 581 CURVE SMOOTH",
-"145 581 LINE",
-"145 561 LINE SMOOTH",
-"145 524 OFFCURVE",
-"125 499 OFFCURVE",
-"82 499 CURVE SMOOTH",
-"63 499 OFFCURVE",
-"46 506 OFFCURVE",
-"29 518 CURVE",
-"20 507 LINE",
-"33 495 OFFCURVE",
-"59 485 OFFCURVE",
-"79 485 CURVE SMOOTH"
+"136 -15 OFFCURVE",
+"159 17 OFFCURVE",
+"159 64 CURVE SMOOTH",
+"159 271 LINE",
+"128 271 LINE SMOOTH",
+"61 271 OFFCURVE",
+"23 232 OFFCURVE",
+"23 171 CURVE SMOOTH",
+"23 107 OFFCURVE",
+"59 81 OFFCURVE",
+"112 81 CURVE SMOOTH",
+"145 81 LINE",
+"145 61 LINE SMOOTH",
+"145 24 OFFCURVE",
+"125 -1 OFFCURVE",
+"82 -1 CURVE SMOOTH",
+"63 -1 OFFCURVE",
+"46 6 OFFCURVE",
+"29 18 CURVE",
+"20 7 LINE",
+"33 -5 OFFCURVE",
+"59 -15 OFFCURVE",
+"79 -15 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"111 595 LINE SMOOTH",
-"59 595 OFFCURVE",
-"37 622 OFFCURVE",
-"37 670 CURVE SMOOTH",
-"37 722 OFFCURVE",
-"66 757 OFFCURVE",
-"128 757 CURVE SMOOTH",
-"145 757 LINE",
-"145 595 LINE"
+"111 95 LINE SMOOTH",
+"59 95 OFFCURVE",
+"37 122 OFFCURVE",
+"37 170 CURVE SMOOTH",
+"37 222 OFFCURVE",
+"66 257 OFFCURVE",
+"128 257 CURVE SMOOTH",
+"145 257 LINE",
+"145 95 LINE"
 );
 }
 );
@@ -82558,43 +82798,43 @@ paths = (
 {
 closed = 1;
 nodes = (
-"180 482 OFFCURVE",
-"228 521 OFFCURVE",
-"228 585 CURVE SMOOTH",
-"228 782 LINE",
-"162 782 LINE SMOOTH",
-"75 782 OFFCURVE",
-"23 739 OFFCURVE",
-"23 676 CURVE SMOOTH",
-"23 612 OFFCURVE",
-"59 581 OFFCURVE",
-"112 581 CURVE SMOOTH",
-"151 581 LINE",
-"151 585 LINE SMOOTH",
-"151 555 OFFCURVE",
-"137 541 OFFCURVE",
-"103 541 CURVE SMOOTH",
-"79 541 OFFCURVE",
-"63 550 OFFCURVE",
-"44 558 CURVE",
-"20 504 LINE",
-"43 491 OFFCURVE",
-"76 482 OFFCURVE",
-"107 482 CURVE SMOOTH"
+"180 -18 OFFCURVE",
+"228 21 OFFCURVE",
+"228 85 CURVE SMOOTH",
+"228 282 LINE",
+"162 282 LINE SMOOTH",
+"75 282 OFFCURVE",
+"23 239 OFFCURVE",
+"23 176 CURVE SMOOTH",
+"23 112 OFFCURVE",
+"59 81 OFFCURVE",
+"112 81 CURVE SMOOTH",
+"151 81 LINE",
+"151 85 LINE SMOOTH",
+"151 55 OFFCURVE",
+"137 41 OFFCURVE",
+"103 41 CURVE SMOOTH",
+"79 41 OFFCURVE",
+"63 50 OFFCURVE",
+"44 58 CURVE",
+"20 4 LINE",
+"43 -9 OFFCURVE",
+"76 -18 OFFCURVE",
+"107 -18 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"131 640 LINE SMOOTH",
-"112 640 OFFCURVE",
-"101 654 OFFCURVE",
-"101 678 CURVE SMOOTH",
-"101 705 OFFCURVE",
-"115 722 OFFCURVE",
-"141 722 CURVE SMOOTH",
-"151 722 LINE",
-"151 640 LINE"
+"131 140 LINE SMOOTH",
+"112 140 OFFCURVE",
+"101 154 OFFCURVE",
+"101 178 CURVE SMOOTH",
+"101 205 OFFCURVE",
+"115 222 OFFCURVE",
+"141 222 CURVE SMOOTH",
+"151 222 LINE",
+"151 140 LINE"
 );
 }
 );
@@ -90548,7 +90788,7 @@ unicode = 060F;
 },
 {
 glyphname = "sindhiampersand-ar";
-lastChange = "2019-10-20 21:28:22 +0000";
+lastChange = "2021-01-07 03:46:23 +0000";
 layers = (
 {
 components = (
@@ -90556,12 +90796,14 @@ components = (
 name = "hamza-ar";
 },
 {
+alignment = -1;
 name = "alefbelow-ar";
-transform = "{1, 0, 0, 1, 254, 117}";
+transform = "{1, 0, 0, 1, 191, 117}";
 },
 {
+alignment = -1;
 name = "alefbelow-ar";
-transform = "{1, 0, 0, 1, 254, -118}";
+transform = "{1, 0, 0, 1, 315, 117}";
 }
 );
 layerId = "307C4A58-79B8-4138-817C-FBEE21722E1A";
@@ -90573,12 +90815,14 @@ components = (
 name = "hamza-ar";
 },
 {
+alignment = -1;
 name = "alefbelow-ar";
-transform = "{1, 0, 0, 1, 254, 97}";
+transform = "{1, 0, 0, 1, 193, 97}";
 },
 {
+alignment = -1;
 name = "alefbelow-ar";
-transform = "{1, 0, 0, 1, 254, -137}";
+transform = "{1, 0, 0, 1, 315, 97}";
 }
 );
 layerId = "15908E2C-AB74-4DC1-B0E7-8741EE8F4DA5";
@@ -90590,12 +90834,14 @@ components = (
 name = "hamza-ar";
 },
 {
+alignment = -1;
 name = "alefbelow-ar";
-transform = "{1, 0, 0, 1, 247, 129}";
+transform = "{1, 0, 0, 1, 207, 130}";
 },
 {
+alignment = -1;
 name = "alefbelow-ar";
-transform = "{1, 0, 0, 1, 247, -104}";
+transform = "{1, 0, 0, 1, 284, 130}";
 }
 );
 layerId = "410295A1-92BC-4707-ABFC-13885E60878B";
@@ -90607,12 +90853,14 @@ components = (
 name = "hamza-ar";
 },
 {
+alignment = -1;
 name = "alefbelow-ar";
-transform = "{1, 0, 0, 1, 269, 100}";
+transform = "{1, 0, 0, 1, 193, 100}";
 },
 {
+alignment = -1;
 name = "alefbelow-ar";
-transform = "{1, 0, 0, 1, 266, -174}";
+transform = "{1, 0, 0, 1, 346, 100}";
 }
 );
 layerId = "DCD2D043-4E01-4B5D-9248-443A06E88532";
@@ -94476,7 +94724,7 @@ unicode = 06E9;
 },
 {
 glyphname = "sindhipostpositionmen-ar";
-lastChange = "2019-10-23 18:26:37 +0000";
+lastChange = "2021-01-07 03:42:28 +0000";
 layers = (
 {
 components = (
@@ -94484,12 +94732,14 @@ components = (
 name = "meem-ar";
 },
 {
+alignment = -1;
 name = "alefbelow-ar";
-transform = "{1, 0, 0, 1, 400, 117}";
+transform = "{1, 0, 0, 1, 360, 117}";
 },
 {
+alignment = -1;
 name = "alefbelow-ar";
-transform = "{1, 0, 0, 1, 400, -118}";
+transform = "{1, 0, 0, 1, 484, 117}";
 }
 );
 layerId = "307C4A58-79B8-4138-817C-FBEE21722E1A";
@@ -94501,12 +94751,14 @@ components = (
 name = "meem-ar";
 },
 {
+alignment = -1;
 name = "alefbelow-ar";
-transform = "{1, 0, 0, 1, 361, 97}";
+transform = "{1, 0, 0, 1, 291, 97}";
 },
 {
+alignment = -1;
 name = "alefbelow-ar";
-transform = "{1, 0, 0, 1, 361, -137}";
+transform = "{1, 0, 0, 1, 413, 97}";
 }
 );
 layerId = "15908E2C-AB74-4DC1-B0E7-8741EE8F4DA5";
@@ -94518,12 +94770,14 @@ components = (
 name = "meem-ar";
 },
 {
+alignment = -1;
 name = "alefbelow-ar";
-transform = "{1, 0, 0, 1, 322, 77}";
+transform = "{1, 0, 0, 1, 272, 77}";
 },
 {
+alignment = -1;
 name = "alefbelow-ar";
-transform = "{1, 0, 0, 1, 322, -156}";
+transform = "{1, 0, 0, 1, 349, 77}";
 }
 );
 layerId = "410295A1-92BC-4707-ABFC-13885E60878B";
@@ -94535,13 +94789,14 @@ components = (
 name = "meem-ar";
 },
 {
+alignment = -1;
 name = "alefbelow-ar";
-transform = "{1, 0, 0, 1, 453, 100}";
+transform = "{1, 0, 0, 1, 383, 100}";
 },
 {
 alignment = -1;
 name = "alefbelow-ar";
-transform = "{1, 0, 0, 1, 450, -144}";
+transform = "{1, 0, 0, 1, 536, 100}";
 }
 );
 layerId = "DCD2D043-4E01-4B5D-9248-443A06E88532";
@@ -100063,7 +100318,7 @@ unicode = FE7C;
 },
 {
 glyphname = "shadda_fathatan-ar";
-lastChange = "2019-10-24 09:39:12 +0000";
+lastChange = "2021-01-08 18:05:22 +0000";
 layers = (
 {
 anchors = (
@@ -100073,7 +100328,7 @@ position = "{4, 746}";
 },
 {
 name = top;
-position = "{-53, 1236}";
+position = "{10, 1272}";
 }
 );
 components = (
@@ -100084,7 +100339,7 @@ transform = "{1, 0, 0, 1, 0, -40}";
 {
 alignment = -1;
 name = "fathatan-ar";
-transform = "{1, 0, 0, 1, -40, 190}";
+transform = "{1, 0, 0, 1, 20, 190}";
 }
 );
 layerId = "307C4A58-79B8-4138-817C-FBEE21722E1A";
@@ -100098,7 +100353,7 @@ position = "{1, 756}";
 },
 {
 name = top;
-position = "{-68, 1229}";
+position = "{15, 1272}";
 }
 );
 components = (
@@ -100109,7 +100364,7 @@ transform = "{1, 0, 0, 1, 0, -30}";
 {
 alignment = -1;
 name = "fathatan-ar";
-transform = "{1, 0, 0, 1, -42, 209}";
+transform = "{1, 0, 0, 1, 8, 209}";
 }
 );
 layerId = "15908E2C-AB74-4DC1-B0E7-8741EE8F4DA5";
@@ -100123,7 +100378,7 @@ position = "{-2, 786}";
 },
 {
 name = top;
-position = "{-43, 1242}";
+position = "{7, 1252}";
 }
 );
 components = (
@@ -100134,7 +100389,7 @@ name = "shadda-ar";
 {
 alignment = -1;
 name = "fathatan-ar";
-transform = "{1, 0, 0, 1, -44, 248}";
+transform = "{1, 0, 0, 1, -4, 248}";
 }
 );
 layerId = "410295A1-92BC-4707-ABFC-13885E60878B";
@@ -100148,7 +100403,7 @@ position = "{6, 736}";
 },
 {
 name = top;
-position = "{-43, 1237}";
+position = "{7, 1237}";
 }
 );
 components = (
@@ -100160,7 +100415,7 @@ transform = "{1, 0, 0, 1, 0, -50}";
 {
 alignment = -1;
 name = "fathatan-ar";
-transform = "{1, 0, 0, 1, -39, 194}";
+transform = "{1, 0, 0, 1, 11, 194}";
 }
 );
 layerId = "DCD2D043-4E01-4B5D-9248-443A06E88532";
@@ -107331,7 +107586,7 @@ note = uni06B50627.fina;
 },
 {
 glyphname = "lamVaboveMadda_alef-ar.isol";
-lastChange = "2020-12-29 05:14:36 +0000";
+lastChange = "2021-01-03 22:20:01 +0000";
 layers = (
 {
 anchors = (
@@ -107349,11 +107604,11 @@ position = "{357, 0}";
 },
 {
 name = top_1;
-position = "{549, 1072}";
+position = "{555, 1055}";
 },
 {
 name = top_2;
-position = "{170, 884}";
+position = "{182, 890}";
 }
 );
 components = (
@@ -107391,11 +107646,11 @@ position = "{337, 0}";
 },
 {
 name = top_1;
-position = "{522, 1070}";
+position = "{555, 1055}";
 },
 {
 name = top_2;
-position = "{170, 884}";
+position = "{182, 890}";
 }
 );
 components = (
@@ -107433,11 +107688,11 @@ position = "{317, 0}";
 },
 {
 name = top_1;
-position = "{495, 1068}";
+position = "{555, 1055}";
 },
 {
 name = top_2;
-position = "{170, 884}";
+position = "{182, 890}";
 }
 );
 components = (
@@ -107475,11 +107730,11 @@ position = "{370, 0}";
 },
 {
 name = top_1;
-position = "{557, 1073}";
+position = "{555, 1055}";
 },
 {
 name = top_2;
-position = "{170, 884}";
+position = "{182, 890}";
 }
 );
 components = (
@@ -111764,7 +112019,7 @@ note = threedots.horz.below;
 {
 export = 0;
 glyphname = smallv.arabic;
-lastChange = "2019-10-23 19:27:18 +0000";
+lastChange = "2021-01-03 22:18:26 +0000";
 layers = (
 {
 layerId = "307C4A58-79B8-4138-817C-FBEE21722E1A";


### PR DESCRIPTION
Lowered U+06E5 little more googlefonts/noto-fonts#1901
Adjusting the ring position googlefonts/noto-fonts#1897
Adding missing glyphs U+06A8 fixed googlefonts/noto-fonts#1775
Wrong glyphs for Sindhi particles Fixed googlefonts/noto-fonts#1624
Repositioned fathatan in shadda_fathatan-ar mark, fathatan was off to the right
Fixed the stroke in U+075B, in Black weight it is too close to the base, this will improve readability