### PR TITLE
NotoNaskhArabic 2.009

### DIFF
--- a/src/NotoNaskhArabic/NotoNaskhArabic-for-edit.glyphs
+++ b/src/NotoNaskhArabic/NotoNaskhArabic-for-edit.glyphs
@@ -1,5 +1,11 @@
 {
 .appVersion = "1350";
+DisplayStrings = (
+"/uni0650",
+"/uni06DC",
+"/uni0652",
+"/uni0635"
+);
 classes = (
 {
 code = "uni0660 uni0661 uni0662 uni0663 uni0664 uni0665 uni0666 uni0667 uni0668 uni0669 uni06F0 uni06F1 uni06F2 uni06F3 uni06F4 uni06F5 uni06F6 uni06F7 uni06F8 uni06F9 uni06F4.locl uni06F7.locl";
@@ -1029,10 +1035,10 @@ value = 1;
 },
 {
 name = versionString;
-value = "Version 2.008";
+value = "Version 2.009";
 }
 );
-date = "2021-02-09 20:48:21 +0000";
+date = "2021-03-17 14:37:41 +0000";
 designer = "Monotype Design Team, David Williams, Mohamad Dakak";
 designerURL = "http://www.monotype.com/studio";
 disablesNiceNames = 1;
@@ -2374,7 +2380,7 @@ width = 256;
 anchors = (
 {
 name = bottom;
-position = "{156, -231}";
+position = "{149, -235}";
 },
 {
 name = bottom.dot;
@@ -2390,8 +2396,9 @@ components = (
 name = uni0627;
 },
 {
+alignment = -1;
 name = uni0655;
-transform = "{1, 0, 0, 1, 69, -153}";
+transform = "{1, 0, 0, 1, 62, -107}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -18324,8 +18331,7 @@ name = uniFBB3;
 transform = "{1, 0, 0, 1, -66, -194}";
 },
 {
-name = uniFBB2;
-transform = "{1, 0, 0, 1, 2, 77}";
+name = "dotamiddle-ar";
 }
 );
 layerId = master01;
@@ -18363,8 +18369,7 @@ name = uniFBB3;
 transform = "{1, 0, 0, 1, -80, -178}";
 },
 {
-name = uniFBB2;
-transform = "{1, 0, 0, 1, 0, 87}";
+name = "dotamiddle-ar";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -18408,8 +18413,7 @@ name = uniFBB3;
 transform = "{1, 0, 0, 1, -66, -194}";
 },
 {
-name = uniFBB2;
-transform = "{1, 0, 0, 1, 2, 77}";
+name = "dotamiddle-ar";
 }
 );
 layerId = master01;
@@ -18447,8 +18451,7 @@ name = uniFBB3;
 transform = "{1, 0, 0, 1, -80, -178}";
 },
 {
-name = uniFBB2;
-transform = "{1, 0, 0, 1, 0, 87}";
+name = "dotamiddle-ar";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -61605,7 +61608,7 @@ position = "{99, -100}";
 },
 {
 name = top;
-position = "{99, 452}";
+position = "{99, 352}";
 }
 );
 layerId = master01;
@@ -61642,7 +61645,7 @@ position = "{99, -135}";
 },
 {
 name = top;
-position = "{99, 461}";
+position = "{99, 361}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -62039,7 +62042,7 @@ name = uni0640;
 },
 {
 name = uni0650_uni0651;
-transform = "{1, 0, 0, 1, 30, 88}";
+transform = "{1, 0, 0, 1, 30, -12}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -101450,49 +101453,49 @@ paths = (
 {
 closed = 1;
 nodes = (
-"128 -21 OFFCURVE",
-"166 30 OFFCURVE",
-"166 86 CURVE SMOOTH",
-"166 137 OFFCURVE",
-"138 184 OFFCURVE",
-"102 184 CURVE SMOOTH",
-"73 184 OFFCURVE",
-"47 148 OFFCURVE",
-"47 104 CURVE SMOOTH",
-"47 74 OFFCURVE",
-"64 56 OFFCURVE",
-"96 56 CURVE SMOOTH",
-"115 56 OFFCURVE",
-"139 66 OFFCURVE",
-"151 78 CURVE",
-"151 74 LINE",
-"137 30 OFFCURVE",
-"110 8 OFFCURVE",
-"72 8 CURVE SMOOTH",
-"56 8 OFFCURVE",
-"41 11 OFFCURVE",
-"27 16 CURVE",
-"21 3 LINE",
-"35 -9 OFFCURVE",
-"65 -21 OFFCURVE",
-"81 -21 CURVE SMOOTH"
+"133 -26 OFFCURVE",
+"176 25 OFFCURVE",
+"176 86 CURVE SMOOTH",
+"176 143 OFFCURVE",
+"144 189 OFFCURVE",
+"102 189 CURVE SMOOTH",
+"66 189 OFFCURVE",
+"37 151 OFFCURVE",
+"37 104 CURVE SMOOTH",
+"37 71 OFFCURVE",
+"59 51 OFFCURVE",
+"96 51 CURVE SMOOTH",
+"117 51 OFFCURVE",
+"146 62 OFFCURVE",
+"141 57 CURVE",
+"141 74 LINE",
+"127 33 OFFCURVE",
+"105 13 OFFCURVE",
+"72 13 CURVE SMOOTH",
+"54 13 OFFCURVE",
+"40 17 OFFCURVE",
+"21 24 CURVE",
+"11 3 LINE",
+"22 -10 OFFCURVE",
+"61 -26 OFFCURVE",
+"81 -26 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"78 86 OFFCURVE",
-"62 96 OFFCURVE",
-"62 115 CURVE SMOOTH",
-"62 130 OFFCURVE",
-"79 152 OFFCURVE",
-"96 152 CURVE SMOOTH",
-"119 152 OFFCURVE",
-"137 133 OFFCURVE",
-"148 95 CURVE",
-"135 89 OFFCURVE",
-"121 86 OFFCURVE",
-"105 86 CURVE SMOOTH"
+"82 91 OFFCURVE",
+"72 98 OFFCURVE",
+"72 115 CURVE SMOOTH",
+"72 128 OFFCURVE",
+"86 147 OFFCURVE",
+"96 147 CURVE SMOOTH",
+"113 147 OFFCURVE",
+"127 130 OFFCURVE",
+"137 97 CURVE",
+"127 93 OFFCURVE",
+"118 91 OFFCURVE",
+"105 91 CURVE SMOOTH"
 );
 }
 );
@@ -101514,49 +101517,49 @@ paths = (
 {
 closed = 1;
 nodes = (
-"128 -12 OFFCURVE",
-"166 39 OFFCURVE",
-"166 95 CURVE SMOOTH",
-"166 146 OFFCURVE",
-"138 193 OFFCURVE",
-"102 193 CURVE SMOOTH",
-"73 193 OFFCURVE",
-"47 157 OFFCURVE",
-"47 113 CURVE SMOOTH",
-"47 83 OFFCURVE",
-"64 64 OFFCURVE",
+"136 -12 OFFCURVE",
+"181 41 OFFCURVE",
+"181 105 CURVE SMOOTH",
+"181 164 OFFCURVE",
+"147 213 OFFCURVE",
+"102 213 CURVE SMOOTH",
+"63 213 OFFCURVE",
+"32 173 OFFCURVE",
+"32 123 CURVE SMOOTH",
+"32 87 OFFCURVE",
+"57 64 OFFCURVE",
 "96 64 CURVE SMOOTH",
-"115 64 OFFCURVE",
-"139 75 OFFCURVE",
-"151 86 CURVE",
-"151 83 LINE",
-"137 39 OFFCURVE",
-"110 17 OFFCURVE",
-"72 17 CURVE SMOOTH",
-"56 17 OFFCURVE",
-"41 20 OFFCURVE",
-"27 25 CURVE",
-"21 12 LINE",
-"35 -1 OFFCURVE",
-"65 -12 OFFCURVE",
+"117 64 OFFCURVE",
+"147 75 OFFCURVE",
+"136 66 CURVE",
+"136 94 LINE",
+"123 55 OFFCURVE",
+"102 37 OFFCURVE",
+"72 37 CURVE SMOOTH",
+"54 37 OFFCURVE",
+"39 41 OFFCURVE",
+"18 50 CURVE",
+"5 22 LINE",
+"12 6 OFFCURVE",
+"57 -12 OFFCURVE",
 "81 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"78 95 OFFCURVE",
-"62 105 OFFCURVE",
-"62 124 CURVE SMOOTH",
-"62 139 OFFCURVE",
-"79 161 OFFCURVE",
+"85 115 OFFCURVE",
+"77 121 OFFCURVE",
+"77 134 CURVE SMOOTH",
+"77 145 OFFCURVE",
+"89 161 OFFCURVE",
 "96 161 CURVE SMOOTH",
-"119 161 OFFCURVE",
-"137 142 OFFCURVE",
-"148 104 CURVE",
-"135 98 OFFCURVE",
-"121 95 OFFCURVE",
-"105 95 CURVE SMOOTH"
+"109 161 OFFCURVE",
+"122 147 OFFCURVE",
+"131 119 CURVE",
+"123 116 OFFCURVE",
+"115 115 OFFCURVE",
+"105 115 CURVE SMOOTH"
 );
 }
 );
@@ -126373,6 +126376,10 @@ name = _top;
 position = "{75, 422}";
 },
 {
+name = top;
+position = "{10, 646}";
+},
+{
 name = top3;
 position = "{5, 647}";
 }
@@ -126417,7 +126424,7 @@ nodes = (
 "118 560 OFFCURVE",
 "92 572 CURVE",
 "93 576 LINE SMOOTH",
-"99 597 OFFCURVE",
+"98 597 OFFCURVE",
 "104 611 OFFCURVE",
 "108 620 CURVE",
 "106 622 OFFCURVE",
@@ -126473,6 +126480,10 @@ name = _top;
 position = "{75, 431}";
 },
 {
+name = top;
+position = "{6, 652}";
+},
+{
 name = top3;
 position = "{5, 656}";
 }
@@ -126517,7 +126528,7 @@ nodes = (
 "118 569 OFFCURVE",
 "92 581 CURVE",
 "93 584 LINE SMOOTH",
-"99 605 OFFCURVE",
+"100 605 OFFCURVE",
 "104 620 OFFCURVE",
 "108 628 CURVE",
 "106 630 OFFCURVE",
@@ -140101,6 +140112,51 @@ layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
 width = 3556;
 }
 );
+},
+{
+glyphname = "dotamiddle-ar";
+layers = (
+{
+anchors = (
+{
+name = _center;
+position = "{185, 81}";
+},
+{
+name = top;
+position = "{140, 207}";
+}
+);
+components = (
+{
+name = uniFBB2;
+transform = "{1, 0, 0, 1, -60, -297}";
+}
+);
+layerId = master01;
+width = 386;
+},
+{
+anchors = (
+{
+name = _center;
+position = "{171, 81}";
+},
+{
+name = top;
+position = "{123, 217}";
+}
+);
+components = (
+{
+name = uniFBB2;
+transform = "{1, 0, 0, 1, -77, -331}";
+}
+);
+layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
+width = 377;
+}
+);
 }
 );
 instances = (
@@ -140215,5 +140271,5 @@ userData = {
 UFOFormat = 2;
 };
 versionMajor = 2;
-versionMinor = 8;
+versionMinor = 9;
 }

--- a/src/NotoNaskhArabic/NotoNaskhArabic.glyphs
+++ b/src/NotoNaskhArabic/NotoNaskhArabic.glyphs
@@ -1,5 +1,11 @@
 {
 .appVersion = "1350";
+DisplayStrings = (
+"/uni0650",
+"/uni06DC",
+"/uni0652",
+"/uni0635"
+);
 classes = (
 {
 code = "uni0660 uni0661 uni0662 uni0663 uni0664 uni0665 uni0666 uni0667 uni0668 uni0669 uni06F0 uni06F1 uni06F2 uni06F3 uni06F4 uni06F5 uni06F6 uni06F7 uni06F8 uni06F9 uni06F4.locl uni06F7.locl";
@@ -1029,10 +1035,10 @@ value = 1;
 },
 {
 name = versionString;
-value = "Version 2.008";
+value = "Version 2.009";
 }
 );
-date = "2021-02-09 20:48:48 +0000";
+date = "2021-03-17 04:17:39 +0000";
 designer = "Monotype Design Team, David Williams, Mohamad Dakak";
 designerURL = "http://www.monotype.com/studio";
 disablesNiceNames = 1;
@@ -2374,7 +2380,7 @@ width = 256;
 anchors = (
 {
 name = bottom;
-position = "{156, -231}";
+position = "{149, -235}";
 },
 {
 name = bottom.dot;
@@ -2390,8 +2396,9 @@ components = (
 name = uni0627;
 },
 {
+alignment = -1;
 name = uni0655;
-transform = "{1, 0, 0, 1, 69, -153}";
+transform = "{1, 0, 0, 1, 62, -107}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -18324,8 +18331,7 @@ name = uniFBB3;
 transform = "{1, 0, 0, 1, -66, -194}";
 },
 {
-name = uniFBB2;
-transform = "{1, 0, 0, 1, 2, 77}";
+name = "dotamiddle-ar";
 }
 );
 layerId = master01;
@@ -18363,8 +18369,7 @@ name = uniFBB3;
 transform = "{1, 0, 0, 1, -80, -178}";
 },
 {
-name = uniFBB2;
-transform = "{1, 0, 0, 1, 0, 87}";
+name = "dotamiddle-ar";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -18408,8 +18413,7 @@ name = uniFBB3;
 transform = "{1, 0, 0, 1, -66, -194}";
 },
 {
-name = uniFBB2;
-transform = "{1, 0, 0, 1, 2, 77}";
+name = "dotamiddle-ar";
 }
 );
 layerId = master01;
@@ -18447,8 +18451,7 @@ name = uniFBB3;
 transform = "{1, 0, 0, 1, -80, -178}";
 },
 {
-name = uniFBB2;
-transform = "{1, 0, 0, 1, 0, 87}";
+name = "dotamiddle-ar";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -61605,7 +61608,7 @@ position = "{99, -100}";
 },
 {
 name = top;
-position = "{99, 452}";
+position = "{99, 352}";
 }
 );
 layerId = master01;
@@ -61642,7 +61645,7 @@ position = "{99, -135}";
 },
 {
 name = top;
-position = "{99, 461}";
+position = "{99, 361}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -62039,7 +62042,7 @@ name = uni0640;
 },
 {
 name = uni0650_uni0651;
-transform = "{1, 0, 0, 1, 30, 88}";
+transform = "{1, 0, 0, 1, 30, -12}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -101450,49 +101453,49 @@ paths = (
 {
 closed = 1;
 nodes = (
-"128 -21 OFFCURVE",
-"166 30 OFFCURVE",
-"166 86 CURVE SMOOTH",
-"166 137 OFFCURVE",
-"138 184 OFFCURVE",
-"102 184 CURVE SMOOTH",
-"73 184 OFFCURVE",
-"47 148 OFFCURVE",
-"47 104 CURVE SMOOTH",
-"47 74 OFFCURVE",
-"64 56 OFFCURVE",
-"96 56 CURVE SMOOTH",
-"115 56 OFFCURVE",
-"139 66 OFFCURVE",
-"151 78 CURVE",
-"151 74 LINE",
-"137 30 OFFCURVE",
-"110 8 OFFCURVE",
-"72 8 CURVE SMOOTH",
-"56 8 OFFCURVE",
-"41 11 OFFCURVE",
-"27 16 CURVE",
-"21 3 LINE",
-"35 -9 OFFCURVE",
-"65 -21 OFFCURVE",
-"81 -21 CURVE SMOOTH"
+"133 -26 OFFCURVE",
+"176 25 OFFCURVE",
+"176 86 CURVE SMOOTH",
+"176 143 OFFCURVE",
+"144 189 OFFCURVE",
+"102 189 CURVE SMOOTH",
+"66 189 OFFCURVE",
+"37 151 OFFCURVE",
+"37 104 CURVE SMOOTH",
+"37 71 OFFCURVE",
+"59 51 OFFCURVE",
+"96 51 CURVE SMOOTH",
+"117 51 OFFCURVE",
+"146 62 OFFCURVE",
+"141 57 CURVE",
+"141 74 LINE",
+"127 33 OFFCURVE",
+"105 13 OFFCURVE",
+"72 13 CURVE SMOOTH",
+"54 13 OFFCURVE",
+"40 17 OFFCURVE",
+"21 24 CURVE",
+"11 3 LINE",
+"22 -10 OFFCURVE",
+"61 -26 OFFCURVE",
+"81 -26 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"78 86 OFFCURVE",
-"62 96 OFFCURVE",
-"62 115 CURVE SMOOTH",
-"62 130 OFFCURVE",
-"79 152 OFFCURVE",
-"96 152 CURVE SMOOTH",
-"119 152 OFFCURVE",
-"137 133 OFFCURVE",
-"148 95 CURVE",
-"135 89 OFFCURVE",
-"121 86 OFFCURVE",
-"105 86 CURVE SMOOTH"
+"82 91 OFFCURVE",
+"72 98 OFFCURVE",
+"72 115 CURVE SMOOTH",
+"72 128 OFFCURVE",
+"86 147 OFFCURVE",
+"96 147 CURVE SMOOTH",
+"113 147 OFFCURVE",
+"127 130 OFFCURVE",
+"137 97 CURVE",
+"127 93 OFFCURVE",
+"118 91 OFFCURVE",
+"105 91 CURVE SMOOTH"
 );
 }
 );
@@ -101514,49 +101517,49 @@ paths = (
 {
 closed = 1;
 nodes = (
-"128 -12 OFFCURVE",
-"166 39 OFFCURVE",
-"166 95 CURVE SMOOTH",
-"166 146 OFFCURVE",
-"138 193 OFFCURVE",
-"102 193 CURVE SMOOTH",
-"73 193 OFFCURVE",
-"47 157 OFFCURVE",
-"47 113 CURVE SMOOTH",
-"47 83 OFFCURVE",
-"64 64 OFFCURVE",
+"136 -12 OFFCURVE",
+"181 41 OFFCURVE",
+"181 105 CURVE SMOOTH",
+"181 164 OFFCURVE",
+"147 213 OFFCURVE",
+"102 213 CURVE SMOOTH",
+"63 213 OFFCURVE",
+"32 173 OFFCURVE",
+"32 123 CURVE SMOOTH",
+"32 87 OFFCURVE",
+"57 64 OFFCURVE",
 "96 64 CURVE SMOOTH",
-"115 64 OFFCURVE",
-"139 75 OFFCURVE",
-"151 86 CURVE",
-"151 83 LINE",
-"137 39 OFFCURVE",
-"110 17 OFFCURVE",
-"72 17 CURVE SMOOTH",
-"56 17 OFFCURVE",
-"41 20 OFFCURVE",
-"27 25 CURVE",
-"21 12 LINE",
-"35 -1 OFFCURVE",
-"65 -12 OFFCURVE",
+"117 64 OFFCURVE",
+"147 75 OFFCURVE",
+"136 66 CURVE",
+"136 94 LINE",
+"123 55 OFFCURVE",
+"102 37 OFFCURVE",
+"72 37 CURVE SMOOTH",
+"54 37 OFFCURVE",
+"39 41 OFFCURVE",
+"18 50 CURVE",
+"5 22 LINE",
+"12 6 OFFCURVE",
+"57 -12 OFFCURVE",
 "81 -12 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"78 95 OFFCURVE",
-"62 105 OFFCURVE",
-"62 124 CURVE SMOOTH",
-"62 139 OFFCURVE",
-"79 161 OFFCURVE",
+"85 115 OFFCURVE",
+"77 121 OFFCURVE",
+"77 134 CURVE SMOOTH",
+"77 145 OFFCURVE",
+"89 161 OFFCURVE",
 "96 161 CURVE SMOOTH",
-"119 161 OFFCURVE",
-"137 142 OFFCURVE",
-"148 104 CURVE",
-"135 98 OFFCURVE",
-"121 95 OFFCURVE",
-"105 95 CURVE SMOOTH"
+"109 161 OFFCURVE",
+"122 147 OFFCURVE",
+"131 119 CURVE",
+"123 116 OFFCURVE",
+"115 115 OFFCURVE",
+"105 115 CURVE SMOOTH"
 );
 }
 );
@@ -126373,6 +126376,10 @@ name = _top;
 position = "{75, 422}";
 },
 {
+name = top;
+position = "{10, 646}";
+},
+{
 name = top3;
 position = "{5, 647}";
 }
@@ -126417,7 +126424,7 @@ nodes = (
 "118 560 OFFCURVE",
 "92 572 CURVE",
 "93 576 LINE SMOOTH",
-"99 597 OFFCURVE",
+"98 597 OFFCURVE",
 "104 611 OFFCURVE",
 "108 620 CURVE",
 "106 622 OFFCURVE",
@@ -126473,6 +126480,10 @@ name = _top;
 position = "{75, 431}";
 },
 {
+name = top;
+position = "{6, 652}";
+},
+{
 name = top3;
 position = "{5, 656}";
 }
@@ -126517,7 +126528,7 @@ nodes = (
 "118 569 OFFCURVE",
 "92 581 CURVE",
 "93 584 LINE SMOOTH",
-"99 605 OFFCURVE",
+"100 605 OFFCURVE",
 "104 620 OFFCURVE",
 "108 628 CURVE",
 "106 630 OFFCURVE",
@@ -140101,6 +140112,51 @@ layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
 width = 3556;
 }
 );
+},
+{
+glyphname = "dotamiddle-ar";
+layers = (
+{
+anchors = (
+{
+name = _center;
+position = "{185, 81}";
+},
+{
+name = top;
+position = "{140, 207}";
+}
+);
+components = (
+{
+name = uniFBB2;
+transform = "{1, 0, 0, 1, -60, -297}";
+}
+);
+layerId = master01;
+width = 386;
+},
+{
+anchors = (
+{
+name = _center;
+position = "{171, 81}";
+},
+{
+name = top;
+position = "{123, 217}";
+}
+);
+components = (
+{
+name = uniFBB2;
+transform = "{1, 0, 0, 1, -77, -331}";
+}
+);
+layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
+width = 377;
+}
+);
 }
 );
 instances = (
@@ -140215,5 +140271,5 @@ userData = {
 UFOFormat = 2;
 };
 versionMajor = 2;
-versionMinor = 8;
+versionMinor = 9;
 }

--- a/src/NotoNaskhArabicUI/NotoNaskhArabicUI-for-edit.glyphs
+++ b/src/NotoNaskhArabicUI/NotoNaskhArabicUI-for-edit.glyphs
@@ -1029,10 +1029,10 @@ value = 1;
 },
 {
 name = versionString;
-value = "Version 2.008";
+value = "Version 2.009";
 }
 );
-date = "2021-02-09 20:49:04 +0000";
+date = "2021-03-17 14:40:49 +0000";
 designer = "Monotype Design Team, David Williams, Mohamad Dakak";
 designerURL = "http://www.monotype.com/studio";
 disablesNiceNames = 1;
@@ -18304,8 +18304,8 @@ name = uniFBB3;
 transform = "{1, 0, 0, 1, -66, -174}";
 },
 {
-name = uniFBB2;
-transform = "{1, 0, 0, 1, 2, 77}";
+name = "dotamiddle-ar";
+transform = "{1, 0, 0, 1, 0, 135}";
 }
 );
 layerId = master01;
@@ -18343,8 +18343,9 @@ name = uniFBB3;
 transform = "{1, 0, 0, 1, -80, -168}";
 },
 {
-name = uniFBB2;
-transform = "{1, 0, 0, 1, 0, 87}";
+alignment = -1;
+name = "dotamiddle-ar";
+transform = "{1, 0, 0, 1, 0, 135}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -18388,8 +18389,8 @@ name = uniFBB3;
 transform = "{1, 0, 0, 1, -66, -174}";
 },
 {
-name = uniFBB2;
-transform = "{1, 0, 0, 1, 2, 77}";
+name = "dotamiddle-ar";
+transform = "{1, 0, 0, 1, 0, 135}";
 }
 );
 layerId = master01;
@@ -18427,8 +18428,8 @@ name = uniFBB3;
 transform = "{1, 0, 0, 1, -80, -168}";
 },
 {
-name = uniFBB2;
-transform = "{1, 0, 0, 1, 0, 87}";
+name = "dotamiddle-ar";
+transform = "{1, 0, 0, 1, 0, 135}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -61489,7 +61490,7 @@ position = "{99, 35}";
 },
 {
 name = top;
-position = "{99, 587}";
+position = "{99, 487}";
 }
 );
 layerId = master01;
@@ -61526,7 +61527,7 @@ position = "{99, 0}";
 },
 {
 name = top;
-position = "{99, 596}";
+position = "{99, 496}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -61923,7 +61924,7 @@ name = uni0640;
 },
 {
 name = uni0650_uni0651;
-transform = "{1, 0, 0, 1, 30, 83}";
+transform = "{1, 0, 0, 1, 30, -17}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -101348,48 +101349,48 @@ paths = (
 {
 closed = 1;
 nodes = (
-"128 114 OFFCURVE",
-"166 165 OFFCURVE",
-"166 221 CURVE SMOOTH",
-"166 272 OFFCURVE",
-"138 319 OFFCURVE",
+"133 104 OFFCURVE",
+"176 155 OFFCURVE",
+"176 216 CURVE SMOOTH",
+"176 273 OFFCURVE",
+"144 319 OFFCURVE",
 "102 319 CURVE SMOOTH",
-"73 319 OFFCURVE",
-"47 283 OFFCURVE",
-"47 239 CURVE SMOOTH",
-"47 209 OFFCURVE",
-"64 191 OFFCURVE",
-"96 191 CURVE SMOOTH",
-"115 191 OFFCURVE",
-"139 201 OFFCURVE",
-"151 213 CURVE",
-"151 209 LINE",
-"137 165 OFFCURVE",
-"110 143 OFFCURVE",
+"66 319 OFFCURVE",
+"37 281 OFFCURVE",
+"37 234 CURVE SMOOTH",
+"37 201 OFFCURVE",
+"59 181 OFFCURVE",
+"96 181 CURVE SMOOTH",
+"117 181 OFFCURVE",
+"146 192 OFFCURVE",
+"141 187 CURVE",
+"141 204 LINE",
+"127 163 OFFCURVE",
+"105 143 OFFCURVE",
 "72 143 CURVE SMOOTH",
-"56 143 OFFCURVE",
-"41 146 OFFCURVE",
-"27 151 CURVE",
-"21 138 LINE",
-"35 126 OFFCURVE",
-"65 114 OFFCURVE",
-"81 114 CURVE SMOOTH"
+"54 143 OFFCURVE",
+"40 147 OFFCURVE",
+"21 154 CURVE",
+"11 133 LINE",
+"22 120 OFFCURVE",
+"61 104 OFFCURVE",
+"81 104 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"78 221 OFFCURVE",
-"62 231 OFFCURVE",
-"62 250 CURVE SMOOTH",
-"62 265 OFFCURVE",
-"79 287 OFFCURVE",
-"96 287 CURVE SMOOTH",
-"119 287 OFFCURVE",
-"137 268 OFFCURVE",
-"148 230 CURVE",
-"135 224 OFFCURVE",
-"121 221 OFFCURVE",
+"82 221 OFFCURVE",
+"72 228 OFFCURVE",
+"72 245 CURVE SMOOTH",
+"72 258 OFFCURVE",
+"86 277 OFFCURVE",
+"96 277 CURVE SMOOTH",
+"113 277 OFFCURVE",
+"127 260 OFFCURVE",
+"137 227 CURVE",
+"127 223 OFFCURVE",
+"118 221 OFFCURVE",
 "105 221 CURVE SMOOTH"
 );
 }
@@ -101412,49 +101413,49 @@ paths = (
 {
 closed = 1;
 nodes = (
-"128 123 OFFCURVE",
-"166 174 OFFCURVE",
-"166 230 CURVE SMOOTH",
-"166 281 OFFCURVE",
-"138 328 OFFCURVE",
-"102 328 CURVE SMOOTH",
-"73 328 OFFCURVE",
-"47 292 OFFCURVE",
-"47 248 CURVE SMOOTH",
-"47 218 OFFCURVE",
-"64 199 OFFCURVE",
-"96 199 CURVE SMOOTH",
-"115 199 OFFCURVE",
-"139 210 OFFCURVE",
-"151 221 CURVE",
-"151 218 LINE",
-"137 174 OFFCURVE",
-"110 152 OFFCURVE",
-"72 152 CURVE SMOOTH",
-"56 152 OFFCURVE",
-"41 155 OFFCURVE",
-"27 160 CURVE",
-"21 147 LINE",
-"35 134 OFFCURVE",
-"65 123 OFFCURVE",
-"81 123 CURVE SMOOTH"
+"136 112 OFFCURVE",
+"181 165 OFFCURVE",
+"181 229 CURVE SMOOTH",
+"181 288 OFFCURVE",
+"147 337 OFFCURVE",
+"102 337 CURVE SMOOTH",
+"63 337 OFFCURVE",
+"32 297 OFFCURVE",
+"32 247 CURVE SMOOTH",
+"32 211 OFFCURVE",
+"57 188 OFFCURVE",
+"96 188 CURVE SMOOTH",
+"117 188 OFFCURVE",
+"147 199 OFFCURVE",
+"136 190 CURVE",
+"136 218 LINE",
+"123 179 OFFCURVE",
+"102 161 OFFCURVE",
+"72 161 CURVE SMOOTH",
+"54 161 OFFCURVE",
+"39 165 OFFCURVE",
+"18 174 CURVE",
+"5 146 LINE",
+"12 130 OFFCURVE",
+"57 112 OFFCURVE",
+"81 112 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"78 230 OFFCURVE",
-"62 240 OFFCURVE",
-"62 259 CURVE SMOOTH",
-"62 274 OFFCURVE",
-"79 296 OFFCURVE",
-"96 296 CURVE SMOOTH",
-"119 296 OFFCURVE",
-"137 277 OFFCURVE",
-"148 239 CURVE",
-"135 233 OFFCURVE",
-"121 230 OFFCURVE",
-"105 230 CURVE SMOOTH"
+"85 239 OFFCURVE",
+"77 245 OFFCURVE",
+"77 258 CURVE SMOOTH",
+"77 269 OFFCURVE",
+"89 285 OFFCURVE",
+"96 285 CURVE SMOOTH",
+"109 285 OFFCURVE",
+"122 271 OFFCURVE",
+"131 243 CURVE",
+"123 240 OFFCURVE",
+"115 239 OFFCURVE",
+"105 239 CURVE SMOOTH"
 );
 }
 );
@@ -127259,6 +127260,10 @@ name = _top;
 position = "{75, 557}";
 },
 {
+name = top;
+position = "{7, 782}";
+},
+{
 name = top3;
 position = "{5, 782}";
 }
@@ -127303,7 +127308,7 @@ nodes = (
 "118 695 OFFCURVE",
 "92 707 CURVE",
 "93 711 LINE SMOOTH",
-"99 732 OFFCURVE",
+"98 732 OFFCURVE",
 "104 746 OFFCURVE",
 "108 755 CURVE",
 "106 757 OFFCURVE",
@@ -127359,6 +127364,10 @@ name = _top;
 position = "{75, 566}";
 },
 {
+name = top;
+position = "{5, 792}";
+},
+{
 name = top3;
 position = "{5, 791}";
 }
@@ -127403,7 +127412,7 @@ nodes = (
 "118 704 OFFCURVE",
 "92 716 CURVE",
 "93 719 LINE SMOOTH",
-"99 740 OFFCURVE",
+"100 740 OFFCURVE",
 "104 755 OFFCURVE",
 "108 763 CURVE",
 "106 765 OFFCURVE",
@@ -141012,6 +141021,51 @@ nodes = (
 width = 631;
 }
 );
+},
+{
+glyphname = "dotamiddle-ar";
+layers = (
+{
+anchors = (
+{
+name = _center;
+position = "{185, 81}";
+},
+{
+name = top;
+position = "{140, 207}";
+}
+);
+components = (
+{
+name = uniFBB2;
+transform = "{1, 0, 0, 1, -60, -450}";
+}
+);
+layerId = master01;
+width = 386;
+},
+{
+anchors = (
+{
+name = _center;
+position = "{171, 81}";
+},
+{
+name = top;
+position = "{123, 217}";
+}
+);
+components = (
+{
+name = uniFBB2;
+transform = "{1, 0, 0, 1, -77, -487}";
+}
+);
+layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
+width = 377;
+}
+);
 }
 );
 instances = (
@@ -141126,5 +141180,5 @@ userData = {
 UFOFormat = 2;
 };
 versionMajor = 2;
-versionMinor = 8;
+versionMinor = 9;
 }

--- a/src/NotoNaskhArabicUI/NotoNaskhArabicUI.glyphs
+++ b/src/NotoNaskhArabicUI/NotoNaskhArabicUI.glyphs
@@ -1029,10 +1029,10 @@ value = 1;
 },
 {
 name = versionString;
-value = "Version 2.008";
+value = "Version 2.009";
 }
 );
-date = "2021-02-09 20:49:18 +0000";
+date = "2021-03-17 04:38:12 +0000";
 designer = "Monotype Design Team, David Williams, Mohamad Dakak";
 designerURL = "http://www.monotype.com/studio";
 disablesNiceNames = 1;
@@ -18304,8 +18304,8 @@ name = uniFBB3;
 transform = "{1, 0, 0, 1, -66, -174}";
 },
 {
-name = uniFBB2;
-transform = "{1, 0, 0, 1, 2, 77}";
+name = "dotamiddle-ar";
+transform = "{1, 0, 0, 1, 0, 135}";
 }
 );
 layerId = master01;
@@ -18343,8 +18343,9 @@ name = uniFBB3;
 transform = "{1, 0, 0, 1, -80, -168}";
 },
 {
-name = uniFBB2;
-transform = "{1, 0, 0, 1, 0, 87}";
+alignment = -1;
+name = "dotamiddle-ar";
+transform = "{1, 0, 0, 1, 0, 135}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -18388,8 +18389,8 @@ name = uniFBB3;
 transform = "{1, 0, 0, 1, -66, -174}";
 },
 {
-name = uniFBB2;
-transform = "{1, 0, 0, 1, 2, 77}";
+name = "dotamiddle-ar";
+transform = "{1, 0, 0, 1, 0, 135}";
 }
 );
 layerId = master01;
@@ -18427,8 +18428,8 @@ name = uniFBB3;
 transform = "{1, 0, 0, 1, -80, -168}";
 },
 {
-name = uniFBB2;
-transform = "{1, 0, 0, 1, 0, 87}";
+name = "dotamiddle-ar";
+transform = "{1, 0, 0, 1, 0, 135}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -61489,7 +61490,7 @@ position = "{99, 35}";
 },
 {
 name = top;
-position = "{99, 587}";
+position = "{99, 487}";
 }
 );
 layerId = master01;
@@ -61526,7 +61527,7 @@ position = "{99, 0}";
 },
 {
 name = top;
-position = "{99, 596}";
+position = "{99, 496}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -61923,7 +61924,7 @@ name = uni0640;
 },
 {
 name = uni0650_uni0651;
-transform = "{1, 0, 0, 1, 30, 83}";
+transform = "{1, 0, 0, 1, 30, -17}";
 }
 );
 layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
@@ -101348,48 +101349,48 @@ paths = (
 {
 closed = 1;
 nodes = (
-"128 114 OFFCURVE",
-"166 165 OFFCURVE",
-"166 221 CURVE SMOOTH",
-"166 272 OFFCURVE",
-"138 319 OFFCURVE",
+"133 104 OFFCURVE",
+"176 155 OFFCURVE",
+"176 216 CURVE SMOOTH",
+"176 273 OFFCURVE",
+"144 319 OFFCURVE",
 "102 319 CURVE SMOOTH",
-"73 319 OFFCURVE",
-"47 283 OFFCURVE",
-"47 239 CURVE SMOOTH",
-"47 209 OFFCURVE",
-"64 191 OFFCURVE",
-"96 191 CURVE SMOOTH",
-"115 191 OFFCURVE",
-"139 201 OFFCURVE",
-"151 213 CURVE",
-"151 209 LINE",
-"137 165 OFFCURVE",
-"110 143 OFFCURVE",
+"66 319 OFFCURVE",
+"37 281 OFFCURVE",
+"37 234 CURVE SMOOTH",
+"37 201 OFFCURVE",
+"59 181 OFFCURVE",
+"96 181 CURVE SMOOTH",
+"117 181 OFFCURVE",
+"146 192 OFFCURVE",
+"141 187 CURVE",
+"141 204 LINE",
+"127 163 OFFCURVE",
+"105 143 OFFCURVE",
 "72 143 CURVE SMOOTH",
-"56 143 OFFCURVE",
-"41 146 OFFCURVE",
-"27 151 CURVE",
-"21 138 LINE",
-"35 126 OFFCURVE",
-"65 114 OFFCURVE",
-"81 114 CURVE SMOOTH"
+"54 143 OFFCURVE",
+"40 147 OFFCURVE",
+"21 154 CURVE",
+"11 133 LINE",
+"22 120 OFFCURVE",
+"61 104 OFFCURVE",
+"81 104 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"78 221 OFFCURVE",
-"62 231 OFFCURVE",
-"62 250 CURVE SMOOTH",
-"62 265 OFFCURVE",
-"79 287 OFFCURVE",
-"96 287 CURVE SMOOTH",
-"119 287 OFFCURVE",
-"137 268 OFFCURVE",
-"148 230 CURVE",
-"135 224 OFFCURVE",
-"121 221 OFFCURVE",
+"82 221 OFFCURVE",
+"72 228 OFFCURVE",
+"72 245 CURVE SMOOTH",
+"72 258 OFFCURVE",
+"86 277 OFFCURVE",
+"96 277 CURVE SMOOTH",
+"113 277 OFFCURVE",
+"127 260 OFFCURVE",
+"137 227 CURVE",
+"127 223 OFFCURVE",
+"118 221 OFFCURVE",
 "105 221 CURVE SMOOTH"
 );
 }
@@ -101412,49 +101413,49 @@ paths = (
 {
 closed = 1;
 nodes = (
-"128 123 OFFCURVE",
-"166 174 OFFCURVE",
-"166 230 CURVE SMOOTH",
-"166 281 OFFCURVE",
-"138 328 OFFCURVE",
-"102 328 CURVE SMOOTH",
-"73 328 OFFCURVE",
-"47 292 OFFCURVE",
-"47 248 CURVE SMOOTH",
-"47 218 OFFCURVE",
-"64 199 OFFCURVE",
-"96 199 CURVE SMOOTH",
-"115 199 OFFCURVE",
-"139 210 OFFCURVE",
-"151 221 CURVE",
-"151 218 LINE",
-"137 174 OFFCURVE",
-"110 152 OFFCURVE",
-"72 152 CURVE SMOOTH",
-"56 152 OFFCURVE",
-"41 155 OFFCURVE",
-"27 160 CURVE",
-"21 147 LINE",
-"35 134 OFFCURVE",
-"65 123 OFFCURVE",
-"81 123 CURVE SMOOTH"
+"136 112 OFFCURVE",
+"181 165 OFFCURVE",
+"181 229 CURVE SMOOTH",
+"181 288 OFFCURVE",
+"147 337 OFFCURVE",
+"102 337 CURVE SMOOTH",
+"63 337 OFFCURVE",
+"32 297 OFFCURVE",
+"32 247 CURVE SMOOTH",
+"32 211 OFFCURVE",
+"57 188 OFFCURVE",
+"96 188 CURVE SMOOTH",
+"117 188 OFFCURVE",
+"147 199 OFFCURVE",
+"136 190 CURVE",
+"136 218 LINE",
+"123 179 OFFCURVE",
+"102 161 OFFCURVE",
+"72 161 CURVE SMOOTH",
+"54 161 OFFCURVE",
+"39 165 OFFCURVE",
+"18 174 CURVE",
+"5 146 LINE",
+"12 130 OFFCURVE",
+"57 112 OFFCURVE",
+"81 112 CURVE SMOOTH"
 );
 },
 {
 closed = 1;
 nodes = (
-"78 230 OFFCURVE",
-"62 240 OFFCURVE",
-"62 259 CURVE SMOOTH",
-"62 274 OFFCURVE",
-"79 296 OFFCURVE",
-"96 296 CURVE SMOOTH",
-"119 296 OFFCURVE",
-"137 277 OFFCURVE",
-"148 239 CURVE",
-"135 233 OFFCURVE",
-"121 230 OFFCURVE",
-"105 230 CURVE SMOOTH"
+"85 239 OFFCURVE",
+"77 245 OFFCURVE",
+"77 258 CURVE SMOOTH",
+"77 269 OFFCURVE",
+"89 285 OFFCURVE",
+"96 285 CURVE SMOOTH",
+"109 285 OFFCURVE",
+"122 271 OFFCURVE",
+"131 243 CURVE",
+"123 240 OFFCURVE",
+"115 239 OFFCURVE",
+"105 239 CURVE SMOOTH"
 );
 }
 );
@@ -127259,6 +127260,10 @@ name = _top;
 position = "{75, 557}";
 },
 {
+name = top;
+position = "{7, 782}";
+},
+{
 name = top3;
 position = "{5, 782}";
 }
@@ -127303,7 +127308,7 @@ nodes = (
 "118 695 OFFCURVE",
 "92 707 CURVE",
 "93 711 LINE SMOOTH",
-"99 732 OFFCURVE",
+"98 732 OFFCURVE",
 "104 746 OFFCURVE",
 "108 755 CURVE",
 "106 757 OFFCURVE",
@@ -127359,6 +127364,10 @@ name = _top;
 position = "{75, 566}";
 },
 {
+name = top;
+position = "{5, 792}";
+},
+{
 name = top3;
 position = "{5, 791}";
 }
@@ -127403,7 +127412,7 @@ nodes = (
 "118 704 OFFCURVE",
 "92 716 CURVE",
 "93 719 LINE SMOOTH",
-"99 740 OFFCURVE",
+"100 740 OFFCURVE",
 "104 755 OFFCURVE",
 "108 763 CURVE",
 "106 765 OFFCURVE",
@@ -141012,6 +141021,51 @@ nodes = (
 width = 631;
 }
 );
+},
+{
+glyphname = "dotamiddle-ar";
+layers = (
+{
+anchors = (
+{
+name = _center;
+position = "{185, 81}";
+},
+{
+name = top;
+position = "{140, 207}";
+}
+);
+components = (
+{
+name = uniFBB2;
+transform = "{1, 0, 0, 1, -60, -450}";
+}
+);
+layerId = master01;
+width = 386;
+},
+{
+anchors = (
+{
+name = _center;
+position = "{171, 81}";
+},
+{
+name = top;
+position = "{123, 217}";
+}
+);
+components = (
+{
+name = uniFBB2;
+transform = "{1, 0, 0, 1, -77, -487}";
+}
+);
+layerId = "26E2967D-790C-4793-AF2A-2D0AD74EDC69";
+width = 377;
+}
+);
 }
 );
 instances = (
@@ -141126,5 +141180,5 @@ userData = {
 UFOFormat = 2;
 };
 versionMajor = 2;
-versionMinor = 8;
+versionMinor = 9;
 }


### PR DESCRIPTION
NotoNaskhArabic 2.009 changes:
1- U+0670 aligned high cause overlap with other diacritics 
Fix https://github.com/googlefonts/noto-fonts/issues/2032 

2- U+06E5 too thin in regular and bold
Fix https://github.com/googlefonts/noto-fonts/issues/2016 

3- U+0625 Below diacritics overlap with the Hamza (Bold weight) 
Fix https://github.com/googlefonts/noto-fonts/issues/2033 

4- U+0696 wrong dot placement
Fix https://github.com/googlefonts/noto-fonts/issues/2022 

5- U+06DC missing the top anchor, above diacritics not aligning correctly (overlap)
Fix https://github.com/googlefonts/noto-fonts/issues/2034 