### PR TITLE
Resolve several rendering problems in source of NotoSansOldHungUI

### DIFF
--- a/src/NotoSansOldHungUI/NotoSansOldHungUI-Regular.ufo/glyphs/u10C_89.glif
+++ b/src/NotoSansOldHungUI/NotoSansOldHungUI-Regular.ufo/glyphs/u10C_89.glif
@@ -1,49 +1,48 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="u10C89" format="2">
   <advance width="1121"/>
   <unicode hex="10C89"/>
   <outline>
     <contour>
-      <point x="273" y="1" type="qcurve"/>
-      <point x="273" y="1"/>
-      <point x="172" y="117" type="qcurve"/>
-      <point x="258" y="161"/>
-      <point x="328" y="202" type="qcurve" smooth="yes"/>
-      <point x="408" y="249"/>
-      <point x="455" y="280" type="qcurve"/>
-      <point x="196" y="465" type="line"/>
-      <point x="305" y="560" type="line"/>
-      <point x="572" y="371" type="line"/>
-      <point x="666" y="454"/>
-      <point x="746" y="628"/>
-      <point x="746" y="731" type="qcurve" smooth="yes"/>
-      <point x="746" y="834"/>
-      <point x="664" y="1007"/>
-      <point x="564" y="1093" type="qcurve"/>
-      <point x="305" y="908" type="line"/>
-      <point x="196" y="1007" type="line"/>
-      <point x="447" y="1183" type="line"/>
-      <point x="389" y="1222"/>
-      <point x="248" y="1306"/>
-      <point x="162" y="1352" type="qcurve"/>
-      <point x="283" y="1462" type="line"/>
-      <point x="373" y="1414"/>
-      <point x="522" y="1324"/>
-      <point x="584" y="1280" type="qcurve"/>
-      <point x="833" y="1457" type="line"/>
-      <point x="931" y="1354" type="line"/>
-      <point x="702" y="1190" type="line"/>
-      <point x="828" y="1081"/>
-      <point x="933" y="862"/>
-      <point x="933" y="731" type="qcurve" smooth="yes"/>
-      <point x="933" y="600"/>
-      <point x="829" y="383"/>
-      <point x="706" y="276" type="qcurve"/>
-      <point x="931" y="117" type="line"/>
+      <point x="273" y="1" type="line"/>
+      <point x="367" y="51" type="curve" smooth="yes"/>
+      <point x="524" y="143" type="offcurve"/>
+      <point x="588" y="187" type="offcurve"/>
       <point x="833" y="14" type="line"/>
-      <point x="588" y="187" type="line"/>
-      <point x="524" y="143"/>
-      <point x="367" y="51"/>
+      <point x="931" y="117" type="line"/>
+      <point x="706" y="276" type="line"/>
+      <point x="829" y="383" type="curve" smooth="yes"/>
+      <point x="933" y="600" type="offcurve"/>
+      <point x="933" y="731" type="curve" smooth="yes"/>
+      <point x="933" y="862" type="offcurve"/>
+      <point x="828" y="1081" type="offcurve"/>
+      <point x="702" y="1190" type="offcurve"/>
+      <point x="931" y="1354" type="line"/>
+      <point x="833" y="1457" type="line"/>
+      <point x="584" y="1280" type="line"/>
+      <point x="522" y="1324" type="curve" smooth="yes"/>
+      <point x="373" y="1414" type="offcurve"/>
+      <point x="283" y="1462" type="offcurve"/>
+      <point x="162" y="1352" type="line"/>
+      <point x="248" y="1306" type="curve" smooth="yes"/>
+      <point x="389" y="1222" type="offcurve"/>
+      <point x="447" y="1183" type="offcurve"/>
+      <point x="196" y="1007" type="line"/>
+      <point x="305" y="908" type="line"/>
+      <point x="564" y="1093" type="line"/>
+      <point x="664" y="1007" type="curve" smooth="yes"/>
+      <point x="746" y="834" type="offcurve"/>
+      <point x="746" y="731" type="curve" smooth="yes"/>
+      <point x="746" y="628" type="offcurve"/>
+      <point x="666" y="454" type="offcurve"/>
+      <point x="572" y="371" type="offcurve"/>
+      <point x="305" y="560" type="line"/>
+      <point x="196" y="465" type="line"/>
+      <point x="455" y="280" type="line"/>
+      <point x="408" y="249" type="curve" smooth="yes"/>
+      <point x="328" y="202" type="curve" smooth="yes"/>
+      <point x="258" y="161" type="offcurve"/>
+      <point x="172" y="117" type="offcurve"/>
     </contour>
   </outline>
 </glyph>

--- a/src/NotoSansOldHungUI/NotoSansOldHungUI-Regular.ufo/glyphs/u10C_8A_.glif
+++ b/src/NotoSansOldHungUI/NotoSansOldHungUI-Regular.ufo/glyphs/u10C_8A_.glif
@@ -1,62 +1,61 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="u10C8A" format="2">
   <advance width="1167"/>
   <unicode hex="10C8A"/>
   <outline>
     <contour>
-      <point x="299" y="2" type="qcurve"/>
-      <point x="299" y="2"/>
-      <point x="196" y="119" type="qcurve"/>
-      <point x="272" y="159"/>
-      <point x="399" y="230"/>
-      <point x="453" y="264" type="qcurve"/>
-      <point x="319" y="375"/>
-      <point x="204" y="599"/>
-      <point x="204" y="731" type="qcurve" smooth="yes"/>
-      <point x="204" y="863"/>
-      <point x="317" y="1088"/>
-      <point x="451" y="1197" type="qcurve"/>
-      <point x="395" y="1235"/>
-      <point x="263" y="1311"/>
-      <point x="186" y="1353" type="qcurve"/>
-      <point x="307" y="1463" type="line"/>
-      <point x="471" y="1376"/>
-      <point x="584" y="1299" type="qcurve"/>
-      <point x="698" y="1375"/>
-      <point x="861" y="1463" type="qcurve"/>
-      <point x="983" y="1356" type="line"/>
-      <point x="939" y="1334"/>
-      <point x="839" y="1274" type="qcurve" smooth="yes"/>
-      <point x="773" y="1235"/>
-      <point x="720" y="1199" type="qcurve"/>
-      <point x="852" y="1088"/>
-      <point x="965" y="865"/>
-      <point x="965" y="598"/>
-      <point x="851" y="375"/>
-      <point x="716" y="264" type="qcurve"/>
-      <point x="770" y="229"/>
-      <point x="899" y="157"/>
-      <point x="973" y="119" type="qcurve"/>
-      <point x="869" y="2" type="line"/>
-      <point x="787" y="46"/>
-      <point x="644" y="128"/>
-      <point x="584" y="168" type="qcurve"/>
-      <point x="524" y="128"/>
-      <point x="381" y="46"/>
+      <point x="299" y="2" type="curve"/>
+      <point x="381" y="46" type="offcurve"/>
+      <point x="524" y="128" type="offcurve"/>
+      <point x="584" y="168" type="curve"/>
+      <point x="644" y="128" type="offcurve"/>
+      <point x="787" y="46" type="offcurve"/>
+      <point x="869" y="2" type="curve"/>
+      <point x="973" y="119" type="line"/>
+      <point x="899" y="157" type="curve" smooth="yes"/>
+      <point x="770" y="229" type="offcurve"/>
+      <point x="716" y="264" type="curve"/>
+      <point x="851" y="375" type="offcurve"/>
+      <point x="965" y="598" type="offcurve"/>
+      <point x="965" y="865" type="curve"/>
+      <point x="852" y="1088" type="offcurve"/>
+      <point x="720" y="1199" type="curve"/>
+      <point x="773" y="1235" type="offcurve"/>
+      <point x="839" y="1274" type="curve" smooth="yes"/>
+      <point x="939" y="1334" type="offcurve"/>
+      <point x="983" y="1356" type="curve"/>
+      <point x="861" y="1463" type="line"/>
+      <point x="698" y="1375" type="curve" smooth="yes"/>
+      <point x="584" y="1299" type="offcurve"/>
+      <point x="471" y="1376" type="offcurve"/>
+      <point x="307" y="1463" type="curve"/>
+      <point x="186" y="1353" type="line"/>
+      <point x="263" y="1311" type="curve" smooth="yes"/>
+      <point x="395" y="1235" type="offcurve"/>
+      <point x="451" y="1197" type="curve"/>
+      <point x="317" y="1088" type="offcurve"/>
+      <point x="204" y="863" type="offcurve"/>
+      <point x="204" y="731" type="curve" smooth="yes"/>
+      <point x="204" y="599" type="offcurve"/>
+      <point x="319" y="375" type="offcurve"/>
+      <point x="453" y="264" type="curve"/>
+      <point x="399" y="230" type="offcurve"/>
+      <point x="272" y="159" type="offcurve"/>
+      <point x="196" y="119" type="curve"/>
     </contour>
     <contour>
-      <point x="584" y="360" type="qcurve"/>
-      <point x="688" y="447"/>
-      <point x="777" y="627"/>
-      <point x="777" y="731" type="qcurve" smooth="yes"/>
-      <point x="777" y="835"/>
-      <point x="690" y="1012"/>
-      <point x="584" y="1099" type="qcurve"/>
-      <point x="478" y="1010"/>
-      <point x="391" y="836"/>
-      <point x="391" y="731" type="qcurve" smooth="yes"/>
-      <point x="391" y="626"/>
-      <point x="480" y="447"/>
+      <point x="584" y="360" type="curve"/>
+      <point x="480" y="447" type="offcurve"/>
+      <point x="391" y="626" type="offcurve"/>
+      <point x="391" y="731" type="curve" smooth="yes"/>
+      <point x="391" y="836" type="offcurve"/>
+      <point x="478" y="1010" type="offcurve"/>
+      <point x="584" y="1099" type="curve"/>
+      <point x="690" y="1012" type="offcurve"/>
+      <point x="777" y="835" type="offcurve"/>
+      <point x="777" y="731" type="curve" smooth="yes"/>
+      <point x="777" y="627" type="offcurve"/>
+      <point x="688" y="447" type="offcurve"/>
     </contour>
   </outline>
 </glyph>

--- a/src/NotoSansOldHungUI/NotoSansOldHungUI-Regular.ufo/glyphs/u10C_8B_.glif
+++ b/src/NotoSansOldHungUI/NotoSansOldHungUI-Regular.ufo/glyphs/u10C_8B_.glif
@@ -4,27 +4,27 @@
   <unicode hex="10C8B"/>
   <outline>
     <contour>
-      <point x="461" y="167" type="qcurve"/>
+      <point x="461" y="167" type="offcurve"/>
       <point x="674" y="1" type="line"/>
       <point x="558" y="-127" type="line"/>
       <point x="176" y="183" type="line"/>
-      <point x="348" y="277"/>
-      <point x="564" y="449"/>
-      <point x="670" y="625"/>
-      <point x="670" y="730" type="qcurve" smooth="yes"/>
-      <point x="670" y="837"/>
-      <point x="566" y="1014"/>
-      <point x="347" y="1186"/>
-      <point x="176" y="1282" type="qcurve"/>
-      <point x="176" y="1282"/>
-      <point x="558" y="1590" type="qcurve"/>
+      <point x="348" y="277" type="curve" smooth="yes"/>
+      <point x="564" y="449" type="offcurve"/>
+      <point x="670" y="625" type="offcurve"/>
+      <point x="670" y="730" type="curve" smooth="yes"/>
+      <point x="670" y="837" type="offcurve"/>
+      <point x="566" y="1014" type="offcurve"/>
+      <point x="347" y="1186" type="offcurve"/>
+      <point x="176" y="1282" type="offcurve"/>
+      <point x="176" y="1282" type="offcurve"/>
+      <point x="558" y="1590" type="offcurve"/>
       <point x="674" y="1465" type="line"/>
       <point x="461" y="1297" type="line"/>
-      <point x="673" y="1161"/>
-      <point x="857" y="897"/>
-      <point x="857" y="730" type="qcurve" smooth="yes"/>
-      <point x="857" y="568"/>
-      <point x="672" y="303"/>
+      <point x="673" y="1161" type="curve" smooth="yes"/>
+      <point x="857" y="897" type="offcurve"/>
+      <point x="857" y="730" type="curve" smooth="yes"/>
+      <point x="857" y="568" type="offcurve"/>
+      <point x="672" y="303" type="offcurve"/>
     </contour>
   </outline>
 </glyph>

--- a/src/NotoSansOldHungUI/NotoSansOldHungUI-Regular.ufo/glyphs/u10C_8C_.glif
+++ b/src/NotoSansOldHungUI/NotoSansOldHungUI-Regular.ufo/glyphs/u10C_8C_.glif
@@ -1,66 +1,66 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <glyph name="u10C8C" format="2">
   <advance width="1533"/>
   <unicode hex="10C8C"/>
   <outline>
     <contour>
-      <point x="859" y="6" type="qcurve"/>
-      <point x="859" y="6"/>
-      <point x="674" y="6" type="qcurve"/>
-      <point x="514" y="113"/>
-      <point x="285" y="331"/>
-      <point x="162" y="581"/>
-      <point x="162" y="736" type="qcurve" smooth="yes"/>
-      <point x="162" y="891"/>
-      <point x="285" y="1142"/>
-      <point x="514" y="1361"/>
-      <point x="672" y="1467" type="qcurve"/>
-      <point x="859" y="1467" type="line"/>
-      <point x="1019" y="1361"/>
-      <point x="1247" y="1142"/>
-      <point x="1370" y="891"/>
-      <point x="1370" y="736" type="qcurve" smooth="yes"/>
-      <point x="1370" y="580"/>
-      <point x="1247" y="331"/>
-      <point x="1019" y="113"/>
+      <point x="859" y="1" type="curve"/>
+      <point x="674" y="1" type="offcurve"/>
+      <point x="514" y="108" type="offcurve"/>
+      <point x="285" y="326" type="curve"/>
+      <point x="162" y="576" type="offcurve"/>
+      <point x="162" y="731" type="curve" smooth="yes"/>
+      <point x="162" y="886" type="offcurve"/>
+      <point x="285" y="1137" type="curve"/>
+      <point x="514" y="1356" type="offcurve"/>
+      <point x="672" y="1462" type="curve"/>
+      <point x="859" y="1462" type="line"/>
+      <point x="1019" y="1356" type="curve" smooth="yes"/>
+      <point x="1247" y="1137" type="offcurve"/>
+      <point x="1370" y="886" type="offcurve"/>
+      <point x="1370" y="731" type="curve" smooth="yes"/>
+      <point x="1370" y="575" type="offcurve"/>
+      <point x="1247" y="326" type="curve"/>
+      <point x="1019" y="108" type="offcurve"/>
     </contour>
     <contour>
-      <point x="493" y="1111" type="qcurve"/>
-      <point x="769" y="826" type="line"/>
-      <point x="1041" y="1109" type="line"/>
-      <point x="991" y="1167"/>
-      <point x="867" y="1281"/>
-      <point x="779" y="1345" type="qcurve"/>
-      <point x="752" y="1346" type="line"/>
-      <point x="610" y="1244"/>
+      <point x="493" y="1106" type="curve"/>
+      <point x="493" y="1106" type="offcurve"/>
+      <point x="769" y="821" type="curve"/>
+      <point x="1041" y="1104" type="line"/>
+      <point x="991" y="1162" type="curve" smooth="yes"/>
+      <point x="867" y="1276" type="offcurve"/>
+      <point x="779" y="1340" type="curve"/>
+      <point x="752" y="1341" type="line"/>
+      <point x="610" y="1239" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="419" y="464" type="qcurve"/>
-      <point x="676" y="732" type="line"/>
-      <point x="417" y="1006" type="line"/>
-      <point x="347" y="886"/>
-      <point x="347" y="736" type="qcurve" smooth="yes"/>
-      <point x="347" y="657"/>
-      <point x="383" y="526"/>
+      <point x="419" y="459" type="curve"/>
+      <point x="676" y="727" type="line"/>
+      <point x="417" y="1001" type="line"/>
+      <point x="347" y="881" type="curve" smooth="yes"/>
+      <point x="347" y="731" type="curve" smooth="yes"/>
+      <point x="347" y="652" type="offcurve"/>
+      <point x="383" y="521" type="offcurve"/>
     </contour>
     <contour>
-      <point x="1117" y="1000" type="qcurve"/>
-      <point x="861" y="732" type="line"/>
-      <point x="1117" y="469" type="line"/>
-      <point x="1185" y="587"/>
-      <point x="1185" y="884"/>
+      <point x="1117" y="995" type="curve"/>
+      <point x="861" y="727" type="line"/>
+      <point x="1117" y="464" type="line"/>
+      <point x="1185" y="582" type="curve" smooth="yes"/>
+      <point x="1185" y="879" type="offcurve"/>
     </contour>
     <contour>
-      <point x="757" y="132" type="qcurve"/>
-      <point x="769" y="133" type="line"/>
-      <point x="874" y="208"/>
-      <point x="919" y="246" type="qcurve" smooth="yes"/>
-      <point x="985" y="302"/>
-      <point x="1035" y="360" type="qcurve"/>
-      <point x="769" y="637" type="line"/>
-      <point x="501" y="355" type="line"/>
-      <point x="551" y="300"/>
-      <point x="675" y="192"/>
+      <point x="750" y="127" type="curve"/>
+      <point x="776" y="128" type="line"/>
+      <point x="836" y="171" type="curve" smooth="yes"/>
+      <point x="919" y="241" type="curve" smooth="yes"/>
+      <point x="985" y="297" type="offcurve"/>
+      <point x="1035" y="355" type="curve"/>
+      <point x="769" y="632" type="line"/>
+      <point x="501" y="350" type="line"/>
+      <point x="551" y="295" type="curve" smooth="yes"/>
+      <point x="668" y="187" type="offcurve"/>
     </contour>
   </outline>
 </glyph>

--- a/src/NotoSansOldHungUI/NotoSansOldHungUI-Regular.ufo/glyphs/u10C_97.glif
+++ b/src/NotoSansOldHungUI/NotoSansOldHungUI-Regular.ufo/glyphs/u10C_97.glif
@@ -4,51 +4,51 @@
   <unicode hex="10C97"/>
   <outline>
     <contour>
-      <point x="859" y="5" type="qcurve"/>
-      <point x="859" y="5"/>
-      <point x="674" y="5" type="qcurve"/>
-      <point x="518" y="112"/>
-      <point x="293" y="330"/>
-      <point x="170" y="580"/>
-      <point x="170" y="737" type="qcurve" smooth="yes"/>
-      <point x="170" y="890"/>
-      <point x="291" y="1141"/>
-      <point x="518" y="1360"/>
-      <point x="672" y="1466" type="qcurve"/>
+      <point x="859" y="5" type="offcurve"/>
+      <point x="859" y="5" type="curve"/>
+      <point x="674" y="5" type="offcurve"/>
+      <point x="518" y="112" type="curve"/>
+      <point x="293" y="330" type="offcurve"/>
+      <point x="170" y="580" type="offcurve"/>
+      <point x="170" y="737" type="curve" smooth="yes"/>
+      <point x="170" y="890" type="offcurve"/>
+      <point x="291" y="1141" type="curve"/>
+      <point x="518" y="1360" type="offcurve"/>
+      <point x="672" y="1466" type="curve"/>
       <point x="859" y="1466" type="line"/>
-      <point x="1015" y="1360"/>
-      <point x="1241" y="1141"/>
-      <point x="1362" y="890"/>
-      <point x="1362" y="737" type="qcurve" smooth="yes"/>
-      <point x="1362" y="579"/>
-      <point x="1241" y="330"/>
-      <point x="1015" y="112"/>
+      <point x="1015" y="1360" type="curve" smooth="yes"/>
+      <point x="1241" y="1141" type="offcurve"/>
+      <point x="1362" y="890" type="offcurve"/>
+      <point x="1362" y="737" type="curve" smooth="yes"/>
+      <point x="1362" y="579" type="offcurve"/>
+      <point x="1241" y="330" type="curve"/>
+      <point x="1015" y="112" type="offcurve"/>
     </contour>
     <contour>
-      <point x="415" y="483" type="qcurve"/>
+      <point x="415" y="483" type="curve"/>
       <point x="1035" y="1110" type="line"/>
-      <point x="985" y="1166"/>
-      <point x="853" y="1280"/>
-      <point x="769" y="1344" type="qcurve"/>
+      <point x="985" y="1166" type="curve" smooth="yes"/>
+      <point x="853" y="1280" type="offcurve"/>
+      <point x="769" y="1344" type="curve"/>
       <point x="762" y="1344" type="line"/>
-      <point x="626" y="1240"/>
-      <point x="445" y="1056"/>
-      <point x="355" y="859"/>
-      <point x="355" y="737" type="qcurve" smooth="yes"/>
-      <point x="355" y="596"/>
+      <point x="626" y="1240" type="curve" smooth="yes"/>
+      <point x="445" y="1056" type="offcurve"/>
+      <point x="355" y="859" type="offcurve"/>
+      <point x="355" y="737" type="curve" smooth="yes"/>
+      <point x="355" y="596" type="offcurve"/>
     </contour>
     <contour>
-      <point x="759" y="128" type="qcurve"/>
+      <point x="759" y="128" type="curve"/>
       <point x="769" y="129" type="line"/>
-      <point x="907" y="233"/>
-      <point x="1087" y="415"/>
-      <point x="1184" y="557"/>
-      <point x="1184" y="726" type="qcurve" smooth="yes"/>
-      <point x="1184" y="880"/>
-      <point x="1113" y="1005" type="qcurve"/>
+      <point x="907" y="233" type="curve" smooth="yes"/>
+      <point x="1087" y="415" type="offcurve"/>
+      <point x="1184" y="557" type="offcurve"/>
+      <point x="1184" y="726" type="curve" smooth="yes"/>
+      <point x="1184" y="880" type="offcurve"/>
+      <point x="1113" y="1005" type="curve"/>
       <point x="499" y="363" type="line"/>
-      <point x="549" y="305"/>
-      <point x="677" y="192"/>
+      <point x="549" y="305" type="curve" smooth="yes"/>
+      <point x="677" y="192" type="offcurve"/>
     </contour>
   </outline>
 </glyph>


### PR DESCRIPTION
 On branch ohuUIrendering1
 Changes to be committed:
	modified:   src/NotoSansOldHungUI/NotoSansOldHungUI-Regular.ufo/glyphs/u10C_89.glif
	modified:   src/NotoSansOldHungUI/NotoSansOldHungUI-Regular.ufo/glyphs/u10C_8A_.glif
	modified:   src/NotoSansOldHungUI/NotoSansOldHungUI-Regular.ufo/glyphs/u10C_8B_.glif
	modified:   src/NotoSansOldHungUI/NotoSansOldHungUI-Regular.ufo/glyphs/u10C_8C_.glif
	modified:   src/NotoSansOldHungUI/NotoSansOldHungUI-Regular.ufo/glyphs/u10C_97.glif