### PR TITLE
Unicode 14 Ethiopic Extended-B Additions (Regular for Sans and Serif)

### DIFF
--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/bweeG_urage.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/bweeG_urage.eth.glif
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="bweeGurage.eth" format="2">
+  <advance width="932"/>
+  <unicode hex="1E7F4"/>
+  <anchor x="423" y="724" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="528" y="6" type="line"/>
+      <point x="574" y="6" type="line" smooth="yes"/>
+      <point x="627" y="6"/>
+      <point x="667" y="41"/>
+      <point x="667" y="72" type="qcurve" smooth="yes"/>
+      <point x="667" y="104"/>
+      <point x="632" y="136"/>
+      <point x="592" y="136" type="qcurve" smooth="yes"/>
+      <point x="528" y="136" type="line"/>
+    </contour>
+    <contour>
+      <point x="744" y="283" type="qcurve" smooth="yes"/>
+      <point x="782" y="283"/>
+      <point x="818" y="317"/>
+      <point x="818" y="348" type="qcurve" smooth="yes"/>
+      <point x="818" y="378"/>
+      <point x="781" y="412"/>
+      <point x="744" y="412" type="qcurve" smooth="yes"/>
+      <point x="707" y="412"/>
+      <point x="670" y="378"/>
+      <point x="670" y="348" type="qcurve" smooth="yes"/>
+      <point x="670" y="317"/>
+      <point x="707" y="283"/>
+    </contour>
+    <contour>
+      <point x="90" y="0" type="line"/>
+      <point x="90" y="472" type="line" smooth="yes"/>
+      <point x="90" y="586"/>
+      <point x="198" y="724"/>
+      <point x="311" y="724" type="qcurve" smooth="yes"/>
+      <point x="426" y="724"/>
+      <point x="528" y="593"/>
+      <point x="528" y="470" type="qcurve" smooth="yes"/>
+      <point x="528" y="447" type="line"/>
+      <point x="629" y="447" type="line"/>
+      <point x="649" y="463"/>
+      <point x="707" y="480"/>
+      <point x="744" y="480" type="qcurve" smooth="yes"/>
+      <point x="827" y="480"/>
+      <point x="907" y="408"/>
+      <point x="907" y="349" type="qcurve" smooth="yes"/>
+      <point x="907" y="294"/>
+      <point x="824" y="216"/>
+      <point x="744" y="216" type="qcurve" smooth="yes"/>
+      <point x="656" y="216"/>
+      <point x="581" y="291"/>
+      <point x="581" y="346" type="qcurve" smooth="yes"/>
+      <point x="581" y="361"/>
+      <point x="584" y="374" type="qcurve"/>
+      <point x="528" y="374" type="line"/>
+      <point x="528" y="204" type="line"/>
+      <point x="608" y="204" type="line" smooth="yes"/>
+      <point x="756.337" y="204"/>
+      <point x="756" y="72" type="qcurve" smooth="yes"/>
+      <point x="756" y="16"/>
+      <point x="675" y="-60"/>
+      <point x="581" y="-60" type="qcurve" smooth="yes"/>
+      <point x="437" y="-60" type="line"/>
+      <point x="437" y="465" type="line" smooth="yes"/>
+      <point x="437" y="551"/>
+      <point x="379" y="644"/>
+      <point x="311" y="644" type="qcurve" smooth="yes"/>
+      <point x="236" y="644"/>
+      <point x="181" y="546"/>
+      <point x="181" y="464" type="qcurve" smooth="yes"/>
+      <point x="181" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/bwiG_urage.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/bwiG_urage.eth.glif
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="bwiGurage.eth" format="2">
+  <advance width="932"/>
+  <unicode hex="1E7F3"/>
+  <anchor x="406" y="724" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="744" y="240" type="qcurve" smooth="yes"/>
+      <point x="782" y="240"/>
+      <point x="818" y="274"/>
+      <point x="818" y="305" type="qcurve" smooth="yes"/>
+      <point x="818" y="335"/>
+      <point x="781" y="369"/>
+      <point x="744" y="369" type="qcurve" smooth="yes"/>
+      <point x="707" y="369"/>
+      <point x="670" y="335"/>
+      <point x="670" y="305" type="qcurve" smooth="yes"/>
+      <point x="670" y="274"/>
+      <point x="707" y="240"/>
+    </contour>
+    <contour>
+      <point x="90" y="0" type="line"/>
+      <point x="90" y="472" type="line" smooth="yes"/>
+      <point x="90" y="586"/>
+      <point x="198" y="724"/>
+      <point x="311" y="724" type="qcurve" smooth="yes"/>
+      <point x="426" y="724"/>
+      <point x="528" y="593"/>
+      <point x="528" y="470" type="qcurve" smooth="yes"/>
+      <point x="528" y="404" type="line"/>
+      <point x="629" y="404" type="line"/>
+      <point x="649" y="420"/>
+      <point x="707" y="437"/>
+      <point x="744" y="437" type="qcurve" smooth="yes"/>
+      <point x="827" y="437"/>
+      <point x="907" y="365"/>
+      <point x="907" y="306" type="qcurve" smooth="yes"/>
+      <point x="907" y="251"/>
+      <point x="824" y="173"/>
+      <point x="744" y="173" type="qcurve" smooth="yes"/>
+      <point x="656" y="173"/>
+      <point x="581" y="248"/>
+      <point x="581" y="303" type="qcurve" smooth="yes"/>
+      <point x="581" y="318"/>
+      <point x="584" y="331" type="qcurve"/>
+      <point x="528" y="331" type="line"/>
+      <point x="528" y="23" type="line"/>
+      <point x="615" y="23" type="line"/>
+      <point x="623" y="51"/>
+      <point x="668" y="104"/>
+      <point x="699" y="104" type="qcurve" smooth="yes"/>
+      <point x="723" y="104" type="line"/>
+      <point x="697" y="-14" type="line"/>
+      <point x="723" y="-132" type="line"/>
+      <point x="699" y="-132" type="line" smooth="yes"/>
+      <point x="668" y="-132"/>
+      <point x="623" y="-78"/>
+      <point x="615" y="-50" type="qcurve"/>
+      <point x="437" y="-50" type="line"/>
+      <point x="437" y="465" type="line" smooth="yes"/>
+      <point x="437" y="551"/>
+      <point x="379" y="644"/>
+      <point x="311" y="644" type="qcurve" smooth="yes"/>
+      <point x="236" y="644"/>
+      <point x="181" y="546"/>
+      <point x="181" y="464" type="qcurve" smooth="yes"/>
+      <point x="181" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/fweeG_urage.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/fweeG_urage.eth.glif
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="fweeGurage.eth" format="2">
+  <advance width="837"/>
+  <unicode hex="1E7FC"/>
+  <anchor x="381" y="724" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="206" y="312" type="qcurve"/>
+      <point x="139" y="269"/>
+      <point x="139" y="176" type="qcurve" smooth="yes"/>
+      <point x="139" y="121"/>
+      <point x="183" y="68"/>
+      <point x="221" y="68" type="qcurve" smooth="yes"/>
+      <point x="265" y="68"/>
+      <point x="309" y="128"/>
+      <point x="309" y="178" type="qcurve" smooth="yes"/>
+      <point x="309" y="237"/>
+      <point x="250" y="304"/>
+    </contour>
+    <contour>
+      <point x="569" y="66" type="qcurve" smooth="yes"/>
+      <point x="600" y="66"/>
+      <point x="630" y="96"/>
+      <point x="630" y="120" type="qcurve" smooth="yes"/>
+      <point x="630" y="143"/>
+      <point x="600" y="173"/>
+      <point x="569" y="173" type="qcurve" smooth="yes"/>
+      <point x="539" y="173"/>
+      <point x="508" y="143"/>
+      <point x="508" y="120" type="qcurve" smooth="yes"/>
+      <point x="508" y="96"/>
+      <point x="538" y="66"/>
+    </contour>
+    <contour>
+      <point x="648.651" y="366.937" type="qcurve" smooth="yes"/>
+      <point x="686.651" y="366.937"/>
+      <point x="722.651" y="400.937"/>
+      <point x="722.651" y="431.937" type="qcurve" smooth="yes"/>
+      <point x="722.651" y="461.937"/>
+      <point x="685.651" y="495.937"/>
+      <point x="648.651" y="495.937" type="qcurve" smooth="yes"/>
+      <point x="611.651" y="495.937"/>
+      <point x="574.651" y="461.937"/>
+      <point x="574.651" y="431.937" type="qcurve" smooth="yes"/>
+      <point x="574.651" y="400.937"/>
+      <point x="611.651" y="366.937"/>
+    </contour>
+    <contour>
+      <point x="223" y="0" type="qcurve" smooth="yes"/>
+      <point x="132" y="0"/>
+      <point x="50" y="96"/>
+      <point x="50" y="169" type="qcurve" smooth="yes"/>
+      <point x="50" y="231"/>
+      <point x="93" y="315"/>
+      <point x="164" y="375"/>
+      <point x="205" y="400" type="qcurve" smooth="yes"/>
+      <point x="262" y="435"/>
+      <point x="332" y="496"/>
+      <point x="372" y="566"/>
+      <point x="391" y="658"/>
+      <point x="396" y="724" type="qcurve"/>
+      <point x="487" y="724" type="line"/>
+      <point x="483" y="632"/>
+      <point x="462" y="566" type="qcurve" smooth="yes"/>
+      <point x="456.216" y="547.823"/>
+      <point x="448.651" y="530.938" type="qcurve"/>
+      <point x="533.651" y="530.938" type="line"/>
+      <point x="553.651" y="546.938"/>
+      <point x="611.651" y="563.938"/>
+      <point x="648.651" y="563.938" type="qcurve" smooth="yes"/>
+      <point x="731.651" y="563.938"/>
+      <point x="811.651" y="491.938"/>
+      <point x="811.651" y="432.938" type="qcurve" smooth="yes"/>
+      <point x="811.651" y="377.938"/>
+      <point x="728.651" y="299.938"/>
+      <point x="648.651" y="299.938" type="qcurve" smooth="yes"/>
+      <point x="560.651" y="299.938"/>
+      <point x="485.651" y="374.938"/>
+      <point x="485.651" y="429.938" type="qcurve" smooth="yes"/>
+      <point x="485.651" y="444.938"/>
+      <point x="488.651" y="457.938" type="qcurve"/>
+      <point x="402.61" y="457.938" type="line"/>
+      <point x="396.5" y="451" type="line" smooth="yes"/>
+      <point x="352" y="402"/>
+      <point x="275" y="360" type="qcurve"/>
+      <point x="330" y="341"/>
+      <point x="397" y="250"/>
+      <point x="397" y="176" type="qcurve" smooth="yes"/>
+      <point x="397" y="128"/>
+      <point x="380" y="91" type="qcurve"/>
+      <point x="427" y="91" type="line"/>
+      <point x="425" y="103"/>
+      <point x="425" y="117" type="qcurve" smooth="yes"/>
+      <point x="425" y="175"/>
+      <point x="505" y="237"/>
+      <point x="569" y="237" type="qcurve" smooth="yes"/>
+      <point x="642" y="237"/>
+      <point x="713" y="173"/>
+      <point x="713" y="120" type="qcurve" smooth="yes"/>
+      <point x="713" y="71"/>
+      <point x="639" y="0"/>
+      <point x="569" y="0" type="qcurve" smooth="yes"/>
+      <point x="533" y="0"/>
+      <point x="480" y="16"/>
+      <point x="462" y="30" type="qcurve"/>
+      <point x="329" y="30" type="line"/>
+      <point x="285" y="0"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/fwiG_urage.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/fwiG_urage.eth.glif
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="fwiGurage.eth" format="2">
+  <advance width="837"/>
+  <unicode hex="1E7FB"/>
+  <anchor x="340" y="724" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="206" y="312" type="qcurve"/>
+      <point x="139" y="269"/>
+      <point x="139" y="176" type="qcurve" smooth="yes"/>
+      <point x="139" y="121"/>
+      <point x="183" y="68"/>
+      <point x="221" y="68" type="qcurve" smooth="yes"/>
+      <point x="265" y="68"/>
+      <point x="309" y="128"/>
+      <point x="309" y="178" type="qcurve" smooth="yes"/>
+      <point x="309" y="237"/>
+      <point x="250" y="304"/>
+    </contour>
+    <contour>
+      <point x="648.651" y="366.937" type="qcurve" smooth="yes"/>
+      <point x="686.651" y="366.937"/>
+      <point x="722.651" y="400.937"/>
+      <point x="722.651" y="431.937" type="qcurve" smooth="yes"/>
+      <point x="722.651" y="461.937"/>
+      <point x="685.651" y="495.937"/>
+      <point x="648.651" y="495.937" type="qcurve" smooth="yes"/>
+      <point x="611.651" y="495.937"/>
+      <point x="574.651" y="461.937"/>
+      <point x="574.651" y="431.937" type="qcurve" smooth="yes"/>
+      <point x="574.651" y="400.937"/>
+      <point x="611.651" y="366.937"/>
+    </contour>
+    <contour>
+      <point x="212" y="0" type="line"/>
+      <point x="127" y="3"/>
+      <point x="50" y="98"/>
+      <point x="50" y="169" type="qcurve" smooth="yes"/>
+      <point x="50" y="231"/>
+      <point x="93" y="315"/>
+      <point x="164" y="375"/>
+      <point x="205" y="400" type="qcurve" smooth="yes"/>
+      <point x="262" y="435"/>
+      <point x="332" y="496"/>
+      <point x="372" y="566"/>
+      <point x="391" y="658"/>
+      <point x="396" y="724" type="qcurve"/>
+      <point x="487" y="724" type="line"/>
+      <point x="483" y="632"/>
+      <point x="462" y="566" type="qcurve" smooth="yes"/>
+      <point x="456.217" y="547.823"/>
+      <point x="448.651" y="530.937" type="qcurve"/>
+      <point x="481.798" y="530.937"/>
+      <point x="500.501" y="530.937"/>
+      <point x="533.651" y="530.937" type="curve"/>
+      <point x="553.651" y="546.937"/>
+      <point x="611.651" y="563.937"/>
+      <point x="648.651" y="563.937" type="qcurve" smooth="yes"/>
+      <point x="731.651" y="563.937"/>
+      <point x="811.651" y="491.937"/>
+      <point x="811.651" y="432.937" type="qcurve" smooth="yes"/>
+      <point x="811.651" y="377.937"/>
+      <point x="728.651" y="299.937"/>
+      <point x="648.651" y="299.937" type="qcurve" smooth="yes"/>
+      <point x="560.651" y="299.937"/>
+      <point x="485.651" y="374.937"/>
+      <point x="485.651" y="429.937" type="qcurve" smooth="yes"/>
+      <point x="485.651" y="444.937"/>
+      <point x="488.651" y="457.937" type="qcurve"/>
+      <point x="402.61" y="457.937" type="line"/>
+      <point x="396.5" y="451" type="line" smooth="yes"/>
+      <point x="352" y="402"/>
+      <point x="275" y="360" type="qcurve"/>
+      <point x="330" y="341"/>
+      <point x="397" y="250"/>
+      <point x="397" y="176" type="qcurve" smooth="yes"/>
+      <point x="397" y="113"/>
+      <point x="368" y="70" type="qcurve"/>
+      <point x="390" y="70" type="line" smooth="yes"/>
+      <point x="467" y="70"/>
+      <point x="540" y="137"/>
+      <point x="540" y="221" type="qcurve" smooth="yes"/>
+      <point x="540" y="267" type="line"/>
+      <point x="631" y="267" type="line"/>
+      <point x="631" y="217" type="line" smooth="yes"/>
+      <point x="631" y="0"/>
+      <point x="393" y="0" type="qcurve" smooth="yes"/>
+      <point x="212" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/gweG_urage.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/gweG_urage.eth.glif
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="gweGurage.eth" format="2">
+  <advance width="1019"/>
+  <unicode hex="1E7FA"/>
+  <anchor x="343" y="714" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="188" y="517" type="qcurve" smooth="yes"/>
+      <point x="226" y="517"/>
+      <point x="262" y="551"/>
+      <point x="262" y="582" type="qcurve" smooth="yes"/>
+      <point x="262" y="612"/>
+      <point x="225" y="646"/>
+      <point x="188" y="646" type="qcurve" smooth="yes"/>
+      <point x="151" y="646"/>
+      <point x="114" y="612"/>
+      <point x="114" y="582" type="qcurve" smooth="yes"/>
+      <point x="114" y="551"/>
+      <point x="151" y="517"/>
+    </contour>
+    <contour>
+      <point x="850" y="227" type="qcurve" smooth="yes"/>
+      <point x="881" y="227"/>
+      <point x="911" y="257"/>
+      <point x="911" y="281" type="qcurve" smooth="yes"/>
+      <point x="911" y="304"/>
+      <point x="881" y="334"/>
+      <point x="850" y="334" type="qcurve" smooth="yes"/>
+      <point x="820" y="334"/>
+      <point x="789" y="304"/>
+      <point x="789" y="281" type="qcurve" smooth="yes"/>
+      <point x="789" y="257"/>
+      <point x="819" y="227"/>
+    </contour>
+    <contour>
+      <point x="570" y="0" type="line"/>
+      <point x="570" y="377" type="line" smooth="yes"/>
+      <point x="570" y="484"/>
+      <point x="527" y="601"/>
+      <point x="427" y="648"/>
+      <point x="339" y="648" type="qcurve" smooth="yes"/>
+      <point x="335" y="648" type="line"/>
+      <point x="351" y="620"/>
+      <point x="351" y="583" type="qcurve" smooth="yes"/>
+      <point x="351" y="528"/>
+      <point x="268" y="450"/>
+      <point x="188" y="450" type="qcurve" smooth="yes"/>
+      <point x="100" y="450"/>
+      <point x="25" y="525"/>
+      <point x="25" y="580" type="qcurve" smooth="yes"/>
+      <point x="25" y="638"/>
+      <point x="108" y="714"/>
+      <point x="188" y="714" type="qcurve" smooth="yes"/>
+      <point x="192" y="714" type="line"/>
+      <point x="192" y="714" type="line"/>
+      <point x="334" y="714" type="line" smooth="yes"/>
+      <point x="415" y="714"/>
+      <point x="537" y="688"/>
+      <point x="620" y="621"/>
+      <point x="661" y="500"/>
+      <point x="661" y="404" type="qcurve" smooth="yes"/>
+      <point x="661" y="383" type="line"/>
+      <point x="772" y="383" type="line"/>
+      <point x="805" y="398"/>
+      <point x="850" y="398" type="qcurve" smooth="yes"/>
+      <point x="923" y="398"/>
+      <point x="994" y="334"/>
+      <point x="994" y="281" type="qcurve" smooth="yes"/>
+      <point x="994" y="232"/>
+      <point x="920" y="161"/>
+      <point x="850" y="161" type="qcurve" smooth="yes"/>
+      <point x="773" y="161"/>
+      <point x="706" y="228"/>
+      <point x="706" y="278" type="qcurve" smooth="yes"/>
+      <point x="706" y="284"/>
+      <point x="707" y="295"/>
+      <point x="708" y="300" type="qcurve"/>
+      <point x="661" y="300" type="line"/>
+      <point x="661" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/gweeG_urage.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/gweeG_urage.eth.glif
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="gweeGurage.eth" format="2">
+  <advance width="871"/>
+  <unicode hex="1E7F9"/>
+  <anchor x="362" y="714" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="481" y="-34" type="line"/>
+      <point x="527" y="-34" type="line" smooth="yes"/>
+      <point x="599.863" y="-34"/>
+      <point x="620" y="13"/>
+      <point x="620" y="32" type="qcurve" smooth="yes"/>
+      <point x="620" y="64"/>
+      <point x="585" y="96"/>
+      <point x="545" y="96" type="qcurve" smooth="yes"/>
+      <point x="481" y="96" type="line"/>
+    </contour>
+    <contour>
+      <point x="390" y="-100" type="line"/>
+      <point x="390" y="377" type="line" smooth="yes"/>
+      <point x="390" y="484"/>
+      <point x="341" y="598"/>
+      <point x="232" y="641"/>
+      <point x="142" y="641" type="qcurve" smooth="yes"/>
+      <point x="123" y="641" type="line"/>
+      <point x="110" y="598"/>
+      <point x="62" y="559"/>
+      <point x="34" y="559" type="qcurve" smooth="yes"/>
+      <point x="15" y="559" type="line"/>
+      <point x="49" y="714" type="line"/>
+      <point x="144" y="714" type="line" smooth="yes"/>
+      <point x="225" y="714"/>
+      <point x="350" y="688"/>
+      <point x="437" y="621"/>
+      <point x="481" y="500"/>
+      <point x="481" y="404" type="qcurve" smooth="yes"/>
+      <point x="481" y="383" type="line"/>
+      <point x="602.22" y="382.979" type="line"/>
+      <point x="637.449" y="408"/>
+      <point x="702" y="408" type="qcurve" smooth="yes"/>
+      <point x="775" y="408"/>
+      <point x="846" y="344"/>
+      <point x="846" y="291" type="qcurve" smooth="yes"/>
+      <point x="846" y="242"/>
+      <point x="772" y="171"/>
+      <point x="702" y="171" type="qcurve" smooth="yes"/>
+      <point x="625" y="171"/>
+      <point x="558" y="238"/>
+      <point x="558" y="288" type="qcurve" smooth="yes"/>
+      <point x="558" y="294"/>
+      <point x="559" y="305"/>
+      <point x="560" y="310" type="qcurve"/>
+      <point x="481" y="310" type="line"/>
+      <point x="481" y="164" type="line"/>
+      <point x="561" y="164" type="line" smooth="yes"/>
+      <point x="709" y="164"/>
+      <point x="709" y="32" type="qcurve" smooth="yes"/>
+      <point x="709" y="-24"/>
+      <point x="628" y="-100"/>
+      <point x="534" y="-100" type="qcurve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="702" y="237" type="qcurve" smooth="yes"/>
+      <point x="733" y="237"/>
+      <point x="763" y="267"/>
+      <point x="763" y="291" type="qcurve" smooth="yes"/>
+      <point x="763" y="314"/>
+      <point x="733" y="344"/>
+      <point x="702" y="344" type="qcurve" smooth="yes"/>
+      <point x="672" y="344"/>
+      <point x="641" y="314"/>
+      <point x="641" y="291" type="qcurve" smooth="yes"/>
+      <point x="641" y="267"/>
+      <point x="671" y="237"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/gwiG_urage.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/gwiG_urage.eth.glif
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="gwiGurage.eth" format="2">
+  <advance width="839"/>
+  <unicode hex="1E7F8"/>
+  <anchor x="349" y="714" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="670" y="227" type="qcurve" smooth="yes"/>
+      <point x="701" y="227"/>
+      <point x="731" y="257"/>
+      <point x="731" y="281" type="qcurve" smooth="yes"/>
+      <point x="731" y="304"/>
+      <point x="701" y="334"/>
+      <point x="670" y="334" type="qcurve" smooth="yes"/>
+      <point x="640" y="334"/>
+      <point x="609" y="304"/>
+      <point x="609" y="281" type="qcurve" smooth="yes"/>
+      <point x="609" y="257"/>
+      <point x="639" y="227"/>
+    </contour>
+    <contour>
+      <point x="390" y="-50" type="line"/>
+      <point x="390" y="377" type="line" smooth="yes"/>
+      <point x="390" y="484"/>
+      <point x="341" y="598"/>
+      <point x="232" y="641"/>
+      <point x="142" y="641" type="qcurve" smooth="yes"/>
+      <point x="123" y="641" type="line"/>
+      <point x="110" y="598"/>
+      <point x="62" y="559"/>
+      <point x="34" y="559" type="qcurve" smooth="yes"/>
+      <point x="15" y="559" type="line"/>
+      <point x="49" y="714" type="line"/>
+      <point x="144" y="714" type="line" smooth="yes"/>
+      <point x="225" y="714"/>
+      <point x="350" y="688"/>
+      <point x="437" y="621"/>
+      <point x="481" y="500"/>
+      <point x="481" y="404" type="qcurve" smooth="yes"/>
+      <point x="481" y="383" type="line"/>
+      <point x="592" y="383" type="line"/>
+      <point x="625" y="398"/>
+      <point x="670" y="398" type="qcurve" smooth="yes"/>
+      <point x="743" y="398"/>
+      <point x="814" y="334"/>
+      <point x="814" y="281" type="qcurve" smooth="yes"/>
+      <point x="814" y="232"/>
+      <point x="740" y="161"/>
+      <point x="670" y="161" type="qcurve" smooth="yes"/>
+      <point x="593" y="161"/>
+      <point x="526" y="228"/>
+      <point x="526" y="278" type="qcurve" smooth="yes"/>
+      <point x="526" y="284"/>
+      <point x="527" y="295"/>
+      <point x="528" y="300" type="qcurve"/>
+      <point x="481" y="300" type="line"/>
+      <point x="481" y="23" type="line"/>
+      <point x="576" y="23" type="line"/>
+      <point x="584" y="51"/>
+      <point x="629" y="104"/>
+      <point x="660" y="104" type="qcurve" smooth="yes"/>
+      <point x="684" y="104" type="line"/>
+      <point x="658" y="-14" type="line"/>
+      <point x="684" y="-132" type="line"/>
+      <point x="660" y="-132" type="line" smooth="yes"/>
+      <point x="629" y="-132"/>
+      <point x="584" y="-78"/>
+      <point x="576" y="-50" type="qcurve"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhwaG_urage.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhwaG_urage.eth.glif
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhwaGurage.eth" format="2">
+  <advance width="1091"/>
+  <unicode hex="1E7E8"/>
+  <anchor x="463" y="714" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="903" y="126" type="qcurve" smooth="yes"/>
+      <point x="941" y="126"/>
+      <point x="977" y="160"/>
+      <point x="977" y="191" type="qcurve" smooth="yes"/>
+      <point x="977" y="221"/>
+      <point x="940" y="255"/>
+      <point x="903" y="255" type="qcurve" smooth="yes"/>
+      <point x="866" y="255"/>
+      <point x="829" y="221"/>
+      <point x="829" y="191" type="qcurve" smooth="yes"/>
+      <point x="829" y="160"/>
+      <point x="866" y="126"/>
+    </contour>
+    <contour>
+      <point x="74" y="0" type="line"/>
+      <point x="74" y="185" type="line" smooth="yes"/>
+      <point x="74" y="303"/>
+      <point x="216" y="430"/>
+      <point x="333" y="434" type="qcurve"/>
+      <point x="333" y="714" type="line"/>
+      <point x="424" y="714" type="line"/>
+      <point x="424" y="434" type="line"/>
+      <point x="514" y="431"/>
+      <point x="638" y="358"/>
+      <point x="665" y="290" type="qcurve"/>
+      <point x="788" y="290" type="line"/>
+      <point x="808" y="306"/>
+      <point x="866" y="323"/>
+      <point x="903" y="323" type="qcurve" smooth="yes"/>
+      <point x="986" y="323"/>
+      <point x="1066" y="251"/>
+      <point x="1066" y="192" type="qcurve" smooth="yes"/>
+      <point x="1066" y="137"/>
+      <point x="983" y="59"/>
+      <point x="903" y="59" type="qcurve" smooth="yes"/>
+      <point x="815" y="59"/>
+      <point x="740" y="134"/>
+      <point x="740" y="189" type="qcurve" smooth="yes"/>
+      <point x="740" y="204"/>
+      <point x="743" y="217" type="qcurve"/>
+      <point x="682" y="217" type="line"/>
+      <point x="683" y="202"/>
+      <point x="683" y="185" type="qcurve" smooth="yes"/>
+      <point x="683" y="0" type="line"/>
+      <point x="592" y="0" type="line"/>
+      <point x="592" y="174" type="line" smooth="yes"/>
+      <point x="592" y="263"/>
+      <point x="504" y="349"/>
+      <point x="424" y="351" type="qcurve"/>
+      <point x="424" y="0" type="line"/>
+      <point x="333" y="0" type="line"/>
+      <point x="333" y="351" type="line"/>
+      <point x="255" y="349"/>
+      <point x="165" y="263"/>
+      <point x="165" y="175" type="qcurve" smooth="yes"/>
+      <point x="165" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhwe.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhwe.eth.glif
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhwe.eth" format="2">
+  <advance width="1091"/>
+  <unicode hex="1E7EB"/>
+  <anchor x="378" y="796" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="903" y="126" type="qcurve" smooth="yes"/>
+      <point x="941" y="126"/>
+      <point x="977" y="160"/>
+      <point x="977" y="191" type="qcurve" smooth="yes"/>
+      <point x="977" y="221"/>
+      <point x="940" y="255"/>
+      <point x="903" y="255" type="qcurve" smooth="yes"/>
+      <point x="866" y="255"/>
+      <point x="829" y="221"/>
+      <point x="829" y="191" type="qcurve" smooth="yes"/>
+      <point x="829" y="160"/>
+      <point x="866" y="126"/>
+    </contour>
+    <contour>
+      <point x="74" y="0" type="line"/>
+      <point x="74" y="185" type="line" smooth="yes"/>
+      <point x="74" y="303"/>
+      <point x="216" y="430"/>
+      <point x="333" y="434" type="qcurve"/>
+      <point x="333" y="641" type="line"/>
+      <point x="172" y="641" type="line"/>
+      <point x="138" y="796" type="line"/>
+      <point x="158" y="796" type="line" smooth="yes"/>
+      <point x="188" y="796"/>
+      <point x="236" y="752"/>
+      <point x="246" y="714" type="qcurve"/>
+      <point x="424" y="714" type="line"/>
+      <point x="424" y="434" type="line"/>
+      <point x="514" y="431"/>
+      <point x="638" y="358"/>
+      <point x="665" y="290" type="qcurve"/>
+      <point x="788" y="290" type="line"/>
+      <point x="808" y="306"/>
+      <point x="866" y="323"/>
+      <point x="903" y="323" type="qcurve" smooth="yes"/>
+      <point x="986" y="323"/>
+      <point x="1066" y="251"/>
+      <point x="1066" y="192" type="qcurve" smooth="yes"/>
+      <point x="1066" y="137"/>
+      <point x="983" y="59"/>
+      <point x="903" y="59" type="qcurve" smooth="yes"/>
+      <point x="815" y="59"/>
+      <point x="740" y="134"/>
+      <point x="740" y="189" type="qcurve" smooth="yes"/>
+      <point x="740" y="204"/>
+      <point x="743" y="217" type="qcurve"/>
+      <point x="682" y="217" type="line"/>
+      <point x="683" y="202"/>
+      <point x="683" y="185" type="qcurve" smooth="yes"/>
+      <point x="683" y="0" type="line"/>
+      <point x="592" y="0" type="line"/>
+      <point x="592" y="174" type="line" smooth="yes"/>
+      <point x="592" y="263"/>
+      <point x="504" y="349"/>
+      <point x="424" y="351" type="qcurve"/>
+      <point x="424" y="0" type="line"/>
+      <point x="333" y="0" type="line"/>
+      <point x="333" y="351" type="line"/>
+      <point x="255" y="349"/>
+      <point x="165" y="263"/>
+      <point x="165" y="175" type="qcurve" smooth="yes"/>
+      <point x="165" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhwee.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhwee.eth.glif
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhwee.eth" format="2">
+  <advance width="1055"/>
+  <unicode hex="1E7EA"/>
+  <anchor x="492" y="714" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="683.226" y="-130" type="line"/>
+      <point x="729.226" y="-130" type="line" smooth="yes"/>
+      <point x="782.226" y="-130"/>
+      <point x="822.226" y="-90"/>
+      <point x="822.226" y="-59" type="qcurve" smooth="yes"/>
+      <point x="822.226" y="-31"/>
+      <point x="787.226" y="0"/>
+      <point x="747.226" y="0" type="qcurve" smooth="yes"/>
+      <point x="683.226" y="0" type="line"/>
+    </contour>
+    <contour>
+      <point x="886" y="144" type="qcurve" smooth="yes"/>
+      <point x="917" y="144"/>
+      <point x="947" y="174"/>
+      <point x="947" y="198" type="qcurve" smooth="yes"/>
+      <point x="947" y="221"/>
+      <point x="917" y="251"/>
+      <point x="886" y="251" type="qcurve" smooth="yes"/>
+      <point x="856" y="251"/>
+      <point x="825" y="221"/>
+      <point x="825" y="198" type="qcurve" smooth="yes"/>
+      <point x="825" y="174"/>
+      <point x="855" y="144"/>
+    </contour>
+    <contour>
+      <point x="74" y="0" type="line"/>
+      <point x="74" y="185" type="line" smooth="yes"/>
+      <point x="74" y="303"/>
+      <point x="216" y="430"/>
+      <point x="333" y="434" type="qcurve"/>
+      <point x="333" y="714" type="line"/>
+      <point x="424" y="714" type="line"/>
+      <point x="424" y="434" type="line"/>
+      <point x="514" y="431"/>
+      <point x="638" y="358"/>
+      <point x="665" y="290" type="qcurve"/>
+      <point x="786.22" y="289.979" type="line"/>
+      <point x="821.449" y="315"/>
+      <point x="886" y="315" type="qcurve" smooth="yes"/>
+      <point x="959" y="315"/>
+      <point x="1030" y="251"/>
+      <point x="1030" y="198" type="qcurve" smooth="yes"/>
+      <point x="1030" y="149"/>
+      <point x="956" y="78"/>
+      <point x="886" y="78" type="qcurve" smooth="yes"/>
+      <point x="809" y="78"/>
+      <point x="742" y="145"/>
+      <point x="742" y="195" type="qcurve" smooth="yes"/>
+      <point x="742" y="201"/>
+      <point x="743" y="212"/>
+      <point x="744" y="217" type="qcurve"/>
+      <point x="682" y="217" type="line"/>
+      <point x="683" y="202"/>
+      <point x="683" y="185" type="qcurve" smooth="yes"/>
+      <point x="683.226" y="68" type="line"/>
+      <point x="763.226" y="68" type="line" smooth="yes"/>
+      <point x="837.226" y="68"/>
+      <point x="911.226" y="3"/>
+      <point x="911.226" y="-56" type="qcurve" smooth="yes"/>
+      <point x="911.226" y="-118"/>
+      <point x="820.226" y="-196"/>
+      <point x="726.226" y="-196" type="qcurve" smooth="yes"/>
+      <point x="592.226" y="-196" type="line"/>
+      <point x="592" y="174" type="line" smooth="yes"/>
+      <point x="591.946" y="263"/>
+      <point x="504" y="349"/>
+      <point x="424" y="351" type="qcurve"/>
+      <point x="424" y="0" type="line"/>
+      <point x="333" y="0" type="line"/>
+      <point x="333" y="351" type="line"/>
+      <point x="255" y="349"/>
+      <point x="165" y="263"/>
+      <point x="165" y="175" type="qcurve" smooth="yes"/>
+      <point x="165" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhwi.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhwi.eth.glif
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhwi.eth" format="2">
+  <advance width="1091"/>
+  <unicode hex="1E7E9"/>
+  <anchor x="472" y="714" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="903" y="126" type="qcurve" smooth="yes"/>
+      <point x="941" y="126"/>
+      <point x="977" y="160"/>
+      <point x="977" y="191" type="qcurve" smooth="yes"/>
+      <point x="977" y="221"/>
+      <point x="940" y="255"/>
+      <point x="903" y="255" type="qcurve" smooth="yes"/>
+      <point x="866" y="255"/>
+      <point x="829" y="221"/>
+      <point x="829" y="191" type="qcurve" smooth="yes"/>
+      <point x="829" y="160"/>
+      <point x="866" y="126"/>
+    </contour>
+    <contour>
+      <point x="74" y="0" type="line"/>
+      <point x="74" y="185" type="line" smooth="yes"/>
+      <point x="74" y="303"/>
+      <point x="216" y="430"/>
+      <point x="333" y="434" type="qcurve"/>
+      <point x="333" y="714" type="line"/>
+      <point x="424" y="714" type="line"/>
+      <point x="424" y="434" type="line"/>
+      <point x="514" y="431"/>
+      <point x="638" y="358"/>
+      <point x="665" y="290" type="qcurve"/>
+      <point x="788" y="290" type="line"/>
+      <point x="808" y="306"/>
+      <point x="866" y="323"/>
+      <point x="903" y="323" type="qcurve" smooth="yes"/>
+      <point x="986" y="323"/>
+      <point x="1066" y="251"/>
+      <point x="1066" y="192" type="qcurve" smooth="yes"/>
+      <point x="1066" y="137"/>
+      <point x="983" y="59"/>
+      <point x="903" y="59" type="qcurve" smooth="yes"/>
+      <point x="815" y="59"/>
+      <point x="740" y="134"/>
+      <point x="740" y="189" type="qcurve" smooth="yes"/>
+      <point x="740" y="204"/>
+      <point x="743" y="217" type="qcurve"/>
+      <point x="682" y="217" type="line"/>
+      <point x="683" y="202"/>
+      <point x="683" y="185" type="qcurve" smooth="yes"/>
+      <point x="683" y="-50" type="line"/>
+      <point x="762" y="-50" type="line"/>
+      <point x="770" y="-22"/>
+      <point x="815" y="31"/>
+      <point x="846" y="31" type="qcurve" smooth="yes"/>
+      <point x="870" y="31" type="line"/>
+      <point x="844" y="-87" type="line"/>
+      <point x="870" y="-205" type="line"/>
+      <point x="846" y="-205" type="line" smooth="yes"/>
+      <point x="815" y="-205"/>
+      <point x="770" y="-151"/>
+      <point x="762" y="-123" type="qcurve"/>
+      <point x="592" y="-123" type="line"/>
+      <point x="592" y="174" type="line" smooth="yes"/>
+      <point x="592" y="263"/>
+      <point x="504" y="349"/>
+      <point x="424" y="351" type="qcurve"/>
+      <point x="424" y="0" type="line"/>
+      <point x="333" y="0" type="line"/>
+      <point x="333" y="351" type="line"/>
+      <point x="255" y="349"/>
+      <point x="165" y="263"/>
+      <point x="165" y="175" type="qcurve" smooth="yes"/>
+      <point x="165" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhya.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhya.eth.glif
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhya.eth" format="2">
+  <advance width="757"/>
+  <unicode hex="1E7E0"/>
+  <anchor x="378" y="714" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="683" y="0" type="line"/>
+      <point x="592" y="0" type="line"/>
+      <point x="592" y="174" type="line" smooth="yes"/>
+      <point x="592" y="263"/>
+      <point x="504" y="349"/>
+      <point x="424" y="351" type="qcurve"/>
+      <point x="424" y="0" type="line"/>
+      <point x="333" y="0" type="line"/>
+      <point x="333" y="351" type="line"/>
+      <point x="255" y="349"/>
+      <point x="165" y="263"/>
+      <point x="165" y="175" type="qcurve" smooth="yes"/>
+      <point x="165" y="0" type="line"/>
+      <point x="74" y="0" type="line"/>
+      <point x="74" y="185" type="line" smooth="yes"/>
+      <point x="74" y="303"/>
+      <point x="216" y="430"/>
+      <point x="333" y="434" type="qcurve"/>
+      <point x="333" y="714" type="line"/>
+      <point x="221" y="714" type="line"/>
+      <point x="214" y="686"/>
+      <point x="169" y="632"/>
+      <point x="137" y="632" type="qcurve" smooth="yes"/>
+      <point x="113" y="632" type="line"/>
+      <point x="139" y="750" type="line"/>
+      <point x="113" y="868" type="line"/>
+      <point x="137" y="868" type="line" smooth="yes"/>
+      <point x="169" y="868"/>
+      <point x="214" y="815"/>
+      <point x="221" y="787" type="qcurve"/>
+      <point x="534" y="787" type="line"/>
+      <point x="542" y="815"/>
+      <point x="587" y="868"/>
+      <point x="618" y="868" type="qcurve" smooth="yes"/>
+      <point x="642" y="868" type="line"/>
+      <point x="616" y="750" type="line"/>
+      <point x="642" y="632" type="line"/>
+      <point x="618" y="632" type="line" smooth="yes"/>
+      <point x="587" y="632"/>
+      <point x="542" y="686"/>
+      <point x="534" y="714" type="qcurve"/>
+      <point x="424" y="714" type="line"/>
+      <point x="424" y="434" type="line"/>
+      <point x="544" y="430"/>
+      <point x="683" y="303"/>
+      <point x="683" y="185" type="qcurve" smooth="yes"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhyaa.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhyaa.eth.glif
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhyaa.eth" format="2">
+  <advance width="757"/>
+  <unicode hex="1E7E3"/>
+  <anchor x="378" y="714" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="683" y="0" type="line"/>
+      <point x="592" y="0" type="line"/>
+      <point x="592" y="184" type="line" smooth="yes"/>
+      <point x="592" y="273"/>
+      <point x="504" y="359"/>
+      <point x="424" y="361" type="qcurve"/>
+      <point x="424" y="156" type="line"/>
+      <point x="333" y="156" type="line"/>
+      <point x="333" y="361" type="line"/>
+      <point x="255" y="359"/>
+      <point x="165" y="273"/>
+      <point x="165" y="185" type="qcurve" smooth="yes"/>
+      <point x="165" y="156" type="line"/>
+      <point x="74" y="156" type="line"/>
+      <point x="74" y="195" type="line" smooth="yes"/>
+      <point x="74" y="313"/>
+      <point x="216" y="440"/>
+      <point x="333" y="444" type="qcurve"/>
+      <point x="333" y="714" type="line"/>
+      <point x="221" y="714" type="line"/>
+      <point x="214" y="686"/>
+      <point x="169" y="632"/>
+      <point x="137" y="632" type="qcurve" smooth="yes"/>
+      <point x="113" y="632" type="line"/>
+      <point x="139" y="750" type="line"/>
+      <point x="113" y="868" type="line"/>
+      <point x="137" y="868" type="line" smooth="yes"/>
+      <point x="169" y="868"/>
+      <point x="214" y="815"/>
+      <point x="221" y="787" type="qcurve"/>
+      <point x="534" y="787" type="line"/>
+      <point x="542" y="815"/>
+      <point x="587" y="868"/>
+      <point x="618" y="868" type="qcurve" smooth="yes"/>
+      <point x="642" y="868" type="line"/>
+      <point x="616" y="750" type="line"/>
+      <point x="642" y="632" type="line"/>
+      <point x="618" y="632" type="line" smooth="yes"/>
+      <point x="587" y="632"/>
+      <point x="542" y="686"/>
+      <point x="534" y="714" type="qcurve"/>
+      <point x="424" y="714" type="line"/>
+      <point x="424" y="444" type="line"/>
+      <point x="544" y="440"/>
+      <point x="683" y="313"/>
+      <point x="683" y="195" type="qcurve" smooth="yes"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhye.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhye.eth.glif
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhye.eth" format="2">
+  <advance width="757"/>
+  <unicode hex="1E7E5"/>
+  <anchor x="378" y="796" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="424" y="607" type="line"/>
+      <point x="424" y="434" type="line"/>
+      <point x="544" y="430"/>
+      <point x="683" y="303"/>
+      <point x="683" y="185" type="qcurve" smooth="yes"/>
+      <point x="683" y="0" type="line"/>
+      <point x="592" y="0" type="line"/>
+      <point x="592" y="174" type="line" smooth="yes"/>
+      <point x="592" y="263"/>
+      <point x="504" y="349"/>
+      <point x="424" y="351" type="qcurve"/>
+      <point x="424" y="0" type="line"/>
+      <point x="333" y="0" type="line"/>
+      <point x="333" y="351" type="line"/>
+      <point x="255" y="349"/>
+      <point x="165" y="263"/>
+      <point x="165" y="175" type="qcurve" smooth="yes"/>
+      <point x="165" y="0" type="line"/>
+      <point x="74" y="0" type="line"/>
+      <point x="74" y="185" type="line" smooth="yes"/>
+      <point x="74" y="303"/>
+      <point x="216" y="430"/>
+      <point x="333" y="434" type="qcurve"/>
+      <point x="333" y="534" type="line"/>
+      <point x="253" y="537"/>
+      <point x="165" y="619"/>
+      <point x="165" y="709" type="qcurve" smooth="yes"/>
+      <point x="165" y="714" type="line"/>
+      <point x="75" y="714" type="line"/>
+      <point x="68" y="686"/>
+      <point x="23" y="632"/>
+      <point x="-9" y="632" type="qcurve" smooth="yes"/>
+      <point x="-33" y="632" type="line"/>
+      <point x="-7" y="750" type="line"/>
+      <point x="-33" y="868" type="line"/>
+      <point x="-9" y="868" type="line" smooth="yes"/>
+      <point x="23" y="868"/>
+      <point x="68" y="815"/>
+      <point x="75" y="787" type="qcurve"/>
+      <point x="357" y="787" type="line"/>
+      <point x="365" y="815"/>
+      <point x="410" y="868"/>
+      <point x="441" y="868" type="qcurve" smooth="yes"/>
+      <point x="465" y="868" type="line"/>
+      <point x="439" y="750" type="line"/>
+      <point x="465" y="632" type="line"/>
+      <point x="441" y="632" type="line" smooth="yes"/>
+      <point x="410" y="632"/>
+      <point x="365" y="686"/>
+      <point x="357" y="714" type="qcurve"/>
+      <point x="256" y="714" type="line"/>
+      <point x="257" y="650"/>
+      <point x="307" y="609"/>
+      <point x="358" y="608" type="qcurve" smooth="yes"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhyee.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhyee.eth.glif
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhyee.eth" format="2">
+  <advance width="929"/>
+  <unicode hex="1E7E4"/>
+  <anchor x="492" y="714" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="683" y="66" type="line"/>
+      <point x="683" y="196" type="line"/>
+      <point x="747" y="196" type="line" smooth="yes"/>
+      <point x="787" y="196"/>
+      <point x="822" y="165"/>
+      <point x="822" y="137" type="qcurve" smooth="yes"/>
+      <point x="822" y="106"/>
+      <point x="782" y="66"/>
+      <point x="729" y="66" type="qcurve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="911" y="140" type="qcurve" smooth="yes"/>
+      <point x="911" y="199"/>
+      <point x="837" y="264"/>
+      <point x="763" y="264" type="qcurve" smooth="yes"/>
+      <point x="673" y="264" type="line"/>
+      <point x="652" y="344"/>
+      <point x="522" y="431"/>
+      <point x="424" y="434" type="qcurve"/>
+      <point x="424" y="714" type="line"/>
+      <point x="534" y="714" type="line"/>
+      <point x="542" y="686"/>
+      <point x="587" y="632"/>
+      <point x="618" y="632" type="qcurve" smooth="yes"/>
+      <point x="642" y="632" type="line"/>
+      <point x="616" y="750" type="line"/>
+      <point x="642" y="868" type="line"/>
+      <point x="618" y="868" type="line" smooth="yes"/>
+      <point x="587" y="868"/>
+      <point x="542" y="815"/>
+      <point x="534" y="787" type="qcurve"/>
+      <point x="221" y="787" type="line"/>
+      <point x="214" y="815"/>
+      <point x="169" y="868"/>
+      <point x="137" y="868" type="qcurve" smooth="yes"/>
+      <point x="113" y="868" type="line"/>
+      <point x="139" y="750" type="line"/>
+      <point x="113" y="632" type="line"/>
+      <point x="137" y="632" type="line" smooth="yes"/>
+      <point x="169" y="632"/>
+      <point x="214" y="686"/>
+      <point x="221" y="714" type="qcurve"/>
+      <point x="333" y="714" type="line"/>
+      <point x="333" y="434" type="line"/>
+      <point x="216" y="430"/>
+      <point x="74" y="303"/>
+      <point x="74" y="185" type="qcurve" smooth="yes"/>
+      <point x="74" y="0" type="line"/>
+      <point x="165" y="0" type="line"/>
+      <point x="165" y="175" type="line" smooth="yes"/>
+      <point x="165" y="263"/>
+      <point x="255" y="349"/>
+      <point x="333" y="351" type="qcurve"/>
+      <point x="333" y="0" type="line"/>
+      <point x="424" y="0" type="line"/>
+      <point x="424" y="351" type="line"/>
+      <point x="504" y="349"/>
+      <point x="592" y="263"/>
+      <point x="592" y="174" type="qcurve" smooth="yes"/>
+      <point x="592" y="0" type="line"/>
+      <point x="726" y="0" type="line" smooth="yes"/>
+      <point x="820" y="0"/>
+      <point x="911" y="78"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhyi.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhyi.eth.glif
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhyi.eth" format="2">
+  <advance width="885"/>
+  <unicode hex="1E7E2"/>
+  <anchor x="472" y="714" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="870" y="-82" type="line"/>
+      <point x="846" y="-82" type="line" smooth="yes"/>
+      <point x="815" y="-82"/>
+      <point x="770" y="-28"/>
+      <point x="762" y="0" type="qcurve"/>
+      <point x="592" y="0" type="line"/>
+      <point x="592" y="174" type="line" smooth="yes"/>
+      <point x="592" y="263"/>
+      <point x="504" y="349"/>
+      <point x="424" y="351" type="qcurve"/>
+      <point x="424" y="0" type="line"/>
+      <point x="333" y="0" type="line"/>
+      <point x="333" y="351" type="line"/>
+      <point x="255" y="349"/>
+      <point x="165" y="263"/>
+      <point x="165" y="175" type="qcurve" smooth="yes"/>
+      <point x="165" y="0" type="line"/>
+      <point x="74" y="0" type="line"/>
+      <point x="74" y="185" type="line" smooth="yes"/>
+      <point x="74" y="303"/>
+      <point x="216" y="430"/>
+      <point x="333" y="434" type="qcurve"/>
+      <point x="333" y="714" type="line"/>
+      <point x="221" y="714" type="line"/>
+      <point x="214" y="686"/>
+      <point x="169" y="632"/>
+      <point x="137" y="632" type="qcurve" smooth="yes"/>
+      <point x="113" y="632" type="line"/>
+      <point x="139" y="750" type="line"/>
+      <point x="113" y="868" type="line"/>
+      <point x="137" y="868" type="line" smooth="yes"/>
+      <point x="169" y="868"/>
+      <point x="214" y="815"/>
+      <point x="221" y="787" type="qcurve"/>
+      <point x="534" y="787" type="line"/>
+      <point x="542" y="815"/>
+      <point x="587" y="868"/>
+      <point x="618" y="868" type="qcurve" smooth="yes"/>
+      <point x="642" y="868" type="line"/>
+      <point x="616" y="750" type="line"/>
+      <point x="642" y="632" type="line"/>
+      <point x="618" y="632" type="line" smooth="yes"/>
+      <point x="587" y="632"/>
+      <point x="542" y="686"/>
+      <point x="534" y="714" type="qcurve"/>
+      <point x="424" y="714" type="line"/>
+      <point x="424" y="434" type="line"/>
+      <point x="544" y="430"/>
+      <point x="683" y="303"/>
+      <point x="683" y="185" type="qcurve" smooth="yes"/>
+      <point x="683" y="73" type="line"/>
+      <point x="762" y="73" type="line"/>
+      <point x="770" y="101"/>
+      <point x="815" y="154"/>
+      <point x="846" y="154" type="qcurve" smooth="yes"/>
+      <point x="870" y="154" type="line"/>
+      <point x="844" y="36" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhyo.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhyo.eth.glif
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhyo.eth" format="2">
+  <advance width="757"/>
+  <unicode hex="1E7E6"/>
+  <anchor x="378" y="714" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="74" y="0" type="line"/>
+      <point x="165" y="0" type="line"/>
+      <point x="165" y="184" type="line" smooth="yes"/>
+      <point x="165" y="273"/>
+      <point x="253" y="359"/>
+      <point x="333" y="361" type="qcurve"/>
+      <point x="333" y="156" type="line"/>
+      <point x="424" y="156" type="line"/>
+      <point x="424" y="361" type="line"/>
+      <point x="502" y="359"/>
+      <point x="592" y="273"/>
+      <point x="592" y="185" type="qcurve" smooth="yes"/>
+      <point x="592" y="156" type="line"/>
+      <point x="683" y="156" type="line"/>
+      <point x="683" y="195" type="line" smooth="yes"/>
+      <point x="683" y="313"/>
+      <point x="541" y="440"/>
+      <point x="424" y="444" type="qcurve"/>
+      <point x="424" y="714" type="line"/>
+      <point x="536" y="714" type="line"/>
+      <point x="543" y="686"/>
+      <point x="588" y="632"/>
+      <point x="620" y="632" type="qcurve" smooth="yes"/>
+      <point x="644" y="632" type="line"/>
+      <point x="618" y="750" type="line"/>
+      <point x="644" y="868" type="line"/>
+      <point x="620" y="868" type="line" smooth="yes"/>
+      <point x="588" y="868"/>
+      <point x="543" y="815"/>
+      <point x="536" y="787" type="qcurve"/>
+      <point x="223" y="787" type="line"/>
+      <point x="215" y="815"/>
+      <point x="170" y="868"/>
+      <point x="139" y="868" type="qcurve" smooth="yes"/>
+      <point x="115" y="868" type="line"/>
+      <point x="141" y="750" type="line"/>
+      <point x="115" y="632" type="line"/>
+      <point x="139" y="632" type="line" smooth="yes"/>
+      <point x="170" y="632"/>
+      <point x="215" y="686"/>
+      <point x="223" y="714" type="qcurve"/>
+      <point x="333" y="714" type="line"/>
+      <point x="333" y="444" type="line"/>
+      <point x="213" y="440"/>
+      <point x="74" y="313"/>
+      <point x="74" y="195" type="qcurve" smooth="yes"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhyu.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/hhyu.eth.glif
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhyu.eth" format="2">
+  <advance width="867"/>
+  <unicode hex="1E7E1"/>
+  <anchor x="463" y="714" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="683" y="0" type="line"/>
+      <point x="592" y="0" type="line"/>
+      <point x="592" y="174" type="line" smooth="yes"/>
+      <point x="592" y="263"/>
+      <point x="504" y="349"/>
+      <point x="424" y="351" type="qcurve"/>
+      <point x="424" y="0" type="line"/>
+      <point x="333" y="0" type="line"/>
+      <point x="333" y="351" type="line"/>
+      <point x="255" y="349"/>
+      <point x="165" y="263"/>
+      <point x="165" y="175" type="qcurve" smooth="yes"/>
+      <point x="165" y="0" type="line"/>
+      <point x="74" y="0" type="line"/>
+      <point x="74" y="185" type="line" smooth="yes"/>
+      <point x="74" y="303"/>
+      <point x="216" y="430"/>
+      <point x="333" y="434" type="qcurve"/>
+      <point x="333" y="714" type="line"/>
+      <point x="221" y="714" type="line"/>
+      <point x="214" y="686"/>
+      <point x="169" y="632"/>
+      <point x="137" y="632" type="qcurve" smooth="yes"/>
+      <point x="113" y="632" type="line"/>
+      <point x="139" y="750" type="line"/>
+      <point x="113" y="868" type="line"/>
+      <point x="137" y="868" type="line" smooth="yes"/>
+      <point x="169" y="868"/>
+      <point x="214" y="815"/>
+      <point x="221" y="787" type="qcurve"/>
+      <point x="534" y="787" type="line"/>
+      <point x="542" y="815"/>
+      <point x="587" y="868"/>
+      <point x="618" y="868" type="qcurve" smooth="yes"/>
+      <point x="642" y="868" type="line"/>
+      <point x="616" y="750" type="line"/>
+      <point x="642" y="632" type="line"/>
+      <point x="618" y="632" type="line" smooth="yes"/>
+      <point x="587" y="632"/>
+      <point x="542" y="686"/>
+      <point x="534" y="714" type="qcurve"/>
+      <point x="424" y="714" type="line"/>
+      <point x="424" y="434" type="line"/>
+      <point x="514" y="431"/>
+      <point x="638" y="358"/>
+      <point x="665" y="290" type="qcurve"/>
+      <point x="818" y="290" type="line"/>
+      <point x="852" y="135" type="line"/>
+      <point x="832" y="135" type="line" smooth="yes"/>
+      <point x="802" y="135"/>
+      <point x="755" y="180"/>
+      <point x="744" y="217" type="qcurve"/>
+      <point x="682" y="217" type="line"/>
+      <point x="683" y="202"/>
+      <point x="683" y="185" type="qcurve" smooth="yes"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/kweG_urage.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/kweG_urage.eth.glif
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="kweGurage.eth" format="2">
+  <advance width="977"/>
+  <unicode hex="1E7F7"/>
+  <anchor x="304" y="760" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="789" y="261" type="qcurve" smooth="yes"/>
+      <point x="827" y="261"/>
+      <point x="863" y="295"/>
+      <point x="863" y="326" type="qcurve" smooth="yes"/>
+      <point x="863" y="356"/>
+      <point x="826" y="390"/>
+      <point x="789" y="390" type="qcurve" smooth="yes"/>
+      <point x="752" y="390"/>
+      <point x="715" y="356"/>
+      <point x="715" y="326" type="qcurve" smooth="yes"/>
+      <point x="715" y="295"/>
+      <point x="752" y="261"/>
+    </contour>
+    <contour>
+      <point x="120" y="0" type="line"/>
+      <point x="120" y="189" type="line" smooth="yes"/>
+      <point x="120" y="240"/>
+      <point x="156" y="317"/>
+      <point x="196" y="339" type="qcurve"/>
+      <point x="120" y="339" type="line"/>
+      <point x="120" y="361" type="line" smooth="yes"/>
+      <point x="120" y="441"/>
+      <point x="146" y="498" type="qcurve"/>
+      <point x="99" y="517"/>
+      <point x="50" y="589"/>
+      <point x="50" y="659" type="qcurve" smooth="yes"/>
+      <point x="50" y="760" type="line"/>
+      <point x="141" y="760" type="line"/>
+      <point x="141" y="662" type="line" smooth="yes"/>
+      <point x="141" y="624"/>
+      <point x="169" y="575"/>
+      <point x="193" y="564" type="qcurve"/>
+      <point x="220" y="587"/>
+      <point x="293" y="613"/>
+      <point x="341" y="613" type="qcurve" smooth="yes"/>
+      <point x="439" y="613"/>
+      <point x="542" y="517"/>
+      <point x="554" y="425" type="qcurve"/>
+      <point x="674" y="425" type="line"/>
+      <point x="694" y="441"/>
+      <point x="752" y="458"/>
+      <point x="789" y="458" type="qcurve" smooth="yes"/>
+      <point x="872" y="458"/>
+      <point x="952" y="386"/>
+      <point x="952" y="327" type="qcurve" smooth="yes"/>
+      <point x="952" y="272"/>
+      <point x="869" y="194"/>
+      <point x="789" y="194" type="qcurve" smooth="yes"/>
+      <point x="701" y="194"/>
+      <point x="626" y="269"/>
+      <point x="626" y="324" type="qcurve" smooth="yes"/>
+      <point x="626" y="339"/>
+      <point x="629" y="352" type="qcurve"/>
+      <point x="558" y="352" type="line"/>
+      <point x="558" y="0" type="line"/>
+      <point x="467" y="0" type="line"/>
+      <point x="467" y="354" type="line" smooth="yes"/>
+      <point x="467" y="440"/>
+      <point x="409" y="533"/>
+      <point x="341" y="533" type="qcurve" smooth="yes"/>
+      <point x="266" y="533"/>
+      <point x="211" y="435"/>
+      <point x="211" y="353" type="qcurve" smooth="yes"/>
+      <point x="211" y="346" type="line"/>
+      <point x="253" y="364"/>
+      <point x="314" y="364" type="qcurve"/>
+      <point x="314" y="284" type="line"/>
+      <point x="271" y="284"/>
+      <point x="226" y="260"/>
+      <point x="211" y="215"/>
+      <point x="211" y="182" type="qcurve" smooth="yes"/>
+      <point x="211" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/kweeG_urage.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/kweeG_urage.eth.glif
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="kweeGurage.eth" format="2">
+  <advance width="977"/>
+  <unicode hex="1E7F6"/>
+  <anchor x="418" y="760" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="558" y="-34" type="line"/>
+      <point x="604" y="-34" type="line" smooth="yes"/>
+      <point x="657" y="-34"/>
+      <point x="697" y="1"/>
+      <point x="697" y="32" type="qcurve" smooth="yes"/>
+      <point x="697" y="64"/>
+      <point x="662" y="96"/>
+      <point x="622" y="96" type="qcurve" smooth="yes"/>
+      <point x="558" y="96" type="line"/>
+    </contour>
+    <contour>
+      <point x="789" y="261" type="qcurve" smooth="yes"/>
+      <point x="827" y="261"/>
+      <point x="863" y="295"/>
+      <point x="863" y="326" type="qcurve" smooth="yes"/>
+      <point x="863" y="356"/>
+      <point x="826" y="390"/>
+      <point x="789" y="390" type="qcurve" smooth="yes"/>
+      <point x="752" y="390"/>
+      <point x="715" y="356"/>
+      <point x="715" y="326" type="qcurve" smooth="yes"/>
+      <point x="715" y="295"/>
+      <point x="752" y="261"/>
+    </contour>
+    <contour>
+      <point x="120" y="0" type="line"/>
+      <point x="120" y="361" type="line" smooth="yes"/>
+      <point x="120" y="441"/>
+      <point x="146" y="498" type="qcurve"/>
+      <point x="99" y="517"/>
+      <point x="50" y="589"/>
+      <point x="50" y="659" type="qcurve" smooth="yes"/>
+      <point x="50" y="760" type="line"/>
+      <point x="141" y="760" type="line"/>
+      <point x="141" y="662" type="line" smooth="yes"/>
+      <point x="141" y="624"/>
+      <point x="169" y="575"/>
+      <point x="193" y="564" type="qcurve"/>
+      <point x="220" y="587"/>
+      <point x="293" y="613"/>
+      <point x="341" y="613" type="qcurve" smooth="yes"/>
+      <point x="439" y="613"/>
+      <point x="542" y="517"/>
+      <point x="554" y="425" type="qcurve"/>
+      <point x="674" y="425" type="line"/>
+      <point x="694" y="441"/>
+      <point x="752" y="458"/>
+      <point x="789" y="458" type="qcurve" smooth="yes"/>
+      <point x="872" y="458"/>
+      <point x="952" y="386"/>
+      <point x="952" y="327" type="qcurve" smooth="yes"/>
+      <point x="952" y="272"/>
+      <point x="869" y="194"/>
+      <point x="789" y="194" type="qcurve" smooth="yes"/>
+      <point x="701" y="194"/>
+      <point x="626" y="269"/>
+      <point x="626" y="324" type="qcurve" smooth="yes"/>
+      <point x="626" y="339"/>
+      <point x="629" y="352" type="qcurve"/>
+      <point x="558" y="352" type="line"/>
+      <point x="558" y="164" type="line"/>
+      <point x="638" y="164" type="line" smooth="yes"/>
+      <point x="786" y="164"/>
+      <point x="786" y="32" type="qcurve" smooth="yes"/>
+      <point x="786" y="-24"/>
+      <point x="705" y="-100"/>
+      <point x="611" y="-100" type="qcurve" smooth="yes"/>
+      <point x="467" y="-100" type="line"/>
+      <point x="467" y="354" type="line" smooth="yes"/>
+      <point x="467" y="440"/>
+      <point x="409" y="533"/>
+      <point x="341" y="533" type="qcurve" smooth="yes"/>
+      <point x="266" y="533"/>
+      <point x="211" y="435"/>
+      <point x="211" y="353" type="qcurve" smooth="yes"/>
+      <point x="211" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/kwiG_urage.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/kwiG_urage.eth.glif
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="kwiGurage.eth" format="2">
+  <advance width="977"/>
+  <unicode hex="1E7F5"/>
+  <anchor x="403" y="760" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="789" y="261" type="qcurve" smooth="yes"/>
+      <point x="827" y="261"/>
+      <point x="863" y="295"/>
+      <point x="863" y="326" type="qcurve" smooth="yes"/>
+      <point x="863" y="356"/>
+      <point x="826" y="390"/>
+      <point x="789" y="390" type="qcurve" smooth="yes"/>
+      <point x="752" y="390"/>
+      <point x="715" y="356"/>
+      <point x="715" y="326" type="qcurve" smooth="yes"/>
+      <point x="715" y="295"/>
+      <point x="752" y="261"/>
+    </contour>
+    <contour>
+      <point x="120" y="0" type="line"/>
+      <point x="120" y="361" type="line" smooth="yes"/>
+      <point x="120" y="441"/>
+      <point x="146" y="498" type="qcurve"/>
+      <point x="99" y="517"/>
+      <point x="50" y="589"/>
+      <point x="50" y="659" type="qcurve" smooth="yes"/>
+      <point x="50" y="760" type="line"/>
+      <point x="141" y="760" type="line"/>
+      <point x="141" y="662" type="line" smooth="yes"/>
+      <point x="141" y="624"/>
+      <point x="169" y="575"/>
+      <point x="193" y="564" type="qcurve"/>
+      <point x="220" y="587"/>
+      <point x="293" y="613"/>
+      <point x="341" y="613" type="qcurve" smooth="yes"/>
+      <point x="439" y="613"/>
+      <point x="542" y="517"/>
+      <point x="554" y="425" type="qcurve"/>
+      <point x="674" y="425" type="line"/>
+      <point x="694" y="441"/>
+      <point x="752" y="458"/>
+      <point x="789" y="458" type="qcurve" smooth="yes"/>
+      <point x="872" y="458"/>
+      <point x="952" y="386"/>
+      <point x="952" y="327" type="qcurve" smooth="yes"/>
+      <point x="952" y="272"/>
+      <point x="869" y="194"/>
+      <point x="789" y="194" type="qcurve" smooth="yes"/>
+      <point x="701" y="194"/>
+      <point x="626" y="269"/>
+      <point x="626" y="324" type="qcurve" smooth="yes"/>
+      <point x="626" y="339"/>
+      <point x="629" y="352" type="qcurve"/>
+      <point x="558" y="352" type="line"/>
+      <point x="558" y="73" type="line"/>
+      <point x="648" y="73" type="line"/>
+      <point x="656" y="101"/>
+      <point x="701" y="154"/>
+      <point x="732" y="154" type="qcurve" smooth="yes"/>
+      <point x="756" y="154" type="line"/>
+      <point x="730" y="36" type="line"/>
+      <point x="756" y="-82" type="line"/>
+      <point x="732" y="-82" type="line" smooth="yes"/>
+      <point x="701" y="-82"/>
+      <point x="656" y="-28"/>
+      <point x="648" y="0" type="qcurve"/>
+      <point x="467" y="0" type="line"/>
+      <point x="467" y="354" type="line" smooth="yes"/>
+      <point x="467" y="440"/>
+      <point x="409" y="533"/>
+      <point x="341" y="533" type="qcurve" smooth="yes"/>
+      <point x="266" y="533"/>
+      <point x="211" y="435"/>
+      <point x="211" y="353" type="qcurve" smooth="yes"/>
+      <point x="211" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/mweeG_urage.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/mweeG_urage.eth.glif
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="mweeGurage.eth" format="2">
+  <advance width="1259"/>
+  <unicode hex="1E7EE"/>
+  <anchor x="488" y="714" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="576" y="0" type="line"/>
+      <point x="576" y="64" type="line"/>
+      <point x="699" y="362" type="line"/>
+      <point x="646" y="362" type="line" smooth="yes"/>
+      <point x="576" y="362"/>
+      <point x="501" y="431"/>
+      <point x="501" y="498" type="qcurve" smooth="yes"/>
+      <point x="501" y="569"/>
+      <point x="518" y="648" type="qcurve"/>
+      <point x="410" y="648" type="line"/>
+      <point x="410" y="360" type="line"/>
+      <point x="376" y="325"/>
+      <point x="282" y="280"/>
+      <point x="223" y="280" type="qcurve" smooth="yes"/>
+      <point x="138" y="280"/>
+      <point x="38" y="382"/>
+      <point x="38" y="476" type="qcurve" smooth="yes"/>
+      <point x="38" y="586"/>
+      <point x="169" y="714"/>
+      <point x="285" y="714" type="qcurve" smooth="yes"/>
+      <point x="681" y="714" type="line" smooth="yes"/>
+      <point x="833.077" y="713.984"/>
+      <point x="851.455" y="605" type="qcurve"/>
+      <point x="956" y="605" type="line"/>
+      <point x="976" y="621"/>
+      <point x="1034" y="638"/>
+      <point x="1071" y="638" type="qcurve" smooth="yes"/>
+      <point x="1154" y="638"/>
+      <point x="1234" y="566"/>
+      <point x="1234" y="507" type="qcurve" smooth="yes"/>
+      <point x="1234" y="452"/>
+      <point x="1151" y="374"/>
+      <point x="1071" y="374" type="qcurve" smooth="yes"/>
+      <point x="983" y="374"/>
+      <point x="908" y="449"/>
+      <point x="908" y="504" type="qcurve" smooth="yes"/>
+      <point x="908" y="519"/>
+      <point x="911" y="532" type="qcurve"/>
+      <point x="850.084" y="532" type="line"/>
+      <point x="846.085" y="509.287"/>
+      <point x="838" y="483" type="qcurve" smooth="yes"/>
+      <point x="822" y="431"/>
+      <point x="802" y="384" type="qcurve" smooth="yes"/>
+      <point x="752" y="264" type="line"/>
+      <point x="790" y="264" type="line" smooth="yes"/>
+      <point x="864" y="264"/>
+      <point x="938" y="199"/>
+      <point x="938" y="140" type="qcurve" smooth="yes"/>
+      <point x="938" y="78"/>
+      <point x="847" y="0"/>
+      <point x="753" y="0" type="qcurve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="1071" y="441" type="qcurve" smooth="yes"/>
+      <point x="1109" y="441"/>
+      <point x="1145" y="475"/>
+      <point x="1145" y="506" type="qcurve" smooth="yes"/>
+      <point x="1145" y="536"/>
+      <point x="1108" y="570"/>
+      <point x="1071" y="570" type="qcurve" smooth="yes"/>
+      <point x="1034" y="570"/>
+      <point x="997" y="536"/>
+      <point x="997" y="506" type="qcurve" smooth="yes"/>
+      <point x="997" y="475"/>
+      <point x="1034" y="441"/>
+    </contour>
+    <contour>
+      <point x="228" y="351" type="qcurve" smooth="yes"/>
+      <point x="260" y="351"/>
+      <point x="302" y="369"/>
+      <point x="319" y="383" type="qcurve"/>
+      <point x="319" y="648" type="line"/>
+      <point x="291" y="648" type="line" smooth="yes"/>
+      <point x="215" y="648"/>
+      <point x="127" y="559"/>
+      <point x="127" y="476" type="qcurve" smooth="yes"/>
+      <point x="127" y="415"/>
+      <point x="182" y="351"/>
+    </contour>
+    <contour>
+      <point x="697" y="428" type="qcurve" smooth="yes"/>
+      <point x="726" y="428" type="line"/>
+      <point x="748" y="483" type="line" smooth="yes"/>
+      <point x="756" y="502"/>
+      <point x="767" y="547"/>
+      <point x="767" y="569" type="qcurve" smooth="yes"/>
+      <point x="767" y="607"/>
+      <point x="717" y="648"/>
+      <point x="673" y="648" type="qcurve" smooth="yes"/>
+      <point x="606" y="648" type="line"/>
+      <point x="597" y="604"/>
+      <point x="589" y="538"/>
+      <point x="589" y="508" type="qcurve" smooth="yes"/>
+      <point x="589" y="465"/>
+      <point x="636" y="428"/>
+    </contour>
+    <contour>
+      <point x="774" y="196" type="qcurve" smooth="yes"/>
+      <point x="724" y="196" type="line"/>
+      <point x="670" y="66" type="line"/>
+      <point x="756" y="66" type="line" smooth="yes"/>
+      <point x="809" y="66"/>
+      <point x="849" y="106"/>
+      <point x="849" y="137" type="qcurve" smooth="yes"/>
+      <point x="849" y="165"/>
+      <point x="814" y="196"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/mwiG_urage.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/mwiG_urage.eth.glif
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="mwiGurage.eth" format="2">
+  <advance width="1259"/>
+  <unicode hex="1E7ED"/>
+  <anchor x="491" y="714" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="228" y="351" type="qcurve" smooth="yes"/>
+      <point x="260" y="351"/>
+      <point x="302" y="369"/>
+      <point x="319" y="383" type="qcurve"/>
+      <point x="319" y="648" type="line"/>
+      <point x="291" y="648" type="line" smooth="yes"/>
+      <point x="215" y="648"/>
+      <point x="127" y="559"/>
+      <point x="127" y="476" type="qcurve" smooth="yes"/>
+      <point x="127" y="415"/>
+      <point x="182" y="351"/>
+    </contour>
+    <contour>
+      <point x="697" y="428" type="qcurve" smooth="yes"/>
+      <point x="726" y="428" type="line"/>
+      <point x="748" y="483" type="line" smooth="yes"/>
+      <point x="756" y="502"/>
+      <point x="767" y="547"/>
+      <point x="767" y="569" type="qcurve" smooth="yes"/>
+      <point x="767" y="607"/>
+      <point x="717" y="648"/>
+      <point x="673" y="648" type="qcurve" smooth="yes"/>
+      <point x="606" y="648" type="line"/>
+      <point x="597" y="604"/>
+      <point x="589" y="538"/>
+      <point x="589" y="508" type="qcurve" smooth="yes"/>
+      <point x="589" y="465"/>
+      <point x="636" y="428"/>
+    </contour>
+    <contour>
+      <point x="1071" y="441" type="qcurve" smooth="yes"/>
+      <point x="1109" y="441"/>
+      <point x="1145" y="475"/>
+      <point x="1145" y="506" type="qcurve" smooth="yes"/>
+      <point x="1145" y="536"/>
+      <point x="1108" y="570"/>
+      <point x="1071" y="570" type="qcurve" smooth="yes"/>
+      <point x="1034" y="570"/>
+      <point x="997" y="536"/>
+      <point x="997" y="506" type="qcurve" smooth="yes"/>
+      <point x="997" y="475"/>
+      <point x="1034" y="441"/>
+    </contour>
+    <contour>
+      <point x="576" y="0" type="line"/>
+      <point x="576" y="63" type="line"/>
+      <point x="699" y="362" type="line"/>
+      <point x="646" y="362" type="line" smooth="yes"/>
+      <point x="576" y="362"/>
+      <point x="501" y="431"/>
+      <point x="501" y="498" type="qcurve" smooth="yes"/>
+      <point x="501" y="569"/>
+      <point x="518" y="648" type="qcurve"/>
+      <point x="410" y="648" type="line"/>
+      <point x="410" y="360" type="line"/>
+      <point x="376" y="325"/>
+      <point x="282" y="280"/>
+      <point x="223" y="280" type="qcurve" smooth="yes"/>
+      <point x="138" y="280"/>
+      <point x="38" y="382"/>
+      <point x="38" y="476" type="qcurve" smooth="yes"/>
+      <point x="38" y="586"/>
+      <point x="169" y="714"/>
+      <point x="285" y="714" type="qcurve" smooth="yes"/>
+      <point x="681" y="714" type="line" smooth="yes"/>
+      <point x="833.077" y="713.984"/>
+      <point x="851.455" y="605" type="qcurve"/>
+      <point x="956" y="605" type="line"/>
+      <point x="976" y="621"/>
+      <point x="1034" y="638"/>
+      <point x="1071" y="638" type="qcurve" smooth="yes"/>
+      <point x="1154" y="638"/>
+      <point x="1234" y="566"/>
+      <point x="1234" y="507" type="qcurve" smooth="yes"/>
+      <point x="1234" y="452"/>
+      <point x="1151" y="374"/>
+      <point x="1071" y="374" type="qcurve" smooth="yes"/>
+      <point x="983" y="374"/>
+      <point x="908" y="449"/>
+      <point x="908" y="504" type="qcurve" smooth="yes"/>
+      <point x="908" y="519"/>
+      <point x="911" y="532" type="qcurve"/>
+      <point x="850.084" y="532" type="line"/>
+      <point x="846.087" y="509.287"/>
+      <point x="838" y="483" type="qcurve" smooth="yes"/>
+      <point x="822.002" y="431"/>
+      <point x="802" y="384" type="qcurve" smooth="yes"/>
+      <point x="673" y="73" type="line"/>
+      <point x="836" y="73" type="line"/>
+      <point x="844" y="101"/>
+      <point x="889" y="154"/>
+      <point x="920" y="154" type="qcurve" smooth="yes"/>
+      <point x="944" y="154" type="line"/>
+      <point x="918" y="36" type="line"/>
+      <point x="944" y="-82" type="line"/>
+      <point x="920" y="-82" type="line" smooth="yes"/>
+      <point x="889" y="-82"/>
+      <point x="844" y="-28"/>
+      <point x="836" y="0" type="qcurve"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/pweeG_urage.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/pweeG_urage.eth.glif
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="pweeGurage.eth" format="2">
+  <advance width="754"/>
+  <unicode hex="1E7FE"/>
+  <anchor x="300" y="714" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="346" y="6" type="line"/>
+      <point x="392" y="6" type="line" smooth="yes"/>
+      <point x="445" y="6"/>
+      <point x="485" y="41"/>
+      <point x="485" y="72" type="qcurve" smooth="yes"/>
+      <point x="485" y="104"/>
+      <point x="450" y="136"/>
+      <point x="410" y="136" type="qcurve" smooth="yes"/>
+      <point x="346" y="136" type="line"/>
+    </contour>
+    <contour>
+      <point x="566" y="272" type="qcurve" smooth="yes"/>
+      <point x="604" y="272"/>
+      <point x="640" y="306"/>
+      <point x="640" y="337" type="qcurve" smooth="yes"/>
+      <point x="640" y="367"/>
+      <point x="603" y="401"/>
+      <point x="566" y="401" type="qcurve" smooth="yes"/>
+      <point x="529" y="401"/>
+      <point x="492" y="367"/>
+      <point x="492" y="337" type="qcurve" smooth="yes"/>
+      <point x="492" y="306"/>
+      <point x="529" y="272"/>
+    </contour>
+    <contour>
+      <point x="255" y="-60" type="line"/>
+      <point x="255" y="641" type="line"/>
+      <point x="123" y="641" type="line"/>
+      <point x="113" y="604"/>
+      <point x="65" y="559"/>
+      <point x="35" y="559" type="qcurve" smooth="yes"/>
+      <point x="15" y="559" type="line"/>
+      <point x="49" y="714" type="line"/>
+      <point x="552" y="714" type="line"/>
+      <point x="586" y="559" type="line"/>
+      <point x="566" y="559" type="line" smooth="yes"/>
+      <point x="536" y="559"/>
+      <point x="489" y="604"/>
+      <point x="478" y="641" type="qcurve"/>
+      <point x="346" y="641" type="line"/>
+      <point x="346" y="436" type="line"/>
+      <point x="451" y="436" type="line"/>
+      <point x="471" y="452"/>
+      <point x="529" y="469"/>
+      <point x="566" y="469" type="qcurve" smooth="yes"/>
+      <point x="649" y="469"/>
+      <point x="729" y="397"/>
+      <point x="729" y="338" type="qcurve" smooth="yes"/>
+      <point x="729" y="283"/>
+      <point x="646" y="205"/>
+      <point x="566" y="205" type="qcurve" smooth="yes"/>
+      <point x="478" y="205"/>
+      <point x="403" y="280"/>
+      <point x="403" y="335" type="qcurve" smooth="yes"/>
+      <point x="403" y="350"/>
+      <point x="406" y="363" type="qcurve"/>
+      <point x="346" y="363" type="line"/>
+      <point x="346" y="204" type="line"/>
+      <point x="426" y="204" type="line" smooth="yes"/>
+      <point x="574" y="204"/>
+      <point x="574" y="72" type="qcurve" smooth="yes"/>
+      <point x="574" y="26"/>
+      <point x="493.53" y="-60"/>
+      <point x="399" y="-60" type="qcurve" smooth="yes"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/pwiG_urage.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/pwiG_urage.eth.glif
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="pwiGurage.eth" format="2">
+  <advance width="754"/>
+  <unicode hex="1E7FD"/>
+  <anchor x="300" y="714" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="566" y="222" type="qcurve" smooth="yes"/>
+      <point x="604" y="222"/>
+      <point x="640" y="256"/>
+      <point x="640" y="287" type="qcurve" smooth="yes"/>
+      <point x="640" y="317"/>
+      <point x="603" y="351"/>
+      <point x="566" y="351" type="qcurve" smooth="yes"/>
+      <point x="529" y="351"/>
+      <point x="492" y="317"/>
+      <point x="492" y="287" type="qcurve" smooth="yes"/>
+      <point x="492" y="256"/>
+      <point x="529" y="222"/>
+    </contour>
+    <contour>
+      <point x="255" y="-50" type="line"/>
+      <point x="255" y="641" type="line"/>
+      <point x="123" y="641" type="line"/>
+      <point x="113" y="604"/>
+      <point x="65" y="559"/>
+      <point x="35" y="559" type="qcurve" smooth="yes"/>
+      <point x="15" y="559" type="line"/>
+      <point x="49" y="714" type="line"/>
+      <point x="552" y="714" type="line"/>
+      <point x="586" y="559" type="line"/>
+      <point x="566" y="559" type="line" smooth="yes"/>
+      <point x="536" y="559"/>
+      <point x="489" y="604"/>
+      <point x="478" y="641" type="qcurve"/>
+      <point x="346" y="641" type="line"/>
+      <point x="346" y="386" type="line"/>
+      <point x="451" y="386" type="line"/>
+      <point x="471" y="402"/>
+      <point x="529" y="419"/>
+      <point x="566" y="419" type="qcurve" smooth="yes"/>
+      <point x="649" y="419"/>
+      <point x="729" y="347"/>
+      <point x="729" y="288" type="qcurve" smooth="yes"/>
+      <point x="729" y="233"/>
+      <point x="646" y="155"/>
+      <point x="566" y="155" type="qcurve" smooth="yes"/>
+      <point x="478" y="155"/>
+      <point x="403" y="230"/>
+      <point x="403" y="285" type="qcurve" smooth="yes"/>
+      <point x="403" y="300"/>
+      <point x="406" y="313" type="qcurve"/>
+      <point x="346" y="313" type="line"/>
+      <point x="346" y="23" type="line"/>
+      <point x="435" y="23" type="line"/>
+      <point x="443" y="51"/>
+      <point x="488" y="104"/>
+      <point x="519" y="104" type="qcurve" smooth="yes"/>
+      <point x="543" y="104" type="line"/>
+      <point x="517" y="-14" type="line"/>
+      <point x="543" y="-132" type="line"/>
+      <point x="519" y="-132" type="line" smooth="yes"/>
+      <point x="488" y="-132"/>
+      <point x="443" y="-78"/>
+      <point x="435" y="-50" type="qcurve"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/qweG_urage.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/qweG_urage.eth.glif
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="qweGurage.eth" format="2">
+  <advance width="1017"/>
+  <unicode hex="1E7F2"/>
+  <anchor x="325" y="855" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="131" y="400" type="qcurve" smooth="yes"/>
+      <point x="131" y="373"/>
+      <point x="155" y="330"/>
+      <point x="219" y="304"/>
+      <point x="280" y="302" type="qcurve"/>
+      <point x="280" y="496" type="line"/>
+      <point x="216" y="494"/>
+      <point x="152" y="466"/>
+      <point x="131" y="424"/>
+    </contour>
+    <contour>
+      <point x="520" y="400" type="qcurve" smooth="yes"/>
+      <point x="520" y="424"/>
+      <point x="497" y="466"/>
+      <point x="432" y="493"/>
+      <point x="371" y="496" type="qcurve"/>
+      <point x="371" y="302" type="line"/>
+      <point x="431" y="304"/>
+      <point x="496" y="331"/>
+      <point x="520" y="374"/>
+    </contour>
+    <contour>
+      <point x="829" y="271" type="qcurve" smooth="yes"/>
+      <point x="867" y="271"/>
+      <point x="903" y="305"/>
+      <point x="903" y="336" type="qcurve" smooth="yes"/>
+      <point x="903" y="366"/>
+      <point x="866" y="400"/>
+      <point x="829" y="400" type="qcurve" smooth="yes"/>
+      <point x="792" y="400"/>
+      <point x="755" y="366"/>
+      <point x="755" y="336" type="qcurve" smooth="yes"/>
+      <point x="755" y="305"/>
+      <point x="792" y="271"/>
+    </contour>
+    <contour>
+      <point x="280" y="0" type="line"/>
+      <point x="280" y="227" type="line"/>
+      <point x="184" y="230"/>
+      <point x="80" y="282"/>
+      <point x="40" y="359"/>
+      <point x="40" y="400" type="qcurve" smooth="yes"/>
+      <point x="40" y="443"/>
+      <point x="80" y="519"/>
+      <point x="184" y="568"/>
+      <point x="280" y="571" type="qcurve"/>
+      <point x="280" y="700" type="line"/>
+      <point x="101" y="700" type="line"/>
+      <point x="67" y="855" type="line"/>
+      <point x="87" y="855" type="line" smooth="yes"/>
+      <point x="117" y="855"/>
+      <point x="165" y="811"/>
+      <point x="175" y="773" type="qcurve"/>
+      <point x="371" y="773" type="line"/>
+      <point x="371" y="571" type="line"/>
+      <point x="453" y="568"/>
+      <point x="552" y="531"/>
+      <point x="601" y="471"/>
+      <point x="608" y="435" type="qcurve"/>
+      <point x="714" y="435" type="line"/>
+      <point x="734" y="451"/>
+      <point x="792" y="468"/>
+      <point x="829" y="468" type="qcurve" smooth="yes"/>
+      <point x="912" y="468"/>
+      <point x="992" y="396"/>
+      <point x="992" y="337" type="qcurve" smooth="yes"/>
+      <point x="992" y="282"/>
+      <point x="909" y="204"/>
+      <point x="829" y="204" type="qcurve" smooth="yes"/>
+      <point x="741" y="204"/>
+      <point x="666" y="279"/>
+      <point x="666" y="334" type="qcurve" smooth="yes"/>
+      <point x="666" y="349"/>
+      <point x="669" y="362" type="qcurve"/>
+      <point x="607" y="362" type="line"/>
+      <point x="599" y="329"/>
+      <point x="549" y="270"/>
+      <point x="451" y="230"/>
+      <point x="371" y="227" type="qcurve"/>
+      <point x="371" y="0" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/qweeG_urage.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/qweeG_urage.eth.glif
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="qweeGurage.eth" format="2">
+  <advance width="1015"/>
+  <unicode hex="1E7F1"/>
+  <anchor x="325" y="714" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="283" y="0" type="line"/>
+      <point x="283" y="294" type="line"/>
+      <point x="185" y="297"/>
+      <point x="80" y="343"/>
+      <point x="40" y="414"/>
+      <point x="40" y="452" type="qcurve" smooth="yes"/>
+      <point x="40" y="491"/>
+      <point x="80" y="561"/>
+      <point x="185" y="607"/>
+      <point x="283" y="610" type="qcurve"/>
+      <point x="283" y="714" type="line"/>
+      <point x="374" y="714" type="line"/>
+      <point x="374" y="610" type="line"/>
+      <point x="468" y="606"/>
+      <point x="571" y="561"/>
+      <point x="591" y="526.5" type="qcurve" smooth="yes"/>
+      <point x="601.955" y="507.575"/>
+      <point x="606.908" y="487" type="qcurve"/>
+      <point x="711.95" y="487" type="line"/>
+      <point x="731.95" y="503"/>
+      <point x="789.95" y="520"/>
+      <point x="826.95" y="520" type="qcurve" smooth="yes"/>
+      <point x="909.95" y="520"/>
+      <point x="989.95" y="448"/>
+      <point x="989.95" y="389" type="qcurve" smooth="yes"/>
+      <point x="989.95" y="334"/>
+      <point x="906.95" y="256"/>
+      <point x="826.95" y="256" type="qcurve" smooth="yes"/>
+      <point x="738.95" y="256"/>
+      <point x="663.95" y="331"/>
+      <point x="663.95" y="386" type="qcurve" smooth="yes"/>
+      <point x="663.95" y="401"/>
+      <point x="666.95" y="414" type="qcurve"/>
+      <point x="605.089" y="414" type="line"/>
+      <point x="600.126" y="398"/>
+      <point x="591" y="382" type="qcurve" smooth="yes"/>
+      <point x="571" y="347"/>
+      <point x="469" y="298"/>
+      <point x="374" y="294" type="qcurve"/>
+      <point x="374" y="231" type="line"/>
+      <point x="442" y="231" type="line" smooth="yes"/>
+      <point x="516" y="231"/>
+      <point x="590" y="174"/>
+      <point x="590" y="123" type="qcurve" smooth="yes"/>
+      <point x="590" y="68"/>
+      <point x="499" y="0"/>
+      <point x="405" y="0" type="qcurve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="131" y="452" type="qcurve" smooth="yes"/>
+      <point x="131" y="427"/>
+      <point x="156" y="391"/>
+      <point x="222" y="371"/>
+      <point x="283" y="369" type="qcurve"/>
+      <point x="283" y="535" type="line"/>
+      <point x="219" y="533"/>
+      <point x="154" y="510"/>
+      <point x="131" y="473"/>
+    </contour>
+    <contour>
+      <point x="520" y="452" type="qcurve" smooth="yes"/>
+      <point x="520" y="473"/>
+      <point x="496" y="509"/>
+      <point x="433" y="532"/>
+      <point x="374" y="534" type="qcurve"/>
+      <point x="374" y="369" type="line"/>
+      <point x="432" y="372"/>
+      <point x="495" y="393"/>
+      <point x="520" y="429"/>
+    </contour>
+    <contour>
+      <point x="374" y="66" type="line"/>
+      <point x="408" y="66" type="line" smooth="yes"/>
+      <point x="461" y="66"/>
+      <point x="501" y="96"/>
+      <point x="501" y="120" type="qcurve" smooth="yes"/>
+      <point x="501" y="141"/>
+      <point x="466" y="165"/>
+      <point x="426" y="165" type="qcurve" smooth="yes"/>
+      <point x="374" y="165" type="line"/>
+    </contour>
+    <contour>
+      <point x="826.933" y="323" type="qcurve" smooth="yes"/>
+      <point x="864.933" y="323"/>
+      <point x="900.933" y="357"/>
+      <point x="900.933" y="388" type="qcurve" smooth="yes"/>
+      <point x="900.933" y="418"/>
+      <point x="863.933" y="452"/>
+      <point x="826.933" y="452" type="qcurve" smooth="yes"/>
+      <point x="789.933" y="452"/>
+      <point x="752.933" y="418"/>
+      <point x="752.933" y="388" type="qcurve" smooth="yes"/>
+      <point x="752.933" y="357"/>
+      <point x="789.933" y="323"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/qwiG_urage.eth.glif
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/glyphs/qwiG_urage.eth.glif
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="qwiGurage.eth" format="2">
+  <advance width="1017"/>
+  <unicode hex="1E7F0"/>
+  <anchor x="325" y="714" name="t.uni030E"/>
+  <outline>
+    <contour>
+      <point x="131" y="401" type="qcurve" smooth="yes"/>
+      <point x="131" y="374"/>
+      <point x="155" y="331"/>
+      <point x="219" y="305"/>
+      <point x="280" y="303" type="qcurve"/>
+      <point x="280" y="497" type="line"/>
+      <point x="216" y="495"/>
+      <point x="152" y="467"/>
+      <point x="131" y="425"/>
+    </contour>
+    <contour>
+      <point x="520" y="401" type="qcurve" smooth="yes"/>
+      <point x="520" y="425"/>
+      <point x="497" y="467"/>
+      <point x="432" y="494"/>
+      <point x="371" y="497" type="qcurve"/>
+      <point x="371" y="303" type="line"/>
+      <point x="431" y="305"/>
+      <point x="496" y="332"/>
+      <point x="520" y="375"/>
+    </contour>
+    <contour>
+      <point x="280" y="0" type="line"/>
+      <point x="280" y="228" type="line"/>
+      <point x="184" y="231"/>
+      <point x="80" y="283"/>
+      <point x="40" y="360"/>
+      <point x="40" y="401" type="qcurve" smooth="yes"/>
+      <point x="40" y="444"/>
+      <point x="80" y="520"/>
+      <point x="184" y="569"/>
+      <point x="280" y="572" type="qcurve"/>
+      <point x="280" y="714" type="line"/>
+      <point x="371" y="714" type="line"/>
+      <point x="371" y="572" type="line"/>
+      <point x="453" y="569"/>
+      <point x="552" y="532"/>
+      <point x="601" y="472"/>
+      <point x="608" y="436" type="qcurve"/>
+      <point x="714" y="436" type="line"/>
+      <point x="734" y="452"/>
+      <point x="792" y="469"/>
+      <point x="829" y="469" type="qcurve" smooth="yes"/>
+      <point x="912" y="469"/>
+      <point x="992" y="397"/>
+      <point x="992" y="338" type="qcurve" smooth="yes"/>
+      <point x="992" y="283"/>
+      <point x="909" y="205"/>
+      <point x="829" y="205" type="qcurve" smooth="yes"/>
+      <point x="741" y="205"/>
+      <point x="666" y="280"/>
+      <point x="666" y="335" type="qcurve" smooth="yes"/>
+      <point x="666" y="350"/>
+      <point x="669" y="363" type="qcurve"/>
+      <point x="607" y="363" type="line"/>
+      <point x="599" y="330"/>
+      <point x="549" y="271"/>
+      <point x="451" y="231"/>
+      <point x="371" y="228" type="qcurve"/>
+      <point x="371" y="73" type="line"/>
+      <point x="472" y="73" type="line"/>
+      <point x="480" y="101"/>
+      <point x="525" y="154"/>
+      <point x="556" y="154" type="qcurve" smooth="yes"/>
+      <point x="580" y="154" type="line"/>
+      <point x="554" y="36" type="line"/>
+      <point x="580" y="-82" type="line"/>
+      <point x="556" y="-82" type="line" smooth="yes"/>
+      <point x="525" y="-82"/>
+      <point x="480" y="-28"/>
+      <point x="472" y="0" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="829" y="272" type="qcurve" smooth="yes"/>
+      <point x="867" y="272"/>
+      <point x="903" y="306"/>
+      <point x="903" y="337" type="qcurve" smooth="yes"/>
+      <point x="903" y="367"/>
+      <point x="866" y="401"/>
+      <point x="829" y="401" type="qcurve" smooth="yes"/>
+      <point x="792" y="401"/>
+      <point x="755" y="367"/>
+      <point x="755" y="337" type="qcurve" smooth="yes"/>
+      <point x="755" y="306"/>
+      <point x="792" y="272"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/lib.plist
+++ b/src/NotoSansEthiopic/NotoSansEthiopic-Regular.ufo/lib.plist
@@ -3751,6 +3751,36 @@
       <string>zzi.eth</string>
       <string>zzo.eth</string>
       <string>zzu.eth</string>
+      <!-- BEGIN: Unicode 14 Ethiopic Extended-B Entries -->
+      <string>hhya.eth</string>
+      <string>hhyu.eth</string>
+      <string>hhyi.eth</string>
+      <string>hhyaa.eth</string>
+      <string>hhyee.eth</string>
+      <string>hhye.eth</string>
+      <string>hhyo.eth</string>
+      <string>hhwaGurage.eth</string>
+      <string>hhwi.eth</string>
+      <string>hwee.eth</string>
+      <string>hhwe.eth</string>
+      <string>mwiGurage.eth</string>
+      <string>mweeGurage.eth</string>
+      <string>qwiGurage.eth</string>
+      <string>qweeGurage.eth</string>
+      <string>qweGurage.eth</string>
+      <string>bwiGurage.eth</string>
+      <string>bweeGurage.eth</string>
+      <string>kwiGurage.eth</string>
+      <string>kweeGurage.eth</string>
+      <string>kweGurage.eth</string>
+      <string>gwiGurage.eth</string>
+      <string>gweeGurage.eth</string>
+      <string>gweGurage.eth</string>
+      <string>fwiGurage.eth</string>
+      <string>fweeGurage.eth</string>
+      <string>pwiGurage.eth</string>
+      <string>pweeGurage.eth</string>
+      <!-- END: Unicode 14 Ethiopic Extended-B Entries -->
       <string>lollipop</string>
       <string>nose</string>
       <string>baashort</string>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/bweeG_urage-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/bweeG_urage-ethiopic.glif
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="bweeGurage-ethiopic" format="2">
+  <advance width="1050"/>
+  <unicode hex="1E7F4"/>
+  <anchor x="435" y="726" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="605" y="0" type="qcurve" smooth="yes"/>
+      <point x="687" y="0"/>
+      <point x="687" y="87" type="qcurve" smooth="yes"/>
+      <point x="687" y="120"/>
+      <point x="652" y="149"/>
+      <point x="617" y="149" type="qcurve" smooth="yes"/>
+      <point x="537" y="149" type="line"/>
+      <point x="537" y="55" type="line" smooth="yes"/>
+      <point x="537" y="23"/>
+      <point x="572" y="0"/>
+    </contour>
+    <contour>
+      <point x="814" y="233" type="qcurve" smooth="yes"/>
+      <point x="852" y="233"/>
+      <point x="893" y="286"/>
+      <point x="893" y="324" type="qcurve" smooth="yes"/>
+      <point x="893" y="354"/>
+      <point x="861" y="389"/>
+      <point x="830" y="389" type="qcurve" smooth="yes"/>
+      <point x="794" y="389"/>
+      <point x="753" y="341"/>
+      <point x="753" y="300" type="qcurve" smooth="yes"/>
+      <point x="753" y="270"/>
+      <point x="785" y="233"/>
+    </contour>
+    <contour>
+      <point x="756" y="198" type="line" smooth="yes"/>
+      <point x="717" y="198"/>
+      <point x="670" y="254"/>
+      <point x="670" y="298" type="qcurve" smooth="yes"/>
+      <point x="670" y="316"/>
+      <point x="673" y="332" type="qcurve"/>
+      <point x="538" y="332" type="line"/>
+      <point x="537" y="187" type="line"/>
+      <point x="648" y="187" type="line" smooth="yes"/>
+      <point x="781" y="187"/>
+      <point x="781" y="91" type="qcurve" smooth="yes"/>
+      <point x="781" y="39"/>
+      <point x="705" y="-35"/>
+      <point x="634" y="-35" type="qcurve" smooth="yes"/>
+      <point x="507" y="-35" type="line"/>
+      <point x="475" y="-28"/>
+      <point x="437" y="12"/>
+      <point x="437" y="48" type="qcurve" smooth="yes"/>
+      <point x="437" y="131"/>
+      <point x="438" y="322"/>
+      <point x="439" y="457"/>
+      <point x="439" y="506" type="qcurve" smooth="yes"/>
+      <point x="439" y="592"/>
+      <point x="395" y="678"/>
+      <point x="339" y="678" type="qcurve" smooth="yes"/>
+      <point x="292" y="678"/>
+      <point x="225" y="624"/>
+      <point x="190" y="504"/>
+      <point x="190" y="404" type="qcurve" smooth="yes"/>
+      <point x="190" y="120" type="line" smooth="yes"/>
+      <point x="190" y="76"/>
+      <point x="218" y="47"/>
+      <point x="249" y="47" type="qcurve"/>
+      <point x="249" y="5" type="line"/>
+      <point x="116" y="-4" type="line"/>
+      <point x="102" y="11"/>
+      <point x="90" y="63"/>
+      <point x="90" y="94" type="qcurve" smooth="yes"/>
+      <point x="90" y="429" type="line" smooth="yes"/>
+      <point x="90" y="529"/>
+      <point x="159" y="660"/>
+      <point x="278" y="726"/>
+      <point x="354" y="726" type="qcurve" smooth="yes"/>
+      <point x="458" y="726"/>
+      <point x="540" y="612"/>
+      <point x="540" y="499" type="qcurve" smooth="yes"/>
+      <point x="540" y="479"/>
+      <point x="539" y="382" type="qcurve"/>
+      <point x="694" y="382" type="line"/>
+      <point x="710" y="404"/>
+      <point x="765" y="428"/>
+      <point x="803" y="428" type="qcurve" smooth="yes"/>
+      <point x="876" y="428" type="line" smooth="yes"/>
+      <point x="926" y="428"/>
+      <point x="976" y="375"/>
+      <point x="976" y="325" type="qcurve" smooth="yes"/>
+      <point x="976" y="292"/>
+      <point x="949" y="234"/>
+      <point x="900" y="198"/>
+      <point x="867" y="198" type="qcurve" smooth="yes"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/bwiG_urage-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/bwiG_urage-ethiopic.glif
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="bwiGurage-ethiopic" format="2">
+  <advance width="1050"/>
+  <unicode hex="1E7F3"/>
+  <anchor x="431" y="726" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="814" y="233" type="qcurve" smooth="yes"/>
+      <point x="852" y="233"/>
+      <point x="893" y="286"/>
+      <point x="893" y="324" type="qcurve" smooth="yes"/>
+      <point x="893" y="354"/>
+      <point x="861" y="389"/>
+      <point x="830" y="389" type="qcurve" smooth="yes"/>
+      <point x="794" y="389"/>
+      <point x="753" y="341"/>
+      <point x="753" y="300" type="qcurve" smooth="yes"/>
+      <point x="753" y="270"/>
+      <point x="785" y="233"/>
+    </contour>
+    <contour>
+      <point x="756" y="198" type="line" smooth="yes"/>
+      <point x="717" y="198"/>
+      <point x="670" y="254"/>
+      <point x="670" y="298" type="qcurve" smooth="yes"/>
+      <point x="670" y="316"/>
+      <point x="673" y="332" type="qcurve"/>
+      <point x="538" y="332" type="line"/>
+      <point x="538" y="281"/>
+      <point x="537" y="171"/>
+      <point x="537" y="120" type="qcurve" smooth="yes"/>
+      <point x="537" y="76"/>
+      <point x="565" y="50"/>
+      <point x="596" y="50" type="qcurve" smooth="yes"/>
+      <point x="632" y="50" type="line"/>
+      <point x="637" y="76"/>
+      <point x="677" y="115"/>
+      <point x="717" y="115" type="qcurve" smooth="yes"/>
+      <point x="735" y="115"/>
+      <point x="766" y="106"/>
+      <point x="773" y="101" type="qcurve"/>
+      <point x="757" y="85"/>
+      <point x="742" y="49"/>
+      <point x="742" y="23" type="qcurve" smooth="yes"/>
+      <point x="742" y="-4"/>
+      <point x="760" y="-40"/>
+      <point x="773" y="-51" type="qcurve"/>
+      <point x="766" y="-57"/>
+      <point x="735" y="-67"/>
+      <point x="717" y="-67" type="qcurve" smooth="yes"/>
+      <point x="677" y="-67"/>
+      <point x="637" y="-27"/>
+      <point x="632" y="0" type="qcurve"/>
+      <point x="461" y="0" type="line"/>
+      <point x="449" y="14"/>
+      <point x="437" y="58"/>
+      <point x="437" y="94" type="qcurve" smooth="yes"/>
+      <point x="437" y="170"/>
+      <point x="438" y="320"/>
+      <point x="439" y="454"/>
+      <point x="439" y="506" type="qcurve" smooth="yes"/>
+      <point x="439" y="592"/>
+      <point x="395" y="678"/>
+      <point x="339" y="678" type="qcurve" smooth="yes"/>
+      <point x="292" y="678"/>
+      <point x="225" y="624"/>
+      <point x="190" y="504"/>
+      <point x="190" y="404" type="qcurve" smooth="yes"/>
+      <point x="190" y="120" type="line" smooth="yes"/>
+      <point x="190" y="76"/>
+      <point x="218" y="47"/>
+      <point x="249" y="47" type="qcurve"/>
+      <point x="249" y="5" type="line"/>
+      <point x="116" y="-4" type="line"/>
+      <point x="102" y="11"/>
+      <point x="90" y="63"/>
+      <point x="90" y="94" type="qcurve" smooth="yes"/>
+      <point x="90" y="429" type="line" smooth="yes"/>
+      <point x="90" y="529"/>
+      <point x="159" y="660"/>
+      <point x="278" y="726"/>
+      <point x="354" y="726" type="qcurve" smooth="yes"/>
+      <point x="458" y="726"/>
+      <point x="540" y="612"/>
+      <point x="540" y="499" type="qcurve" smooth="yes"/>
+      <point x="540" y="479"/>
+      <point x="539" y="418"/>
+      <point x="539" y="382" type="qcurve"/>
+      <point x="694" y="382" type="line"/>
+      <point x="710" y="404"/>
+      <point x="765" y="428"/>
+      <point x="803" y="428" type="qcurve" smooth="yes"/>
+      <point x="876" y="428" type="line" smooth="yes"/>
+      <point x="926" y="428"/>
+      <point x="976" y="375"/>
+      <point x="976" y="325" type="qcurve" smooth="yes"/>
+      <point x="976" y="292"/>
+      <point x="949" y="234"/>
+      <point x="900" y="198"/>
+      <point x="867" y="198" type="qcurve" smooth="yes"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/fweeG_urage-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/fweeG_urage-ethiopic.glif
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="fweeGurage-ethiopic" format="2">
+  <advance width="900"/>
+  <unicode hex="1E7FC"/>
+  <anchor x="407" y="724" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="232" y="331" type="qcurve"/>
+      <point x="196" y="310"/>
+      <point x="144" y="224"/>
+      <point x="144" y="165" type="qcurve" smooth="yes"/>
+      <point x="144" y="102"/>
+      <point x="194" y="42"/>
+      <point x="234" y="42" type="qcurve" smooth="yes"/>
+      <point x="279" y="42"/>
+      <point x="334" y="106"/>
+      <point x="334" y="167" type="qcurve" smooth="yes"/>
+      <point x="334" y="228"/>
+      <point x="273" y="313"/>
+    </contour>
+    <contour>
+      <point x="612" y="35" type="qcurve" smooth="yes"/>
+      <point x="646" y="35"/>
+      <point x="683" y="85"/>
+      <point x="683" y="119" type="qcurve" smooth="yes"/>
+      <point x="683" y="145"/>
+      <point x="654" y="178"/>
+      <point x="627" y="178" type="qcurve" smooth="yes"/>
+      <point x="596" y="178"/>
+      <point x="558" y="134"/>
+      <point x="558" y="96" type="qcurve" smooth="yes"/>
+      <point x="558" y="69"/>
+      <point x="587" y="35"/>
+    </contour>
+    <contour>
+      <point x="685" y="360" type="qcurve" smooth="yes"/>
+      <point x="723" y="360"/>
+      <point x="764" y="413"/>
+      <point x="764" y="451" type="qcurve" smooth="yes"/>
+      <point x="764" y="481"/>
+      <point x="732" y="516"/>
+      <point x="701" y="516" type="qcurve" smooth="yes"/>
+      <point x="665" y="516"/>
+      <point x="624" y="468"/>
+      <point x="624" y="427" type="qcurve" smooth="yes"/>
+      <point x="624" y="397"/>
+      <point x="656" y="360"/>
+    </contour>
+    <contour>
+      <point x="661" y="0" type="qcurve" smooth="yes"/>
+      <point x="206" y="0" type="line" smooth="yes"/>
+      <point x="136" y="0"/>
+      <point x="50" y="76"/>
+      <point x="50" y="152" type="qcurve" smooth="yes"/>
+      <point x="50" y="216"/>
+      <point x="106" y="308"/>
+      <point x="192" y="378"/>
+      <point x="238" y="409" type="qcurve" smooth="yes"/>
+      <point x="320" y="465"/>
+      <point x="389" y="563"/>
+      <point x="389" y="609" type="qcurve" smooth="yes"/>
+      <point x="389" y="644"/>
+      <point x="362" y="676"/>
+      <point x="335" y="676" type="qcurve"/>
+      <point x="335" y="715" type="line"/>
+      <point x="469" y="724" type="line"/>
+      <point x="476" y="709"/>
+      <point x="486" y="671"/>
+      <point x="486" y="641" type="qcurve" smooth="yes"/>
+      <point x="486" y="607"/>
+      <point x="468" y="542"/>
+      <point x="446" y="509" type="qcurve"/>
+      <point x="565" y="509" type="line"/>
+      <point x="581" y="531"/>
+      <point x="636" y="555"/>
+      <point x="674" y="555" type="qcurve" smooth="yes"/>
+      <point x="747" y="555" type="line" smooth="yes"/>
+      <point x="797" y="555"/>
+      <point x="847" y="502"/>
+      <point x="847" y="452" type="qcurve" smooth="yes"/>
+      <point x="847" y="419"/>
+      <point x="820" y="361"/>
+      <point x="771" y="325"/>
+      <point x="738" y="325" type="qcurve" smooth="yes"/>
+      <point x="627" y="325" type="line" smooth="yes"/>
+      <point x="588" y="325"/>
+      <point x="541" y="382"/>
+      <point x="541" y="425" type="qcurve" smooth="yes"/>
+      <point x="541" y="443"/>
+      <point x="544" y="459" type="qcurve"/>
+      <point x="403" y="459" type="line"/>
+      <point x="363" y="420"/>
+      <point x="300" y="378" type="qcurve"/>
+      <point x="332" y="362"/>
+      <point x="391" y="308"/>
+      <point x="430" y="231"/>
+      <point x="430" y="178" type="qcurve" smooth="yes"/>
+      <point x="430" y="132"/>
+      <point x="400" y="63"/>
+      <point x="374" y="41" type="qcurve"/>
+      <point x="491" y="41" type="line"/>
+      <point x="478" y="65"/>
+      <point x="478" y="95" type="qcurve" smooth="yes"/>
+      <point x="478" y="145"/>
+      <point x="538" y="216"/>
+      <point x="599" y="216" type="qcurve" smooth="yes"/>
+      <point x="670" y="216" type="line" smooth="yes"/>
+      <point x="715" y="216"/>
+      <point x="764" y="163"/>
+      <point x="764" y="120" type="qcurve" smooth="yes"/>
+      <point x="764" y="88"/>
+      <point x="737" y="33"/>
+      <point x="691" y="0"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/fwiG_urage-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/fwiG_urage-ethiopic.glif
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="fwiGurage-ethiopic" format="2">
+  <advance width="900"/>
+  <unicode hex="1E7FB"/>
+  <anchor x="356" y="724" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="232" y="331" type="qcurve"/>
+      <point x="196" y="310"/>
+      <point x="144" y="224"/>
+      <point x="144" y="165" type="qcurve" smooth="yes"/>
+      <point x="144" y="102"/>
+      <point x="194" y="42"/>
+      <point x="234" y="42" type="qcurve" smooth="yes"/>
+      <point x="279" y="42"/>
+      <point x="334" y="106"/>
+      <point x="334" y="167" type="qcurve" smooth="yes"/>
+      <point x="334" y="228"/>
+      <point x="273" y="313"/>
+    </contour>
+    <contour>
+      <point x="685" y="360" type="qcurve" smooth="yes"/>
+      <point x="723" y="360"/>
+      <point x="764" y="413"/>
+      <point x="764" y="451" type="qcurve" smooth="yes"/>
+      <point x="764" y="481"/>
+      <point x="732" y="516"/>
+      <point x="701" y="516" type="qcurve" smooth="yes"/>
+      <point x="665" y="516"/>
+      <point x="624" y="468"/>
+      <point x="624" y="427" type="qcurve" smooth="yes"/>
+      <point x="624" y="397"/>
+      <point x="656" y="360"/>
+    </contour>
+    <contour>
+      <point x="421" y="0" type="qcurve" smooth="yes"/>
+      <point x="206" y="0" type="line" smooth="yes"/>
+      <point x="136" y="0"/>
+      <point x="50" y="76"/>
+      <point x="50" y="152" type="qcurve" smooth="yes"/>
+      <point x="50" y="216"/>
+      <point x="106" y="308"/>
+      <point x="192" y="378"/>
+      <point x="238" y="409" type="qcurve" smooth="yes"/>
+      <point x="320" y="465"/>
+      <point x="389" y="563"/>
+      <point x="389" y="609" type="qcurve" smooth="yes"/>
+      <point x="389" y="644"/>
+      <point x="362" y="676"/>
+      <point x="335" y="676" type="qcurve"/>
+      <point x="335" y="715" type="line"/>
+      <point x="469" y="724" type="line"/>
+      <point x="476" y="709"/>
+      <point x="486" y="671"/>
+      <point x="486" y="641" type="qcurve" smooth="yes"/>
+      <point x="486" y="607"/>
+      <point x="468" y="542"/>
+      <point x="446" y="509" type="qcurve"/>
+      <point x="565" y="509" type="line"/>
+      <point x="581" y="531"/>
+      <point x="636" y="555"/>
+      <point x="674" y="555" type="qcurve" smooth="yes"/>
+      <point x="747" y="555" type="line" smooth="yes"/>
+      <point x="797" y="555"/>
+      <point x="847" y="502"/>
+      <point x="847" y="452" type="qcurve" smooth="yes"/>
+      <point x="847" y="419"/>
+      <point x="820" y="361"/>
+      <point x="771" y="325"/>
+      <point x="738" y="325" type="qcurve" smooth="yes"/>
+      <point x="627" y="325" type="line" smooth="yes"/>
+      <point x="588" y="325"/>
+      <point x="541" y="382"/>
+      <point x="541" y="425" type="qcurve" smooth="yes"/>
+      <point x="541" y="443"/>
+      <point x="544" y="459" type="qcurve"/>
+      <point x="403" y="459" type="line"/>
+      <point x="363" y="420"/>
+      <point x="300" y="378" type="qcurve"/>
+      <point x="332" y="362"/>
+      <point x="391" y="308"/>
+      <point x="430" y="231"/>
+      <point x="430" y="178" type="qcurve" smooth="yes"/>
+      <point x="430" y="136"/>
+      <point x="405" y="72"/>
+      <point x="384" y="50" type="qcurve"/>
+      <point x="422" y="50" type="line" smooth="yes"/>
+      <point x="493" y="50"/>
+      <point x="570" y="126"/>
+      <point x="570" y="191" type="qcurve" smooth="yes"/>
+      <point x="570" y="220"/>
+      <point x="549" y="241"/>
+      <point x="516" y="241" type="qcurve"/>
+      <point x="516" y="283" type="line"/>
+      <point x="642" y="292" type="line"/>
+      <point x="650" y="281"/>
+      <point x="663" y="236"/>
+      <point x="663" y="211" type="qcurve" smooth="yes"/>
+      <point x="663" y="156"/>
+      <point x="613" y="60"/>
+      <point x="507" y="0"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/gweG_urage-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/gweG_urage-ethiopic.glif
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="gweGurage-ethiopic" format="2">
+  <advance width="1050"/>
+  <unicode hex="1E7FA"/>
+  <anchor x="358" y="714" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="178" y="519" type="qcurve" smooth="yes"/>
+      <point x="219" y="519"/>
+      <point x="261" y="572"/>
+      <point x="261" y="610" type="qcurve" smooth="yes"/>
+      <point x="261" y="640"/>
+      <point x="227" y="675"/>
+      <point x="195" y="675" type="qcurve" smooth="yes"/>
+      <point x="157" y="675"/>
+      <point x="113" y="627"/>
+      <point x="113" y="586" type="qcurve" smooth="yes"/>
+      <point x="113" y="556"/>
+      <point x="147" y="519"/>
+    </contour>
+    <contour>
+      <point x="541" y="-5" type="line"/>
+      <point x="528" y="8"/>
+      <point x="512" y="45"/>
+      <point x="512" y="73" type="qcurve" smooth="yes"/>
+      <point x="512" y="559" type="line" smooth="yes"/>
+      <point x="512" y="622"/>
+      <point x="478" y="666"/>
+      <point x="425" y="666" type="qcurve" smooth="yes"/>
+      <point x="338" y="666" type="line"/>
+      <point x="349" y="643"/>
+      <point x="349" y="611" type="qcurve" smooth="yes"/>
+      <point x="349" y="559"/>
+      <point x="282" y="484"/>
+      <point x="224" y="484" type="qcurve" smooth="yes"/>
+      <point x="116" y="484" type="line" smooth="yes"/>
+      <point x="75" y="484"/>
+      <point x="25" y="541"/>
+      <point x="25" y="584" type="qcurve" smooth="yes"/>
+      <point x="25" y="643"/>
+      <point x="96" y="714"/>
+      <point x="166" y="714" type="qcurve" smooth="yes"/>
+      <point x="442" y="714" type="line" smooth="yes"/>
+      <point x="502" y="714"/>
+      <point x="576" y="688"/>
+      <point x="610" y="623"/>
+      <point x="610" y="564" type="qcurve" smooth="yes"/>
+      <point x="610" y="361" type="line"/>
+      <point x="738" y="361" type="line"/>
+      <point x="754" y="383"/>
+      <point x="809" y="407"/>
+      <point x="847" y="407" type="qcurve" smooth="yes"/>
+      <point x="920" y="407" type="line" smooth="yes"/>
+      <point x="970" y="407"/>
+      <point x="1020" y="354"/>
+      <point x="1020" y="304" type="qcurve" smooth="yes"/>
+      <point x="1020" y="271"/>
+      <point x="993" y="213"/>
+      <point x="944" y="177"/>
+      <point x="911" y="177" type="qcurve" smooth="yes"/>
+      <point x="800" y="177" type="line" smooth="yes"/>
+      <point x="761" y="177"/>
+      <point x="714" y="234"/>
+      <point x="714" y="277" type="qcurve" smooth="yes"/>
+      <point x="714" y="295"/>
+      <point x="717" y="311" type="qcurve"/>
+      <point x="610" y="311" type="line"/>
+      <point x="610" y="110" type="line" smooth="yes"/>
+      <point x="610" y="70"/>
+      <point x="636" y="43"/>
+      <point x="659" y="43" type="qcurve"/>
+      <point x="659" y="4" type="line"/>
+    </contour>
+    <contour>
+      <point x="858" y="212" type="qcurve" smooth="yes"/>
+      <point x="896" y="212"/>
+      <point x="937" y="265"/>
+      <point x="937" y="303" type="qcurve" smooth="yes"/>
+      <point x="937" y="333"/>
+      <point x="905" y="368"/>
+      <point x="874" y="368" type="qcurve" smooth="yes"/>
+      <point x="838" y="368"/>
+      <point x="797" y="320"/>
+      <point x="797" y="279" type="qcurve" smooth="yes"/>
+      <point x="797" y="249"/>
+      <point x="829" y="212"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/gweeG_urage-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/gweeG_urage-ethiopic.glif
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="gweeGurage-ethiopic" format="2">
+  <advance width="900"/>
+  <unicode hex="1E7F9"/>
+  <anchor x="369" y="714" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="416" y="-22" type="line"/>
+      <point x="384" y="-12"/>
+      <point x="348" y="40"/>
+      <point x="348" y="91" type="qcurve" smooth="yes"/>
+      <point x="348" y="558" type="line" smooth="yes"/>
+      <point x="348" y="621"/>
+      <point x="314" y="666"/>
+      <point x="261" y="666" type="qcurve" smooth="yes"/>
+      <point x="143" y="666" type="line"/>
+      <point x="144" y="660"/>
+      <point x="144" y="654"/>
+      <point x="144" y="650" type="qcurve" smooth="yes"/>
+      <point x="144" y="620"/>
+      <point x="102" y="572"/>
+      <point x="64" y="572" type="qcurve" smooth="yes"/>
+      <point x="48" y="572"/>
+      <point x="23" y="579"/>
+      <point x="15" y="583" type="qcurve"/>
+      <point x="25" y="598"/>
+      <point x="37" y="644"/>
+      <point x="37" y="669" type="qcurve" smooth="yes"/>
+      <point x="37" y="683"/>
+      <point x="35" y="705"/>
+      <point x="33" y="714" type="qcurve"/>
+      <point x="278" y="714" type="line" smooth="yes"/>
+      <point x="367" y="714"/>
+      <point x="446" y="651"/>
+      <point x="446" y="563" type="qcurve" smooth="yes"/>
+      <point x="446" y="434" type="line"/>
+      <point x="574" y="434" type="line"/>
+      <point x="590" y="456"/>
+      <point x="645" y="480"/>
+      <point x="683" y="480" type="qcurve" smooth="yes"/>
+      <point x="756" y="480" type="line" smooth="yes"/>
+      <point x="806" y="480"/>
+      <point x="856" y="427"/>
+      <point x="856" y="377" type="qcurve" smooth="yes"/>
+      <point x="856" y="344"/>
+      <point x="829" y="286"/>
+      <point x="780" y="250"/>
+      <point x="747" y="250" type="qcurve" smooth="yes"/>
+      <point x="636" y="250" type="line" smooth="yes"/>
+      <point x="597" y="250"/>
+      <point x="550" y="307"/>
+      <point x="550" y="350" type="qcurve" smooth="yes"/>
+      <point x="550" y="368"/>
+      <point x="553" y="384" type="qcurve"/>
+      <point x="446" y="384" type="line"/>
+      <point x="446" y="200" type="line"/>
+      <point x="557" y="200" type="line" smooth="yes"/>
+      <point x="690" y="200"/>
+      <point x="690" y="104" type="qcurve" smooth="yes"/>
+      <point x="690" y="52"/>
+      <point x="614" y="-22"/>
+      <point x="543" y="-22" type="qcurve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="514" y="13" type="qcurve" smooth="yes"/>
+      <point x="596" y="13"/>
+      <point x="596" y="100" type="qcurve" smooth="yes"/>
+      <point x="596" y="133"/>
+      <point x="561" y="162"/>
+      <point x="526" y="162" type="qcurve" smooth="yes"/>
+      <point x="446" y="162" type="line"/>
+      <point x="446" y="98" type="line" smooth="yes"/>
+      <point x="446" y="51"/>
+      <point x="481" y="13"/>
+    </contour>
+    <contour>
+      <point x="694" y="285" type="qcurve" smooth="yes"/>
+      <point x="732" y="285"/>
+      <point x="773" y="338"/>
+      <point x="773" y="376" type="qcurve" smooth="yes"/>
+      <point x="773" y="406"/>
+      <point x="741" y="441"/>
+      <point x="710" y="441" type="qcurve" smooth="yes"/>
+      <point x="674" y="441"/>
+      <point x="633" y="393"/>
+      <point x="633" y="352" type="qcurve" smooth="yes"/>
+      <point x="633" y="322"/>
+      <point x="665" y="285"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/gwiG_urage-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/gwiG_urage-ethiopic.glif
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="gwiGurage-ethiopic" format="2">
+  <advance width="900"/>
+  <unicode hex="1E7F8"/>
+  <anchor x="358" y="714" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="406" y="0" type="line"/>
+      <point x="377" y="16"/>
+      <point x="348" y="60"/>
+      <point x="348" y="105" type="qcurve" smooth="yes"/>
+      <point x="348" y="559" type="line" smooth="yes"/>
+      <point x="348" y="622"/>
+      <point x="314" y="666"/>
+      <point x="261" y="666" type="qcurve" smooth="yes"/>
+      <point x="143" y="666" type="line"/>
+      <point x="144" y="660"/>
+      <point x="144" y="654"/>
+      <point x="144" y="650" type="qcurve" smooth="yes"/>
+      <point x="144" y="620"/>
+      <point x="102" y="572"/>
+      <point x="64" y="572" type="qcurve" smooth="yes"/>
+      <point x="48" y="572"/>
+      <point x="23" y="579"/>
+      <point x="15" y="583" type="qcurve"/>
+      <point x="25" y="598"/>
+      <point x="37" y="644"/>
+      <point x="37" y="669" type="qcurve" smooth="yes"/>
+      <point x="37" y="683"/>
+      <point x="35" y="705"/>
+      <point x="33" y="714" type="qcurve"/>
+      <point x="278" y="714" type="line" smooth="yes"/>
+      <point x="338" y="714"/>
+      <point x="412" y="688"/>
+      <point x="446" y="623"/>
+      <point x="446" y="564" type="qcurve" smooth="yes"/>
+      <point x="446" y="361" type="line"/>
+      <point x="574" y="361" type="line"/>
+      <point x="590" y="383"/>
+      <point x="645" y="407"/>
+      <point x="683" y="407" type="qcurve" smooth="yes"/>
+      <point x="756" y="407" type="line" smooth="yes"/>
+      <point x="806" y="407"/>
+      <point x="856" y="354"/>
+      <point x="856" y="304" type="qcurve" smooth="yes"/>
+      <point x="856" y="271"/>
+      <point x="829" y="213"/>
+      <point x="780" y="177"/>
+      <point x="747" y="177" type="qcurve" smooth="yes"/>
+      <point x="636" y="177" type="line" smooth="yes"/>
+      <point x="597" y="177"/>
+      <point x="550" y="234"/>
+      <point x="550" y="277" type="qcurve" smooth="yes"/>
+      <point x="550" y="295"/>
+      <point x="553" y="311" type="qcurve"/>
+      <point x="446" y="311" type="line"/>
+      <point x="446" y="120" type="line" smooth="yes"/>
+      <point x="446" y="83"/>
+      <point x="474" y="50"/>
+      <point x="515" y="50" type="qcurve" smooth="yes"/>
+      <point x="557" y="50" type="line"/>
+      <point x="562" y="76"/>
+      <point x="602" y="115"/>
+      <point x="642" y="115" type="qcurve" smooth="yes"/>
+      <point x="660" y="115"/>
+      <point x="691" y="106"/>
+      <point x="698" y="101" type="qcurve"/>
+      <point x="682" y="85"/>
+      <point x="667" y="49"/>
+      <point x="667" y="23" type="qcurve" smooth="yes"/>
+      <point x="667" y="-4"/>
+      <point x="685" y="-40"/>
+      <point x="698" y="-51" type="qcurve"/>
+      <point x="691" y="-57"/>
+      <point x="660" y="-67"/>
+      <point x="642" y="-67" type="qcurve" smooth="yes"/>
+      <point x="602" y="-67"/>
+      <point x="562" y="-27"/>
+      <point x="557" y="0" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="694" y="212" type="qcurve" smooth="yes"/>
+      <point x="732" y="212"/>
+      <point x="773" y="265"/>
+      <point x="773" y="303" type="qcurve" smooth="yes"/>
+      <point x="773" y="333"/>
+      <point x="741" y="368"/>
+      <point x="710" y="368" type="qcurve" smooth="yes"/>
+      <point x="674" y="368"/>
+      <point x="633" y="320"/>
+      <point x="633" y="279" type="qcurve" smooth="yes"/>
+      <point x="633" y="249"/>
+      <point x="665" y="212"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhwaG_urage-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhwaG_urage-ethiopic.glif
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhwaGurage-ethiopic" format="2">
+  <advance width="1225"/>
+  <unicode hex="1E7E8"/>
+  <anchor x="518" y="718" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="1010" y="136" type="qcurve" smooth="yes"/>
+      <point x="1048" y="136"/>
+      <point x="1089" y="189"/>
+      <point x="1089" y="227" type="qcurve" smooth="yes"/>
+      <point x="1089" y="257"/>
+      <point x="1057" y="292"/>
+      <point x="1026" y="292" type="qcurve" smooth="yes"/>
+      <point x="990" y="292"/>
+      <point x="949" y="244"/>
+      <point x="949" y="203" type="qcurve" smooth="yes"/>
+      <point x="949" y="173"/>
+      <point x="981" y="136"/>
+    </contour>
+    <contour>
+      <point x="659" y="-5" type="line"/>
+      <point x="637" y="24"/>
+      <point x="637" y="81" type="qcurve" smooth="yes"/>
+      <point x="637" y="103"/>
+      <point x="638" y="159"/>
+      <point x="639" y="214"/>
+      <point x="639" y="232" type="qcurve" smooth="yes"/>
+      <point x="639" y="278"/>
+      <point x="605" y="348"/>
+      <point x="524" y="390"/>
+      <point x="453" y="394" type="qcurve"/>
+      <point x="453" y="111" type="line" smooth="yes"/>
+      <point x="453" y="71"/>
+      <point x="479" y="44"/>
+      <point x="502" y="44" type="qcurve"/>
+      <point x="502" y="4" type="line"/>
+      <point x="384" y="-5" type="line"/>
+      <point x="371" y="8"/>
+      <point x="355" y="45"/>
+      <point x="355" y="73" type="qcurve" smooth="yes"/>
+      <point x="355" y="391" type="line"/>
+      <point x="251" y="377"/>
+      <point x="164" y="246"/>
+      <point x="164" y="129" type="qcurve" smooth="yes"/>
+      <point x="164" y="81"/>
+      <point x="193" y="45"/>
+      <point x="223" y="44" type="qcurve"/>
+      <point x="223" y="4" type="line"/>
+      <point x="99" y="-5" type="line"/>
+      <point x="89" y="10"/>
+      <point x="70" y="69"/>
+      <point x="70" y="121" type="qcurve" smooth="yes"/>
+      <point x="70" y="252"/>
+      <point x="207" y="422"/>
+      <point x="355" y="439" type="qcurve"/>
+      <point x="355" y="610" type="line" smooth="yes"/>
+      <point x="355" y="669"/>
+      <point x="309" y="669" type="qcurve"/>
+      <point x="309" y="709" type="line"/>
+      <point x="424" y="718" type="line"/>
+      <point x="438" y="710"/>
+      <point x="453" y="670"/>
+      <point x="453" y="647" type="qcurve" smooth="yes"/>
+      <point x="453" y="443" type="line"/>
+      <point x="546" y="440"/>
+      <point x="661" y="398"/>
+      <point x="720" y="328"/>
+      <point x="729" y="285" type="qcurve"/>
+      <point x="890" y="285" type="line"/>
+      <point x="906" y="307"/>
+      <point x="961" y="331"/>
+      <point x="999" y="331" type="qcurve" smooth="yes"/>
+      <point x="1072" y="331" type="line" smooth="yes"/>
+      <point x="1122" y="331"/>
+      <point x="1172" y="278"/>
+      <point x="1172" y="228" type="qcurve" smooth="yes"/>
+      <point x="1172" y="195"/>
+      <point x="1145" y="137"/>
+      <point x="1096" y="101"/>
+      <point x="1063" y="101" type="qcurve" smooth="yes"/>
+      <point x="952" y="101" type="line" smooth="yes"/>
+      <point x="913" y="101"/>
+      <point x="866" y="157"/>
+      <point x="866" y="201" type="qcurve" smooth="yes"/>
+      <point x="866" y="219"/>
+      <point x="869" y="235" type="qcurve"/>
+      <point x="734" y="235" type="line"/>
+      <point x="734" y="215"/>
+      <point x="731" y="149"/>
+      <point x="731" y="129" type="qcurve" smooth="yes"/>
+      <point x="731" y="79"/>
+      <point x="758" y="46"/>
+      <point x="787" y="44" type="qcurve"/>
+      <point x="787" y="4" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhwe-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhwe-ethiopic.glif
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhwe-ethiopic" format="2">
+  <advance width="1250"/>
+  <unicode hex="1E7EB"/>
+  <anchor x="428" y="819" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="659" y="-5" type="line"/>
+      <point x="637" y="24"/>
+      <point x="637" y="81" type="qcurve" smooth="yes"/>
+      <point x="637" y="103"/>
+      <point x="638" y="159"/>
+      <point x="639" y="214"/>
+      <point x="639" y="232" type="qcurve" smooth="yes"/>
+      <point x="639" y="300"/>
+      <point x="562" y="386"/>
+      <point x="461" y="393" type="qcurve"/>
+      <point x="461" y="111" type="line" smooth="yes"/>
+      <point x="461" y="71"/>
+      <point x="487" y="44"/>
+      <point x="510" y="44" type="qcurve"/>
+      <point x="510" y="4" type="line"/>
+      <point x="392" y="-5" type="line"/>
+      <point x="379" y="8"/>
+      <point x="363" y="45"/>
+      <point x="363" y="73" type="qcurve" smooth="yes"/>
+      <point x="363" y="392" type="line"/>
+      <point x="254" y="379"/>
+      <point x="164" y="248"/>
+      <point x="164" y="129" type="qcurve" smooth="yes"/>
+      <point x="164" y="81"/>
+      <point x="193" y="45"/>
+      <point x="223" y="44" type="qcurve"/>
+      <point x="223" y="4" type="line"/>
+      <point x="99" y="-5" type="line"/>
+      <point x="89" y="10"/>
+      <point x="70" y="69"/>
+      <point x="70" y="121" type="qcurve" smooth="yes"/>
+      <point x="70" y="254"/>
+      <point x="211" y="425"/>
+      <point x="363" y="440" type="qcurve"/>
+      <point x="363" y="610" type="line" smooth="yes"/>
+      <point x="363" y="639"/>
+      <point x="343" y="664"/>
+      <point x="317" y="664" type="qcurve" smooth="yes"/>
+      <point x="145" y="664" type="line"/>
+      <point x="147" y="671"/>
+      <point x="153" y="702"/>
+      <point x="153" y="720" type="qcurve" smooth="yes"/>
+      <point x="153" y="775"/>
+      <point x="119" y="803" type="qcurve"/>
+      <point x="141" y="819"/>
+      <point x="177" y="819" type="qcurve" smooth="yes"/>
+      <point x="221" y="819"/>
+      <point x="264" y="772"/>
+      <point x="264" y="737" type="qcurve" smooth="yes"/>
+      <point x="264" y="730"/>
+      <point x="263" y="719"/>
+      <point x="262" y="714" type="qcurve"/>
+      <point x="432" y="714" type="line"/>
+      <point x="461" y="696"/>
+      <point x="461" y="643" type="qcurve" smooth="yes"/>
+      <point x="461" y="443" type="line"/>
+      <point x="549" y="439"/>
+      <point x="604" y="419" type="qcurve" smooth="yes"/>
+      <point x="662" y="398"/>
+      <point x="720" y="328"/>
+      <point x="729" y="285" type="qcurve"/>
+      <point x="890" y="285" type="line"/>
+      <point x="906" y="307"/>
+      <point x="961" y="331"/>
+      <point x="999" y="331" type="qcurve" smooth="yes"/>
+      <point x="1072" y="331" type="line" smooth="yes"/>
+      <point x="1122" y="331"/>
+      <point x="1172" y="278"/>
+      <point x="1172" y="228" type="qcurve" smooth="yes"/>
+      <point x="1172" y="195"/>
+      <point x="1145" y="137"/>
+      <point x="1096" y="101"/>
+      <point x="1063" y="101" type="qcurve" smooth="yes"/>
+      <point x="952" y="101" type="line" smooth="yes"/>
+      <point x="913" y="101"/>
+      <point x="866" y="157"/>
+      <point x="866" y="201" type="qcurve" smooth="yes"/>
+      <point x="866" y="219"/>
+      <point x="869" y="235" type="qcurve"/>
+      <point x="734" y="235" type="line"/>
+      <point x="734" y="215"/>
+      <point x="731" y="149"/>
+      <point x="731" y="129" type="qcurve" smooth="yes"/>
+      <point x="731" y="79"/>
+      <point x="758" y="46"/>
+      <point x="787" y="44" type="qcurve"/>
+      <point x="787" y="4" type="line"/>
+    </contour>
+    <contour>
+      <point x="1010" y="136" type="qcurve" smooth="yes"/>
+      <point x="1048" y="136"/>
+      <point x="1089" y="189"/>
+      <point x="1089" y="227" type="qcurve" smooth="yes"/>
+      <point x="1089" y="257"/>
+      <point x="1057" y="292"/>
+      <point x="1026" y="292" type="qcurve" smooth="yes"/>
+      <point x="990" y="292"/>
+      <point x="949" y="244"/>
+      <point x="949" y="203" type="qcurve" smooth="yes"/>
+      <point x="949" y="173"/>
+      <point x="981" y="136"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhwee-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhwee-ethiopic.glif
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhwee-ethiopic" format="2">
+  <advance width="1150"/>
+  <unicode hex="1E7EA"/>
+  <anchor x="523" y="718" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="733" y="-35" type="line"/>
+      <point x="686" y="-25"/>
+      <point x="639" y="27"/>
+      <point x="639" y="78" type="qcurve" smooth="yes"/>
+      <point x="639" y="232" type="line" smooth="yes"/>
+      <point x="639" y="278"/>
+      <point x="605" y="348"/>
+      <point x="523" y="390"/>
+      <point x="452" y="394" type="qcurve"/>
+      <point x="452" y="111" type="line" smooth="yes"/>
+      <point x="452" y="71"/>
+      <point x="478" y="44"/>
+      <point x="501" y="44" type="qcurve"/>
+      <point x="501" y="4" type="line"/>
+      <point x="383" y="-5" type="line"/>
+      <point x="370" y="8"/>
+      <point x="354" y="45"/>
+      <point x="354" y="73" type="qcurve" smooth="yes"/>
+      <point x="354" y="391" type="line"/>
+      <point x="251" y="377"/>
+      <point x="164" y="246"/>
+      <point x="164" y="129" type="qcurve" smooth="yes"/>
+      <point x="164" y="81"/>
+      <point x="193" y="45"/>
+      <point x="223" y="44" type="qcurve"/>
+      <point x="223" y="4" type="line"/>
+      <point x="99" y="-5" type="line"/>
+      <point x="89" y="10"/>
+      <point x="70" y="69"/>
+      <point x="70" y="121" type="qcurve" smooth="yes"/>
+      <point x="70" y="252"/>
+      <point x="206" y="422"/>
+      <point x="354" y="439" type="qcurve"/>
+      <point x="354" y="610" type="line" smooth="yes"/>
+      <point x="354" y="669"/>
+      <point x="308" y="669" type="qcurve"/>
+      <point x="308" y="709" type="line"/>
+      <point x="423" y="718" type="line"/>
+      <point x="437" y="710"/>
+      <point x="452" y="670"/>
+      <point x="452" y="647" type="qcurve" smooth="yes"/>
+      <point x="452" y="443" type="line"/>
+      <point x="580" y="440"/>
+      <point x="647" y="400" type="qcurve"/>
+      <point x="808" y="400" type="line"/>
+      <point x="800" y="400"/>
+      <point x="879" y="446"/>
+      <point x="917" y="446" type="qcurve" smooth="yes"/>
+      <point x="990" y="446" type="line" smooth="yes"/>
+      <point x="1040" y="446"/>
+      <point x="1090" y="393"/>
+      <point x="1090" y="343" type="qcurve" smooth="yes"/>
+      <point x="1090" y="310"/>
+      <point x="1063" y="252"/>
+      <point x="1014" y="216"/>
+      <point x="981" y="216" type="qcurve" smooth="yes"/>
+      <point x="870" y="216" type="line" smooth="yes"/>
+      <point x="831" y="216"/>
+      <point x="784" y="272"/>
+      <point x="784" y="316" type="qcurve" smooth="yes"/>
+      <point x="784" y="334"/>
+      <point x="787" y="350" type="qcurve"/>
+      <point x="700" y="350" type="line"/>
+      <point x="734" y="300"/>
+      <point x="734" y="222" type="qcurve" smooth="yes"/>
+      <point x="734" y="187" type="line"/>
+      <point x="844" y="187" type="line" smooth="yes"/>
+      <point x="977" y="187"/>
+      <point x="977" y="91" type="qcurve" smooth="yes"/>
+      <point x="977" y="39"/>
+      <point x="901" y="-35"/>
+      <point x="830" y="-35" type="qcurve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="801" y="0" type="qcurve" smooth="yes"/>
+      <point x="883" y="0"/>
+      <point x="883" y="87" type="qcurve" smooth="yes"/>
+      <point x="883" y="120"/>
+      <point x="848" y="149"/>
+      <point x="813" y="149" type="qcurve" smooth="yes"/>
+      <point x="734" y="149" type="line"/>
+      <point x="734" y="85" type="line" smooth="yes"/>
+      <point x="734" y="38"/>
+      <point x="769" y="0"/>
+    </contour>
+    <contour>
+      <point x="928" y="251" type="qcurve" smooth="yes"/>
+      <point x="966" y="251"/>
+      <point x="1007" y="304"/>
+      <point x="1007" y="342" type="qcurve" smooth="yes"/>
+      <point x="1007" y="372"/>
+      <point x="975" y="407"/>
+      <point x="944" y="407" type="qcurve" smooth="yes"/>
+      <point x="908" y="407"/>
+      <point x="867" y="359"/>
+      <point x="867" y="318" type="qcurve" smooth="yes"/>
+      <point x="867" y="288"/>
+      <point x="899" y="251"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhwi-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhwi-ethiopic.glif
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhwi-ethiopic" format="2">
+  <advance width="1150"/>
+  <unicode hex="1E7E9"/>
+  <anchor x="532" y="718" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="731" y="129" type="qcurve" smooth="yes"/>
+      <point x="731" y="79"/>
+      <point x="758" y="50"/>
+      <point x="787" y="50" type="qcurve" smooth="yes"/>
+      <point x="854" y="50" type="line"/>
+      <point x="859" y="76"/>
+      <point x="899" y="115"/>
+      <point x="939" y="115" type="qcurve" smooth="yes"/>
+      <point x="957" y="115"/>
+      <point x="988" y="106"/>
+      <point x="995" y="101" type="qcurve"/>
+      <point x="979" y="85"/>
+      <point x="964" y="49"/>
+      <point x="964" y="23" type="qcurve" smooth="yes"/>
+      <point x="964" y="-4"/>
+      <point x="982" y="-40"/>
+      <point x="995" y="-51" type="qcurve"/>
+      <point x="988" y="-57"/>
+      <point x="957" y="-67"/>
+      <point x="939" y="-67" type="qcurve" smooth="yes"/>
+      <point x="899" y="-67"/>
+      <point x="859" y="-27"/>
+      <point x="854" y="0" type="qcurve"/>
+      <point x="656" y="0" type="line"/>
+      <point x="647" y="14"/>
+      <point x="637" y="52"/>
+      <point x="637" y="81" type="qcurve" smooth="yes"/>
+      <point x="637" y="103"/>
+      <point x="638" y="159"/>
+      <point x="639" y="214"/>
+      <point x="639" y="232" type="qcurve" smooth="yes"/>
+      <point x="639" y="278"/>
+      <point x="605" y="348"/>
+      <point x="525" y="389"/>
+      <point x="456" y="394" type="qcurve"/>
+      <point x="456" y="111" type="line" smooth="yes"/>
+      <point x="456" y="71"/>
+      <point x="482" y="44"/>
+      <point x="505" y="44" type="qcurve"/>
+      <point x="505" y="4" type="line"/>
+      <point x="387" y="-5" type="line"/>
+      <point x="374" y="8"/>
+      <point x="358" y="45"/>
+      <point x="358" y="73" type="qcurve" smooth="yes"/>
+      <point x="358" y="391" type="line"/>
+      <point x="252" y="378"/>
+      <point x="164" y="247"/>
+      <point x="164" y="129" type="qcurve" smooth="yes"/>
+      <point x="164" y="81"/>
+      <point x="193" y="45"/>
+      <point x="223" y="44" type="qcurve"/>
+      <point x="223" y="4" type="line"/>
+      <point x="99" y="-5" type="line"/>
+      <point x="89" y="10"/>
+      <point x="70" y="69"/>
+      <point x="70" y="121" type="qcurve" smooth="yes"/>
+      <point x="70" y="252"/>
+      <point x="208" y="423"/>
+      <point x="358" y="439" type="qcurve"/>
+      <point x="358" y="610" type="line" smooth="yes"/>
+      <point x="358" y="669"/>
+      <point x="312" y="669" type="qcurve"/>
+      <point x="312" y="709" type="line"/>
+      <point x="427" y="718" type="line"/>
+      <point x="441" y="710"/>
+      <point x="456" y="670"/>
+      <point x="456" y="647" type="qcurve" smooth="yes"/>
+      <point x="456" y="442" type="line"/>
+      <point x="542" y="440"/>
+      <point x="602" y="424"/>
+      <point x="645" y="400" type="curve"/>
+      <point x="807" y="400" type="line"/>
+      <point x="799" y="400"/>
+      <point x="878" y="446"/>
+      <point x="916" y="446" type="qcurve" smooth="yes"/>
+      <point x="989" y="446" type="line" smooth="yes"/>
+      <point x="1039" y="446"/>
+      <point x="1089" y="393"/>
+      <point x="1089" y="343" type="qcurve" smooth="yes"/>
+      <point x="1089" y="310"/>
+      <point x="1062" y="252"/>
+      <point x="1013" y="216"/>
+      <point x="980" y="216" type="qcurve" smooth="yes"/>
+      <point x="869" y="216" type="line" smooth="yes"/>
+      <point x="830" y="216"/>
+      <point x="783" y="272"/>
+      <point x="783" y="316" type="qcurve" smooth="yes"/>
+      <point x="783" y="334"/>
+      <point x="786" y="350" type="qcurve"/>
+      <point x="702" y="350" type="line"/>
+      <point x="725" y="317"/>
+      <point x="734" y="277"/>
+      <point x="734" y="235" type="curve" smooth="yes"/>
+      <point x="734" y="215"/>
+      <point x="731" y="149"/>
+    </contour>
+    <contour>
+      <point x="927" y="251" type="qcurve" smooth="yes"/>
+      <point x="965" y="251"/>
+      <point x="1006" y="304"/>
+      <point x="1006" y="342" type="qcurve" smooth="yes"/>
+      <point x="1006" y="372"/>
+      <point x="974" y="407"/>
+      <point x="943" y="407" type="qcurve" smooth="yes"/>
+      <point x="907" y="407"/>
+      <point x="866" y="359"/>
+      <point x="866" y="318" type="qcurve" smooth="yes"/>
+      <point x="866" y="288"/>
+      <point x="898" y="251"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhya-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhya-ethiopic.glif
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhya-ethiopic" format="2">
+  <advance width="827"/>
+  <unicode hex="1E7E0"/>
+  <anchor x="428" y="718" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="659" y="-5" type="line"/>
+      <point x="637" y="24"/>
+      <point x="637" y="81" type="qcurve" smooth="yes"/>
+      <point x="637" y="103"/>
+      <point x="638" y="159"/>
+      <point x="639" y="214"/>
+      <point x="639" y="232" type="qcurve" smooth="yes"/>
+      <point x="639" y="278"/>
+      <point x="605" y="348"/>
+      <point x="524" y="390"/>
+      <point x="453" y="394" type="qcurve"/>
+      <point x="453" y="111" type="line" smooth="yes"/>
+      <point x="453" y="71"/>
+      <point x="479" y="44"/>
+      <point x="502" y="44" type="qcurve"/>
+      <point x="502" y="4" type="line"/>
+      <point x="384" y="-5" type="line"/>
+      <point x="371" y="8"/>
+      <point x="355" y="45"/>
+      <point x="355" y="73" type="qcurve" smooth="yes"/>
+      <point x="355" y="391" type="line"/>
+      <point x="251" y="377"/>
+      <point x="164" y="246"/>
+      <point x="164" y="129" type="qcurve" smooth="yes"/>
+      <point x="164" y="81"/>
+      <point x="193" y="45"/>
+      <point x="223" y="44" type="qcurve"/>
+      <point x="223" y="4" type="line"/>
+      <point x="99" y="-5" type="line"/>
+      <point x="89" y="10"/>
+      <point x="70" y="69"/>
+      <point x="70" y="121" type="qcurve" smooth="yes"/>
+      <point x="70" y="252"/>
+      <point x="207" y="422"/>
+      <point x="355" y="439" type="qcurve"/>
+      <point x="355" y="668" type="line"/>
+      <point x="260" y="668" type="line"/>
+      <point x="256" y="643"/>
+      <point x="213" y="602"/>
+      <point x="176" y="602" type="qcurve" smooth="yes"/>
+      <point x="158" y="602"/>
+      <point x="131" y="612"/>
+      <point x="123" y="617" type="qcurve"/>
+      <point x="139" y="633"/>
+      <point x="154" y="670"/>
+      <point x="154" y="695" type="qcurve" smooth="yes"/>
+      <point x="154" y="722"/>
+      <point x="136" y="758"/>
+      <point x="123" y="769" type="qcurve"/>
+      <point x="131" y="775"/>
+      <point x="158" y="784"/>
+      <point x="176" y="784" type="qcurve" smooth="yes"/>
+      <point x="213" y="784"/>
+      <point x="255" y="745"/>
+      <point x="260" y="718" type="qcurve"/>
+      <point x="545" y="718" type="line"/>
+      <point x="550" y="744"/>
+      <point x="592" y="784"/>
+      <point x="629" y="784" type="qcurve" smooth="yes"/>
+      <point x="647" y="784"/>
+      <point x="675" y="774"/>
+      <point x="682" y="769" type="qcurve"/>
+      <point x="666" y="753"/>
+      <point x="651" y="717"/>
+      <point x="651" y="691" type="qcurve" smooth="yes"/>
+      <point x="651" y="664"/>
+      <point x="669" y="628"/>
+      <point x="682" y="617" type="qcurve"/>
+      <point x="675" y="611"/>
+      <point x="647" y="602"/>
+      <point x="629" y="602" type="qcurve" smooth="yes"/>
+      <point x="592" y="602"/>
+      <point x="550" y="641"/>
+      <point x="545" y="668" type="qcurve"/>
+      <point x="453" y="668" type="line"/>
+      <point x="453" y="443" type="line"/>
+      <point x="563" y="439"/>
+      <point x="686" y="382"/>
+      <point x="734" y="290"/>
+      <point x="734" y="235" type="qcurve" smooth="yes"/>
+      <point x="734" y="215"/>
+      <point x="731" y="149"/>
+      <point x="731" y="129" type="qcurve" smooth="yes"/>
+      <point x="731" y="79"/>
+      <point x="758" y="46"/>
+      <point x="787" y="44" type="qcurve"/>
+      <point x="787" y="4" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhyaa-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhyaa-ethiopic.glif
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhyaa-ethiopic" format="2">
+  <advance width="782"/>
+  <unicode hex="1E7E3"/>
+  <anchor x="393" y="718" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="614" y="-5" type="line"/>
+      <point x="592" y="24"/>
+      <point x="592" y="81" type="qcurve" smooth="yes"/>
+      <point x="592" y="103"/>
+      <point x="593" y="159"/>
+      <point x="594" y="214"/>
+      <point x="594" y="232" type="qcurve" smooth="yes"/>
+      <point x="594" y="301"/>
+      <point x="518" y="387"/>
+      <point x="420" y="394" type="qcurve"/>
+      <point x="420" y="258" type="line" smooth="yes"/>
+      <point x="420" y="218"/>
+      <point x="446" y="191"/>
+      <point x="469" y="191" type="qcurve"/>
+      <point x="469" y="152" type="line"/>
+      <point x="351" y="143" type="line"/>
+      <point x="338" y="156"/>
+      <point x="322" y="193"/>
+      <point x="322" y="221" type="qcurve" smooth="yes"/>
+      <point x="322" y="392" type="line"/>
+      <point x="224" y="382"/>
+      <point x="139" y="302"/>
+      <point x="139" y="247" type="qcurve" smooth="yes"/>
+      <point x="139" y="224"/>
+      <point x="168" y="196"/>
+      <point x="198" y="195" type="qcurve"/>
+      <point x="198" y="153" type="line"/>
+      <point x="62" y="144" type="line"/>
+      <point x="55" y="160"/>
+      <point x="45" y="192"/>
+      <point x="45" y="219" type="qcurve" smooth="yes"/>
+      <point x="45" y="273"/>
+      <point x="104" y="366"/>
+      <point x="227" y="431"/>
+      <point x="322" y="440" type="qcurve"/>
+      <point x="322" y="669" type="line"/>
+      <point x="227" y="669" type="line"/>
+      <point x="223" y="644"/>
+      <point x="180" y="603"/>
+      <point x="143" y="603" type="qcurve" smooth="yes"/>
+      <point x="125" y="603"/>
+      <point x="98" y="613"/>
+      <point x="90" y="618" type="qcurve"/>
+      <point x="106" y="634"/>
+      <point x="121" y="671"/>
+      <point x="121" y="696" type="qcurve" smooth="yes"/>
+      <point x="121" y="723"/>
+      <point x="103" y="759"/>
+      <point x="90" y="770" type="qcurve"/>
+      <point x="98" y="776"/>
+      <point x="125" y="785"/>
+      <point x="143" y="785" type="qcurve" smooth="yes"/>
+      <point x="180" y="785"/>
+      <point x="222" y="746"/>
+      <point x="227" y="719" type="qcurve"/>
+      <point x="512" y="719" type="line"/>
+      <point x="517" y="745"/>
+      <point x="559" y="785"/>
+      <point x="596" y="785" type="qcurve" smooth="yes"/>
+      <point x="614" y="785"/>
+      <point x="642" y="775"/>
+      <point x="649" y="770" type="qcurve"/>
+      <point x="633" y="754"/>
+      <point x="618" y="718"/>
+      <point x="618" y="692" type="qcurve" smooth="yes"/>
+      <point x="618" y="665"/>
+      <point x="636" y="629"/>
+      <point x="649" y="618" type="qcurve"/>
+      <point x="642" y="612"/>
+      <point x="614" y="603"/>
+      <point x="596" y="603" type="qcurve" smooth="yes"/>
+      <point x="559" y="603"/>
+      <point x="517" y="642"/>
+      <point x="512" y="669" type="qcurve"/>
+      <point x="420" y="669" type="line"/>
+      <point x="420" y="442" type="line"/>
+      <point x="525" y="439"/>
+      <point x="642" y="381"/>
+      <point x="689" y="290"/>
+      <point x="689" y="235" type="qcurve" smooth="yes"/>
+      <point x="689" y="215"/>
+      <point x="686" y="149"/>
+      <point x="686" y="129" type="qcurve" smooth="yes"/>
+      <point x="686" y="81"/>
+      <point x="713" y="49"/>
+      <point x="742" y="47" type="qcurve"/>
+      <point x="742" y="4" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhye-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhye-ethiopic.glif
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhye-ethiopic" format="2">
+  <advance width="827"/>
+  <unicode hex="1E7E5"/>
+  <anchor x="428" y="819" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="392" y="-5" type="line"/>
+      <point x="379" y="8"/>
+      <point x="363" y="45"/>
+      <point x="363" y="73" type="qcurve" smooth="yes"/>
+      <point x="363" y="392" type="line"/>
+      <point x="254" y="379"/>
+      <point x="164" y="248"/>
+      <point x="164" y="129" type="qcurve" smooth="yes"/>
+      <point x="164" y="81"/>
+      <point x="193" y="45"/>
+      <point x="223" y="44" type="qcurve"/>
+      <point x="223" y="4" type="line"/>
+      <point x="99" y="-5" type="line"/>
+      <point x="89" y="10"/>
+      <point x="70" y="69"/>
+      <point x="70" y="121" type="qcurve" smooth="yes"/>
+      <point x="70" y="254"/>
+      <point x="211" y="425"/>
+      <point x="363" y="440" type="qcurve"/>
+      <point x="363" y="525" type="line" smooth="yes"/>
+      <point x="363" y="554"/>
+      <point x="343" y="579"/>
+      <point x="317" y="579" type="qcurve" smooth="yes"/>
+      <point x="207" y="579" type="line"/>
+      <point x="207" y="749" type="line"/>
+      <point x="144" y="749" type="line"/>
+      <point x="134" y="718"/>
+      <point x="94" y="682"/>
+      <point x="58" y="682" type="qcurve" smooth="yes"/>
+      <point x="41" y="682"/>
+      <point x="13" y="692"/>
+      <point x="5" y="699" type="qcurve"/>
+      <point x="19" y="710"/>
+      <point x="37" y="745"/>
+      <point x="37" y="773" type="qcurve" smooth="yes"/>
+      <point x="37" y="799"/>
+      <point x="22" y="834"/>
+      <point x="5" y="850" type="qcurve"/>
+      <point x="17" y="859"/>
+      <point x="46" y="866"/>
+      <point x="60" y="866" type="qcurve" smooth="yes"/>
+      <point x="97" y="866"/>
+      <point x="140" y="827"/>
+      <point x="146" y="801" type="qcurve"/>
+      <point x="366" y="801" type="line"/>
+      <point x="371" y="827"/>
+      <point x="413" y="866"/>
+      <point x="450" y="866" type="qcurve" smooth="yes"/>
+      <point x="470" y="866"/>
+      <point x="496" y="857"/>
+      <point x="504" y="850" type="qcurve"/>
+      <point x="488" y="834"/>
+      <point x="472" y="799"/>
+      <point x="472" y="774" type="qcurve" smooth="yes"/>
+      <point x="472" y="727"/>
+      <point x="504" y="699" type="qcurve"/>
+      <point x="497" y="692"/>
+      <point x="469" y="682"/>
+      <point x="451" y="682" type="qcurve" smooth="yes"/>
+      <point x="417" y="682"/>
+      <point x="375" y="718"/>
+      <point x="366" y="749" type="qcurve"/>
+      <point x="305" y="749" type="line"/>
+      <point x="305" y="629" type="line"/>
+      <point x="432" y="629" type="line"/>
+      <point x="461" y="611"/>
+      <point x="461" y="558" type="qcurve" smooth="yes"/>
+      <point x="461" y="442" type="line"/>
+      <point x="568" y="438"/>
+      <point x="687" y="381"/>
+      <point x="734" y="290"/>
+      <point x="734" y="235" type="qcurve" smooth="yes"/>
+      <point x="734" y="215"/>
+      <point x="731" y="149"/>
+      <point x="731" y="129" type="qcurve" smooth="yes"/>
+      <point x="731" y="79"/>
+      <point x="758" y="46"/>
+      <point x="787" y="44" type="qcurve"/>
+      <point x="787" y="4" type="line"/>
+      <point x="659" y="-5" type="line"/>
+      <point x="637" y="24"/>
+      <point x="637" y="81" type="qcurve" smooth="yes"/>
+      <point x="637" y="103"/>
+      <point x="638" y="159"/>
+      <point x="639" y="214"/>
+      <point x="639" y="232" type="qcurve" smooth="yes"/>
+      <point x="639" y="300"/>
+      <point x="562" y="386"/>
+      <point x="461" y="393" type="qcurve"/>
+      <point x="461" y="111" type="line" smooth="yes"/>
+      <point x="461" y="71"/>
+      <point x="487" y="44"/>
+      <point x="510" y="44" type="qcurve"/>
+      <point x="510" y="4" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhyee-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhyee-ethiopic.glif
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhyee-ethiopic" format="2">
+  <advance width="1002"/>
+  <unicode hex="1E7E4"/>
+  <anchor x="523" y="718" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="801" y="35" type="qcurve" smooth="yes"/>
+      <point x="883" y="35"/>
+      <point x="883" y="122" type="qcurve" smooth="yes"/>
+      <point x="883" y="155"/>
+      <point x="848" y="184"/>
+      <point x="813" y="184" type="qcurve" smooth="yes"/>
+      <point x="734" y="184" type="line"/>
+      <point x="734" y="120" type="line" smooth="yes"/>
+      <point x="734" y="73"/>
+      <point x="769" y="35"/>
+    </contour>
+    <contour>
+      <point x="733" y="0" type="line"/>
+      <point x="686" y="10"/>
+      <point x="639" y="62"/>
+      <point x="639" y="113" type="qcurve" smooth="yes"/>
+      <point x="639" y="232" type="line" smooth="yes"/>
+      <point x="639" y="278"/>
+      <point x="605" y="348"/>
+      <point x="523" y="390"/>
+      <point x="452" y="394" type="qcurve"/>
+      <point x="452" y="111" type="line" smooth="yes"/>
+      <point x="452" y="71"/>
+      <point x="478" y="44"/>
+      <point x="501" y="44" type="qcurve"/>
+      <point x="501" y="4" type="line"/>
+      <point x="383" y="-5" type="line"/>
+      <point x="370" y="8"/>
+      <point x="354" y="45"/>
+      <point x="354" y="73" type="qcurve" smooth="yes"/>
+      <point x="354" y="391" type="line"/>
+      <point x="251" y="377"/>
+      <point x="164" y="246"/>
+      <point x="164" y="129" type="qcurve" smooth="yes"/>
+      <point x="164" y="81"/>
+      <point x="193" y="45"/>
+      <point x="223" y="44" type="qcurve"/>
+      <point x="223" y="4" type="line"/>
+      <point x="99" y="-5" type="line"/>
+      <point x="89" y="10"/>
+      <point x="70" y="69"/>
+      <point x="70" y="121" type="qcurve" smooth="yes"/>
+      <point x="70" y="252"/>
+      <point x="206" y="422"/>
+      <point x="354" y="439" type="qcurve"/>
+      <point x="354" y="668" type="line"/>
+      <point x="259" y="668" type="line"/>
+      <point x="255" y="643"/>
+      <point x="212" y="602"/>
+      <point x="175" y="602" type="qcurve" smooth="yes"/>
+      <point x="157" y="602"/>
+      <point x="130" y="612"/>
+      <point x="122" y="617" type="qcurve"/>
+      <point x="138" y="633"/>
+      <point x="153" y="670"/>
+      <point x="153" y="695" type="qcurve" smooth="yes"/>
+      <point x="153" y="722"/>
+      <point x="135" y="758"/>
+      <point x="122" y="769" type="qcurve"/>
+      <point x="130" y="775"/>
+      <point x="157" y="784"/>
+      <point x="175" y="784" type="qcurve" smooth="yes"/>
+      <point x="212" y="784"/>
+      <point x="254" y="745"/>
+      <point x="259" y="718" type="qcurve"/>
+      <point x="544" y="718" type="line"/>
+      <point x="549" y="744"/>
+      <point x="591" y="784"/>
+      <point x="628" y="784" type="qcurve" smooth="yes"/>
+      <point x="646" y="784"/>
+      <point x="674" y="774"/>
+      <point x="681" y="769" type="qcurve"/>
+      <point x="665" y="753"/>
+      <point x="650" y="717"/>
+      <point x="650" y="691" type="qcurve" smooth="yes"/>
+      <point x="650" y="664"/>
+      <point x="668" y="628"/>
+      <point x="681" y="617" type="qcurve"/>
+      <point x="674" y="611"/>
+      <point x="646" y="602"/>
+      <point x="628" y="602" type="qcurve" smooth="yes"/>
+      <point x="591" y="602"/>
+      <point x="549" y="641"/>
+      <point x="544" y="668" type="qcurve"/>
+      <point x="452" y="668" type="line"/>
+      <point x="452" y="443" type="line"/>
+      <point x="603" y="439"/>
+      <point x="734" y="331"/>
+      <point x="734" y="222" type="qcurve"/>
+      <point x="844" y="222" type="line" smooth="yes"/>
+      <point x="977" y="222"/>
+      <point x="977" y="126" type="qcurve" smooth="yes"/>
+      <point x="977" y="74"/>
+      <point x="901" y="0"/>
+      <point x="830" y="0" type="qcurve" smooth="yes"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhyi-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhyi-ethiopic.glif
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhyi-ethiopic" format="2">
+  <advance width="1010"/>
+  <unicode hex="1E7E2"/>
+  <anchor x="532" y="718" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="656" y="0" type="line"/>
+      <point x="647" y="14"/>
+      <point x="637" y="52"/>
+      <point x="637" y="81" type="qcurve" smooth="yes"/>
+      <point x="637" y="103"/>
+      <point x="638" y="159"/>
+      <point x="639" y="214"/>
+      <point x="639" y="232" type="qcurve" smooth="yes"/>
+      <point x="639" y="278"/>
+      <point x="605" y="348"/>
+      <point x="525" y="389"/>
+      <point x="456" y="394" type="qcurve"/>
+      <point x="456" y="111" type="line" smooth="yes"/>
+      <point x="456" y="71"/>
+      <point x="482" y="44"/>
+      <point x="505" y="44" type="qcurve"/>
+      <point x="505" y="4" type="line"/>
+      <point x="387" y="-5" type="line"/>
+      <point x="374" y="8"/>
+      <point x="358" y="45"/>
+      <point x="358" y="73" type="qcurve" smooth="yes"/>
+      <point x="358" y="391" type="line"/>
+      <point x="252" y="378"/>
+      <point x="164" y="247"/>
+      <point x="164" y="129" type="qcurve" smooth="yes"/>
+      <point x="164" y="81"/>
+      <point x="193" y="45"/>
+      <point x="223" y="44" type="qcurve"/>
+      <point x="223" y="4" type="line"/>
+      <point x="99" y="-5" type="line"/>
+      <point x="89" y="10"/>
+      <point x="70" y="69"/>
+      <point x="70" y="121" type="qcurve" smooth="yes"/>
+      <point x="70" y="252"/>
+      <point x="208" y="423"/>
+      <point x="358" y="439" type="qcurve"/>
+      <point x="358" y="668" type="line"/>
+      <point x="263" y="668" type="line"/>
+      <point x="259" y="643"/>
+      <point x="216" y="602"/>
+      <point x="179" y="602" type="qcurve" smooth="yes"/>
+      <point x="161" y="602"/>
+      <point x="134" y="612"/>
+      <point x="126" y="617" type="qcurve"/>
+      <point x="142" y="633"/>
+      <point x="157" y="670"/>
+      <point x="157" y="695" type="qcurve" smooth="yes"/>
+      <point x="157" y="722"/>
+      <point x="139" y="758"/>
+      <point x="126" y="769" type="qcurve"/>
+      <point x="134" y="775"/>
+      <point x="161" y="784"/>
+      <point x="179" y="784" type="qcurve" smooth="yes"/>
+      <point x="216" y="784"/>
+      <point x="258" y="745"/>
+      <point x="263" y="718" type="qcurve"/>
+      <point x="548" y="718" type="line"/>
+      <point x="553" y="744"/>
+      <point x="595" y="784"/>
+      <point x="632" y="784" type="qcurve" smooth="yes"/>
+      <point x="650" y="784"/>
+      <point x="678" y="774"/>
+      <point x="685" y="769" type="qcurve"/>
+      <point x="669" y="753"/>
+      <point x="654" y="717"/>
+      <point x="654" y="691" type="qcurve" smooth="yes"/>
+      <point x="654" y="664"/>
+      <point x="672" y="628"/>
+      <point x="685" y="617" type="qcurve"/>
+      <point x="678" y="611"/>
+      <point x="650" y="602"/>
+      <point x="632" y="602" type="qcurve" smooth="yes"/>
+      <point x="595" y="602"/>
+      <point x="553" y="641"/>
+      <point x="548" y="668" type="qcurve"/>
+      <point x="456" y="668" type="line"/>
+      <point x="456" y="442" type="line"/>
+      <point x="565" y="439"/>
+      <point x="686" y="382"/>
+      <point x="734" y="290"/>
+      <point x="734" y="235" type="qcurve" smooth="yes"/>
+      <point x="734" y="215"/>
+      <point x="731" y="149"/>
+      <point x="731" y="129" type="qcurve" smooth="yes"/>
+      <point x="731" y="79"/>
+      <point x="758" y="50"/>
+      <point x="787" y="50" type="qcurve" smooth="yes"/>
+      <point x="854" y="50" type="line"/>
+      <point x="859" y="76"/>
+      <point x="899" y="115"/>
+      <point x="939" y="115" type="qcurve" smooth="yes"/>
+      <point x="957" y="115"/>
+      <point x="988" y="106"/>
+      <point x="995" y="101" type="qcurve"/>
+      <point x="979" y="85"/>
+      <point x="964" y="49"/>
+      <point x="964" y="23" type="qcurve" smooth="yes"/>
+      <point x="964" y="-4"/>
+      <point x="982" y="-40"/>
+      <point x="995" y="-51" type="qcurve"/>
+      <point x="988" y="-57"/>
+      <point x="957" y="-67"/>
+      <point x="939" y="-67" type="qcurve" smooth="yes"/>
+      <point x="899" y="-67"/>
+      <point x="859" y="-27"/>
+      <point x="854" y="0" type="qcurve"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhyo-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhyo-ethiopic.glif
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhyo-ethiopic" format="2">
+  <advance width="787"/>
+  <unicode hex="1E7E6"/>
+  <anchor x="418" y="718" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="636" y="142" type="line"/>
+      <point x="618" y="169"/>
+      <point x="618" y="212" type="qcurve" smooth="yes"/>
+      <point x="618" y="253" type="line" smooth="yes"/>
+      <point x="618" y="312"/>
+      <point x="544" y="387"/>
+      <point x="448" y="394" type="qcurve"/>
+      <point x="448" y="258" type="line" smooth="yes"/>
+      <point x="448" y="218"/>
+      <point x="474" y="191"/>
+      <point x="497" y="191" type="qcurve"/>
+      <point x="497" y="151" type="line"/>
+      <point x="379" y="142" type="line"/>
+      <point x="366" y="155"/>
+      <point x="350" y="192"/>
+      <point x="350" y="221" type="qcurve" smooth="yes"/>
+      <point x="350" y="391" type="line"/>
+      <point x="250" y="375"/>
+      <point x="164" y="241"/>
+      <point x="164" y="137" type="qcurve" smooth="yes"/>
+      <point x="164" y="85"/>
+      <point x="193" y="48"/>
+      <point x="223" y="47" type="qcurve"/>
+      <point x="223" y="4" type="line"/>
+      <point x="99" y="-5" type="line"/>
+      <point x="89" y="10"/>
+      <point x="70" y="69"/>
+      <point x="70" y="121" type="qcurve" smooth="yes"/>
+      <point x="70" y="252"/>
+      <point x="211" y="422"/>
+      <point x="350" y="439" type="qcurve"/>
+      <point x="350" y="668" type="line"/>
+      <point x="255" y="668" type="line"/>
+      <point x="251" y="643"/>
+      <point x="208" y="602"/>
+      <point x="171" y="602" type="qcurve" smooth="yes"/>
+      <point x="153" y="602"/>
+      <point x="126" y="612"/>
+      <point x="118" y="617" type="qcurve"/>
+      <point x="134" y="633"/>
+      <point x="149" y="670"/>
+      <point x="149" y="695" type="qcurve" smooth="yes"/>
+      <point x="149" y="722"/>
+      <point x="131" y="758"/>
+      <point x="118" y="769" type="qcurve"/>
+      <point x="126" y="775"/>
+      <point x="153" y="784"/>
+      <point x="171" y="784" type="qcurve" smooth="yes"/>
+      <point x="208" y="784"/>
+      <point x="250" y="745"/>
+      <point x="255" y="718" type="qcurve"/>
+      <point x="540" y="718" type="line"/>
+      <point x="545" y="744"/>
+      <point x="587" y="784"/>
+      <point x="624" y="784" type="qcurve" smooth="yes"/>
+      <point x="642" y="784"/>
+      <point x="670" y="774"/>
+      <point x="677" y="769" type="qcurve"/>
+      <point x="661" y="753"/>
+      <point x="646" y="717"/>
+      <point x="646" y="691" type="qcurve" smooth="yes"/>
+      <point x="646" y="664"/>
+      <point x="664" y="628"/>
+      <point x="677" y="617" type="qcurve"/>
+      <point x="670" y="611"/>
+      <point x="642" y="602"/>
+      <point x="624" y="602" type="qcurve" smooth="yes"/>
+      <point x="587" y="602"/>
+      <point x="545" y="641"/>
+      <point x="540" y="668" type="qcurve"/>
+      <point x="448" y="668" type="line"/>
+      <point x="448" y="442" type="line"/>
+      <point x="551" y="439"/>
+      <point x="667" y="388"/>
+      <point x="713" y="309"/>
+      <point x="713" y="264" type="qcurve" smooth="yes"/>
+      <point x="713" y="235" type="line" smooth="yes"/>
+      <point x="713" y="212"/>
+      <point x="738" y="196"/>
+      <point x="767" y="194" type="qcurve"/>
+      <point x="767" y="151" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhyu-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/hhyu-ethiopic.glif
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="hhyu-ethiopic" format="2">
+  <advance width="982"/>
+  <unicode hex="1E7E1"/>
+  <anchor x="518" y="718" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="659" y="-5" type="line"/>
+      <point x="637" y="24"/>
+      <point x="637" y="81" type="qcurve" smooth="yes"/>
+      <point x="637" y="103"/>
+      <point x="638" y="159"/>
+      <point x="639" y="214"/>
+      <point x="639" y="232" type="qcurve" smooth="yes"/>
+      <point x="639" y="278"/>
+      <point x="605" y="348"/>
+      <point x="524" y="390"/>
+      <point x="453" y="394" type="qcurve"/>
+      <point x="453" y="111" type="line" smooth="yes"/>
+      <point x="453" y="71"/>
+      <point x="479" y="44"/>
+      <point x="502" y="44" type="qcurve"/>
+      <point x="502" y="4" type="line"/>
+      <point x="384" y="-5" type="line"/>
+      <point x="371" y="8"/>
+      <point x="355" y="45"/>
+      <point x="355" y="73" type="qcurve" smooth="yes"/>
+      <point x="355" y="391" type="line"/>
+      <point x="251" y="377"/>
+      <point x="164" y="246"/>
+      <point x="164" y="129" type="qcurve" smooth="yes"/>
+      <point x="164" y="81"/>
+      <point x="193" y="45"/>
+      <point x="223" y="44" type="qcurve"/>
+      <point x="223" y="4" type="line"/>
+      <point x="99" y="-5" type="line"/>
+      <point x="89" y="10"/>
+      <point x="70" y="69"/>
+      <point x="70" y="121" type="qcurve" smooth="yes"/>
+      <point x="70" y="252"/>
+      <point x="207" y="422"/>
+      <point x="355" y="439" type="qcurve"/>
+      <point x="355" y="668" type="line"/>
+      <point x="260" y="668" type="line"/>
+      <point x="256" y="643"/>
+      <point x="213" y="602"/>
+      <point x="176" y="602" type="qcurve" smooth="yes"/>
+      <point x="158" y="602"/>
+      <point x="131" y="612"/>
+      <point x="123" y="617" type="qcurve"/>
+      <point x="139" y="633"/>
+      <point x="154" y="670"/>
+      <point x="154" y="695" type="qcurve" smooth="yes"/>
+      <point x="154" y="722"/>
+      <point x="136" y="758"/>
+      <point x="123" y="769" type="qcurve"/>
+      <point x="131" y="775"/>
+      <point x="158" y="784"/>
+      <point x="176" y="784" type="qcurve" smooth="yes"/>
+      <point x="213" y="784"/>
+      <point x="255" y="745"/>
+      <point x="260" y="718" type="qcurve"/>
+      <point x="545" y="718" type="line"/>
+      <point x="550" y="744"/>
+      <point x="592" y="784"/>
+      <point x="629" y="784" type="qcurve" smooth="yes"/>
+      <point x="647" y="784"/>
+      <point x="675" y="774"/>
+      <point x="682" y="769" type="qcurve"/>
+      <point x="666" y="753"/>
+      <point x="651" y="717"/>
+      <point x="651" y="691" type="qcurve" smooth="yes"/>
+      <point x="651" y="664"/>
+      <point x="669" y="628"/>
+      <point x="682" y="617" type="qcurve"/>
+      <point x="675" y="611"/>
+      <point x="647" y="602"/>
+      <point x="629" y="602" type="qcurve" smooth="yes"/>
+      <point x="592" y="602"/>
+      <point x="550" y="641"/>
+      <point x="545" y="668" type="qcurve"/>
+      <point x="453" y="668" type="line"/>
+      <point x="453" y="443" type="line"/>
+      <point x="546" y="440"/>
+      <point x="661" y="398"/>
+      <point x="720" y="328"/>
+      <point x="729" y="285" type="qcurve"/>
+      <point x="941" y="285" type="line"/>
+      <point x="939" y="278"/>
+      <point x="933" y="247"/>
+      <point x="933" y="229" type="qcurve" smooth="yes"/>
+      <point x="933" y="174"/>
+      <point x="967" y="146" type="qcurve"/>
+      <point x="945" y="130"/>
+      <point x="909" y="130" type="qcurve" smooth="yes"/>
+      <point x="866" y="130"/>
+      <point x="822" y="178"/>
+      <point x="822" y="212" type="qcurve" smooth="yes"/>
+      <point x="822" y="219"/>
+      <point x="823" y="230"/>
+      <point x="824" y="235" type="qcurve"/>
+      <point x="734" y="235" type="line"/>
+      <point x="734" y="215"/>
+      <point x="731" y="149"/>
+      <point x="731" y="129" type="qcurve" smooth="yes"/>
+      <point x="731" y="79"/>
+      <point x="758" y="46"/>
+      <point x="787" y="44" type="qcurve"/>
+      <point x="787" y="4" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/kweG_urage-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/kweG_urage-ethiopic.glif
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="kweGurage-ethiopic" format="2">
+  <advance width="1050"/>
+  <unicode hex="1E7F7"/>
+  <anchor x="347" y="768" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="846" y="254" type="qcurve" smooth="yes"/>
+      <point x="884" y="254"/>
+      <point x="925" y="307"/>
+      <point x="925" y="345" type="qcurve" smooth="yes"/>
+      <point x="925" y="375"/>
+      <point x="893" y="410"/>
+      <point x="862" y="410" type="qcurve" smooth="yes"/>
+      <point x="826" y="410"/>
+      <point x="785" y="362"/>
+      <point x="785" y="321" type="qcurve" smooth="yes"/>
+      <point x="785" y="291"/>
+      <point x="817" y="254"/>
+    </contour>
+    <contour>
+      <point x="517" y="-5" type="line"/>
+      <point x="491" y="22"/>
+      <point x="491" y="93" type="qcurve" smooth="yes"/>
+      <point x="491" y="162"/>
+      <point x="493" y="321"/>
+      <point x="493" y="393" type="qcurve" smooth="yes"/>
+      <point x="493" y="479"/>
+      <point x="449" y="565"/>
+      <point x="393" y="565" type="qcurve" smooth="yes"/>
+      <point x="323" y="565"/>
+      <point x="244" y="456"/>
+      <point x="244" y="360" type="qcurve"/>
+      <point x="366" y="360" type="line"/>
+      <point x="366" y="329" type="line"/>
+      <point x="299" y="319"/>
+      <point x="244" y="245"/>
+      <point x="244" y="182" type="qcurve" smooth="yes"/>
+      <point x="244" y="119" type="line" smooth="yes"/>
+      <point x="244" y="75"/>
+      <point x="272" y="46"/>
+      <point x="303" y="46" type="qcurve"/>
+      <point x="303" y="4" type="line"/>
+      <point x="170" y="-5" type="line"/>
+      <point x="156" y="10"/>
+      <point x="144" y="62"/>
+      <point x="144" y="93" type="qcurve" smooth="yes"/>
+      <point x="144" y="169" type="line" smooth="yes"/>
+      <point x="144" y="228"/>
+      <point x="191" y="301"/>
+      <point x="224" y="320" type="qcurve"/>
+      <point x="144" y="320" type="line"/>
+      <point x="144" y="375"/>
+      <point x="166" y="464"/>
+      <point x="186" y="498" type="qcurve"/>
+      <point x="161" y="494"/>
+      <point x="143" y="494" type="qcurve" smooth="yes"/>
+      <point x="113" y="494"/>
+      <point x="89" y="527"/>
+      <point x="89" y="558" type="qcurve" smooth="yes"/>
+      <point x="89" y="664" type="line" smooth="yes"/>
+      <point x="89" y="718"/>
+      <point x="45" y="718" type="qcurve"/>
+      <point x="45" y="760" type="line"/>
+      <point x="158" y="768" type="line"/>
+      <point x="169" y="758"/>
+      <point x="183" y="724"/>
+      <point x="183" y="689" type="qcurve" smooth="yes"/>
+      <point x="183" y="607" type="line" smooth="yes"/>
+      <point x="183" y="582"/>
+      <point x="202" y="554"/>
+      <point x="229" y="552" type="qcurve"/>
+      <point x="264" y="583"/>
+      <point x="355" y="613"/>
+      <point x="408" y="613" type="qcurve" smooth="yes"/>
+      <point x="507" y="613"/>
+      <point x="591" y="507"/>
+      <point x="594" y="403" type="qcurve"/>
+      <point x="726" y="403" type="line"/>
+      <point x="742" y="425"/>
+      <point x="797" y="449"/>
+      <point x="835" y="449" type="qcurve" smooth="yes"/>
+      <point x="908" y="449" type="line" smooth="yes"/>
+      <point x="958" y="449"/>
+      <point x="1008" y="396"/>
+      <point x="1008" y="346" type="qcurve" smooth="yes"/>
+      <point x="1008" y="313"/>
+      <point x="981" y="255"/>
+      <point x="932" y="219"/>
+      <point x="899" y="219" type="qcurve" smooth="yes"/>
+      <point x="788" y="219" type="line" smooth="yes"/>
+      <point x="749" y="219"/>
+      <point x="702" y="276"/>
+      <point x="702" y="319" type="qcurve" smooth="yes"/>
+      <point x="702" y="337"/>
+      <point x="705" y="353" type="qcurve"/>
+      <point x="594" y="353" type="line"/>
+      <point x="593" y="319"/>
+      <point x="592" y="235"/>
+      <point x="591" y="151"/>
+      <point x="591" y="119" type="qcurve" smooth="yes"/>
+      <point x="591" y="75"/>
+      <point x="619" y="46"/>
+      <point x="650" y="46" type="qcurve"/>
+      <point x="650" y="4" type="line"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/kweeG_urage-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/kweeG_urage-ethiopic.glif
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="kweeGurage-ethiopic" format="2">
+  <advance width="1050"/>
+  <unicode hex="1E7F6"/>
+  <anchor x="437" y="768" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="654" y="13" type="qcurve" smooth="yes"/>
+      <point x="736" y="13"/>
+      <point x="736" y="100" type="qcurve" smooth="yes"/>
+      <point x="736" y="133"/>
+      <point x="701" y="162"/>
+      <point x="666" y="162" type="qcurve" smooth="yes"/>
+      <point x="586" y="162" type="line"/>
+      <point x="586" y="68" type="line" smooth="yes"/>
+      <point x="586" y="36"/>
+      <point x="621" y="13"/>
+    </contour>
+    <contour>
+      <point x="839" y="285" type="qcurve" smooth="yes"/>
+      <point x="877" y="285"/>
+      <point x="918" y="338"/>
+      <point x="918" y="376" type="qcurve" smooth="yes"/>
+      <point x="918" y="406"/>
+      <point x="886" y="441"/>
+      <point x="855" y="441" type="qcurve" smooth="yes"/>
+      <point x="819" y="441"/>
+      <point x="778" y="393"/>
+      <point x="778" y="352" type="qcurve" smooth="yes"/>
+      <point x="778" y="322"/>
+      <point x="810" y="285"/>
+    </contour>
+    <contour>
+      <point x="556" y="-22" type="line"/>
+      <point x="524" y="-15"/>
+      <point x="486" y="25"/>
+      <point x="486" y="61" type="qcurve" smooth="yes"/>
+      <point x="486" y="105"/>
+      <point x="487" y="198"/>
+      <point x="487" y="307"/>
+      <point x="488" y="375"/>
+      <point x="488" y="392" type="qcurve" smooth="yes"/>
+      <point x="488" y="478"/>
+      <point x="444" y="564"/>
+      <point x="388" y="564" type="qcurve" smooth="yes"/>
+      <point x="341" y="564"/>
+      <point x="274" y="510"/>
+      <point x="239" y="390"/>
+      <point x="239" y="290" type="qcurve" smooth="yes"/>
+      <point x="239" y="120" type="line" smooth="yes"/>
+      <point x="239" y="76"/>
+      <point x="267" y="47"/>
+      <point x="298" y="47" type="qcurve"/>
+      <point x="298" y="5" type="line"/>
+      <point x="165" y="-4" type="line"/>
+      <point x="151" y="11"/>
+      <point x="139" y="63"/>
+      <point x="139" y="94" type="qcurve" smooth="yes"/>
+      <point x="139" y="315" type="line" smooth="yes"/>
+      <point x="139" y="371"/>
+      <point x="162" y="463"/>
+      <point x="183" y="498" type="qcurve"/>
+      <point x="160" y="494"/>
+      <point x="143" y="494" type="qcurve" smooth="yes"/>
+      <point x="113" y="494"/>
+      <point x="89" y="527"/>
+      <point x="89" y="558" type="qcurve" smooth="yes"/>
+      <point x="89" y="664" type="line" smooth="yes"/>
+      <point x="89" y="718"/>
+      <point x="45" y="718" type="qcurve"/>
+      <point x="45" y="760" type="line"/>
+      <point x="158" y="768" type="line"/>
+      <point x="169" y="758"/>
+      <point x="183" y="724"/>
+      <point x="183" y="689" type="qcurve" smooth="yes"/>
+      <point x="183" y="607" type="line" smooth="yes"/>
+      <point x="183" y="583"/>
+      <point x="202" y="554"/>
+      <point x="228" y="552" type="qcurve"/>
+      <point x="262" y="582"/>
+      <point x="351" y="612"/>
+      <point x="403" y="612" type="qcurve" smooth="yes"/>
+      <point x="502" y="612"/>
+      <point x="586" y="506"/>
+      <point x="587" y="434" type="qcurve"/>
+      <point x="719" y="434" type="line"/>
+      <point x="735" y="456"/>
+      <point x="790" y="480"/>
+      <point x="828" y="480" type="qcurve" smooth="yes"/>
+      <point x="901" y="480" type="line" smooth="yes"/>
+      <point x="951" y="480"/>
+      <point x="1001" y="427"/>
+      <point x="1001" y="377" type="qcurve" smooth="yes"/>
+      <point x="1001" y="344"/>
+      <point x="974" y="286"/>
+      <point x="925" y="250"/>
+      <point x="892" y="250" type="qcurve" smooth="yes"/>
+      <point x="781" y="250" type="line" smooth="yes"/>
+      <point x="742" y="250"/>
+      <point x="695" y="307"/>
+      <point x="695" y="350" type="qcurve" smooth="yes"/>
+      <point x="695" y="368"/>
+      <point x="698" y="384" type="qcurve"/>
+      <point x="587" y="384" type="line"/>
+      <point x="589" y="366"/>
+      <point x="587" y="302"/>
+      <point x="586" y="240"/>
+      <point x="586" y="200" type="qcurve"/>
+      <point x="697" y="200" type="line" smooth="yes"/>
+      <point x="830" y="200"/>
+      <point x="830" y="104" type="qcurve" smooth="yes"/>
+      <point x="830" y="52"/>
+      <point x="754" y="-22"/>
+      <point x="683" y="-22" type="qcurve" smooth="yes"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/kwiG_urage-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/kwiG_urage-ethiopic.glif
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="kwiGurage-ethiopic" format="2">
+  <advance width="1050"/>
+  <unicode hex="1E7F5"/>
+  <anchor x="419" y="768" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="845" y="254" type="qcurve" smooth="yes"/>
+      <point x="883" y="254"/>
+      <point x="924" y="307"/>
+      <point x="924" y="345" type="qcurve" smooth="yes"/>
+      <point x="924" y="375"/>
+      <point x="892" y="410"/>
+      <point x="861" y="410" type="qcurve" smooth="yes"/>
+      <point x="825" y="410"/>
+      <point x="784" y="362"/>
+      <point x="784" y="321" type="qcurve" smooth="yes"/>
+      <point x="784" y="291"/>
+      <point x="816" y="254"/>
+    </contour>
+    <contour>
+      <point x="516" y="0" type="line"/>
+      <point x="490" y="27"/>
+      <point x="490" y="98" type="qcurve" smooth="yes"/>
+      <point x="490" y="167"/>
+      <point x="492" y="321"/>
+      <point x="492" y="393" type="qcurve" smooth="yes"/>
+      <point x="492" y="479"/>
+      <point x="448" y="565"/>
+      <point x="392" y="565" type="qcurve" smooth="yes"/>
+      <point x="322" y="565"/>
+      <point x="243" y="443"/>
+      <point x="243" y="299" type="qcurve" smooth="yes"/>
+      <point x="243" y="119" type="line" smooth="yes"/>
+      <point x="243" y="75"/>
+      <point x="271" y="46"/>
+      <point x="302" y="46" type="qcurve"/>
+      <point x="302" y="4" type="line"/>
+      <point x="169" y="-5" type="line"/>
+      <point x="155" y="10"/>
+      <point x="143" y="62"/>
+      <point x="143" y="93" type="qcurve" smooth="yes"/>
+      <point x="143" y="324" type="line" smooth="yes"/>
+      <point x="143" y="377"/>
+      <point x="165" y="464"/>
+      <point x="186" y="498" type="qcurve"/>
+      <point x="161" y="494"/>
+      <point x="143" y="494" type="qcurve" smooth="yes"/>
+      <point x="113" y="494"/>
+      <point x="89" y="527"/>
+      <point x="89" y="558" type="qcurve" smooth="yes"/>
+      <point x="89" y="664" type="line" smooth="yes"/>
+      <point x="89" y="718"/>
+      <point x="45" y="718" type="qcurve"/>
+      <point x="45" y="760" type="line"/>
+      <point x="158" y="768" type="line"/>
+      <point x="169" y="758"/>
+      <point x="183" y="724"/>
+      <point x="183" y="689" type="qcurve" smooth="yes"/>
+      <point x="183" y="607" type="line" smooth="yes"/>
+      <point x="183" y="582"/>
+      <point x="202" y="554"/>
+      <point x="230" y="551" type="qcurve"/>
+      <point x="299" y="613"/>
+      <point x="407" y="613" type="qcurve" smooth="yes"/>
+      <point x="506" y="613"/>
+      <point x="590" y="507"/>
+      <point x="593" y="403" type="qcurve"/>
+      <point x="725" y="403" type="line"/>
+      <point x="741" y="425"/>
+      <point x="796" y="449"/>
+      <point x="834" y="449" type="qcurve" smooth="yes"/>
+      <point x="907" y="449" type="line" smooth="yes"/>
+      <point x="957" y="449"/>
+      <point x="1007" y="396"/>
+      <point x="1007" y="346" type="qcurve" smooth="yes"/>
+      <point x="1007" y="313"/>
+      <point x="980" y="255"/>
+      <point x="931" y="219"/>
+      <point x="898" y="219" type="qcurve" smooth="yes"/>
+      <point x="787" y="219" type="line" smooth="yes"/>
+      <point x="748" y="219"/>
+      <point x="701" y="276"/>
+      <point x="701" y="319" type="qcurve" smooth="yes"/>
+      <point x="701" y="337"/>
+      <point x="704" y="353" type="qcurve"/>
+      <point x="593" y="353" type="line"/>
+      <point x="592" y="319"/>
+      <point x="591" y="235"/>
+      <point x="590" y="151"/>
+      <point x="590" y="123" type="qcurve" smooth="yes"/>
+      <point x="590" y="79"/>
+      <point x="618" y="50"/>
+      <point x="649" y="50" type="qcurve" smooth="yes"/>
+      <point x="653" y="50" type="line"/>
+      <point x="658" y="76"/>
+      <point x="698" y="115"/>
+      <point x="738" y="115" type="qcurve" smooth="yes"/>
+      <point x="756" y="115"/>
+      <point x="787" y="106"/>
+      <point x="794" y="101" type="qcurve"/>
+      <point x="778" y="85"/>
+      <point x="763" y="49"/>
+      <point x="763" y="23" type="qcurve" smooth="yes"/>
+      <point x="763" y="-4"/>
+      <point x="781" y="-40"/>
+      <point x="794" y="-51" type="qcurve"/>
+      <point x="787" y="-57"/>
+      <point x="756" y="-67"/>
+      <point x="738" y="-67" type="qcurve" smooth="yes"/>
+      <point x="698" y="-67"/>
+      <point x="658" y="-27"/>
+      <point x="653" y="0" type="qcurve"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/mweeG_urage-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/mweeG_urage-ethiopic.glif
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="mweeGurage-ethiopic" format="2">
+  <advance width="1350"/>
+  <unicode hex="1E7EE"/>
+  <anchor x="485" y="714" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="645" y="0" type="line"/>
+      <point x="623" y="9"/>
+      <point x="596" y="47"/>
+      <point x="596" y="78" type="qcurve" smooth="yes"/>
+      <point x="596" y="95"/>
+      <point x="604" y="135"/>
+      <point x="614" y="159" type="qcurve" smooth="yes"/>
+      <point x="695" y="362" type="line"/>
+      <point x="642" y="362" type="line" smooth="yes"/>
+      <point x="566" y="362"/>
+      <point x="493" y="434"/>
+      <point x="493" y="507" type="qcurve" smooth="yes"/>
+      <point x="493" y="531"/>
+      <point x="501" y="619"/>
+      <point x="510" y="665" type="qcurve"/>
+      <point x="412" y="665" type="line"/>
+      <point x="412" y="360" type="line"/>
+      <point x="378" y="325"/>
+      <point x="278" y="280"/>
+      <point x="219" y="280" type="qcurve" smooth="yes"/>
+      <point x="131" y="280"/>
+      <point x="30" y="381"/>
+      <point x="30" y="477" type="qcurve" smooth="yes"/>
+      <point x="30" y="586"/>
+      <point x="162" y="714"/>
+      <point x="281" y="714" type="qcurve" smooth="yes"/>
+      <point x="677" y="714" type="line"/>
+      <point x="765" y="715"/>
+      <point x="809" y="679" type="qcurve" smooth="yes"/>
+      <point x="851" y="645"/>
+      <point x="853" y="583" type="qcurve"/>
+      <point x="1008" y="583" type="line"/>
+      <point x="1024" y="605"/>
+      <point x="1079" y="629"/>
+      <point x="1117" y="629" type="qcurve" smooth="yes"/>
+      <point x="1190" y="629" type="line" smooth="yes"/>
+      <point x="1240" y="629"/>
+      <point x="1290" y="576"/>
+      <point x="1290" y="526" type="qcurve" smooth="yes"/>
+      <point x="1290" y="493"/>
+      <point x="1263" y="435"/>
+      <point x="1214" y="399"/>
+      <point x="1181" y="399" type="qcurve" smooth="yes"/>
+      <point x="1070" y="399" type="line" smooth="yes"/>
+      <point x="1031" y="399"/>
+      <point x="984" y="456"/>
+      <point x="984" y="499" type="qcurve" smooth="yes"/>
+      <point x="984" y="517"/>
+      <point x="987" y="533" type="qcurve"/>
+      <point x="849" y="533" type="line"/>
+      <point x="849" y="535" type="line"/>
+      <point x="846" y="519"/>
+      <point x="841" y="501" type="qcurve" smooth="yes"/>
+      <point x="829" y="459"/>
+      <point x="798" y="384" type="qcurve" smooth="yes"/>
+      <point x="733" y="222" type="line"/>
+      <point x="807" y="222" type="line" smooth="yes"/>
+      <point x="940" y="222"/>
+      <point x="940" y="126" type="qcurve" smooth="yes"/>
+      <point x="940" y="74"/>
+      <point x="864" y="0"/>
+      <point x="793" y="0" type="qcurve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="229" y="331" type="qcurve" smooth="yes"/>
+      <point x="257" y="331"/>
+      <point x="299" y="350"/>
+      <point x="314" y="363" type="qcurve"/>
+      <point x="314" y="665" type="line"/>
+      <point x="287" y="665" type="line" smooth="yes"/>
+      <point x="213" y="665"/>
+      <point x="125" y="567"/>
+      <point x="125" y="475" type="qcurve" smooth="yes"/>
+      <point x="125" y="405"/>
+      <point x="179" y="331"/>
+    </contour>
+    <contour>
+      <point x="693" y="410" type="qcurve" smooth="yes"/>
+      <point x="717" y="410" type="line"/>
+      <point x="744" y="483" type="line"/>
+      <point x="752" y="503"/>
+      <point x="763" y="547"/>
+      <point x="763" y="570" type="qcurve" smooth="yes"/>
+      <point x="763" y="616"/>
+      <point x="713" y="665"/>
+      <point x="669" y="665" type="qcurve" smooth="yes"/>
+      <point x="602" y="665" type="line"/>
+      <point x="593" y="616"/>
+      <point x="585" y="541"/>
+      <point x="585" y="514" type="qcurve" smooth="yes"/>
+      <point x="585" y="456"/>
+      <point x="629" y="410"/>
+    </contour>
+    <contour>
+      <point x="734" y="42" type="qcurve" smooth="yes"/>
+      <point x="753" y="42" type="line" smooth="yes"/>
+      <point x="794" y="42"/>
+      <point x="846" y="80"/>
+      <point x="846" y="122" type="qcurve" smooth="yes"/>
+      <point x="846" y="155"/>
+      <point x="811" y="184"/>
+      <point x="776" y="184" type="qcurve" smooth="yes"/>
+      <point x="718" y="184" type="line"/>
+      <point x="697" y="131" type="line" smooth="yes"/>
+      <point x="687" y="105"/>
+      <point x="687" y="86" type="qcurve" smooth="yes"/>
+      <point x="687" y="42"/>
+    </contour>
+    <contour>
+      <point x="1128" y="434" type="qcurve" smooth="yes"/>
+      <point x="1166" y="434"/>
+      <point x="1207" y="487"/>
+      <point x="1207" y="525" type="qcurve" smooth="yes"/>
+      <point x="1207" y="555"/>
+      <point x="1175" y="590"/>
+      <point x="1144" y="590" type="qcurve" smooth="yes"/>
+      <point x="1108" y="590"/>
+      <point x="1067" y="542"/>
+      <point x="1067" y="501" type="qcurve" smooth="yes"/>
+      <point x="1067" y="471"/>
+      <point x="1099" y="434"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/mwiG_urage-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/mwiG_urage-ethiopic.glif
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="mwiGurage-ethiopic" format="2">
+  <advance width="1350"/>
+  <unicode hex="1E7ED"/>
+  <anchor x="485" y="714" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="590" y="0" type="line"/>
+      <point x="581" y="18"/>
+      <point x="581" y="42" type="qcurve" smooth="yes"/>
+      <point x="581" y="59"/>
+      <point x="591" y="101"/>
+      <point x="602" y="129" type="qcurve" smooth="yes"/>
+      <point x="695" y="362" type="line"/>
+      <point x="642" y="362" type="line" smooth="yes"/>
+      <point x="566" y="362"/>
+      <point x="493" y="434"/>
+      <point x="493" y="507" type="qcurve" smooth="yes"/>
+      <point x="493" y="531"/>
+      <point x="501" y="619"/>
+      <point x="510" y="665" type="qcurve"/>
+      <point x="412" y="665" type="line"/>
+      <point x="412" y="360" type="line"/>
+      <point x="378" y="325"/>
+      <point x="278" y="280"/>
+      <point x="219" y="280" type="qcurve" smooth="yes"/>
+      <point x="131" y="280"/>
+      <point x="30" y="381"/>
+      <point x="30" y="477" type="qcurve" smooth="yes"/>
+      <point x="30" y="586"/>
+      <point x="162" y="714"/>
+      <point x="281" y="714" type="qcurve" smooth="yes"/>
+      <point x="677" y="714" type="line"/>
+      <point x="765" y="715"/>
+      <point x="809" y="679" type="qcurve" smooth="yes"/>
+      <point x="851" y="645"/>
+      <point x="853" y="583" type="qcurve"/>
+      <point x="1007" y="583" type="line"/>
+      <point x="1023" y="605"/>
+      <point x="1078" y="629"/>
+      <point x="1116" y="629" type="qcurve" smooth="yes"/>
+      <point x="1189" y="629" type="line" smooth="yes"/>
+      <point x="1239" y="629"/>
+      <point x="1289" y="576"/>
+      <point x="1289" y="526" type="qcurve" smooth="yes"/>
+      <point x="1289" y="493"/>
+      <point x="1262" y="435"/>
+      <point x="1213" y="399"/>
+      <point x="1180" y="399" type="qcurve" smooth="yes"/>
+      <point x="1069" y="399" type="line" smooth="yes"/>
+      <point x="1030" y="399"/>
+      <point x="983" y="456"/>
+      <point x="983" y="499" type="qcurve" smooth="yes"/>
+      <point x="983" y="517"/>
+      <point x="986" y="533" type="qcurve"/>
+      <point x="848" y="533" type="line"/>
+      <point x="846" y="518"/>
+      <point x="841" y="501" type="qcurve" smooth="yes"/>
+      <point x="829" y="459"/>
+      <point x="798" y="384" type="qcurve" smooth="yes"/>
+      <point x="697" y="131" type="line" smooth="yes"/>
+      <point x="683" y="97"/>
+      <point x="683" y="79" type="qcurve" smooth="yes"/>
+      <point x="683" y="50"/>
+      <point x="724" y="50" type="qcurve" smooth="yes"/>
+      <point x="800" y="50" type="line"/>
+      <point x="805" y="76"/>
+      <point x="845" y="115"/>
+      <point x="885" y="115" type="qcurve" smooth="yes"/>
+      <point x="903" y="115"/>
+      <point x="934" y="106"/>
+      <point x="941" y="101" type="qcurve"/>
+      <point x="925" y="85"/>
+      <point x="910" y="49"/>
+      <point x="910" y="23" type="qcurve" smooth="yes"/>
+      <point x="910" y="-4"/>
+      <point x="928" y="-40"/>
+      <point x="941" y="-51" type="qcurve"/>
+      <point x="934" y="-57"/>
+      <point x="903" y="-67"/>
+      <point x="885" y="-67" type="qcurve" smooth="yes"/>
+      <point x="845" y="-67"/>
+      <point x="805" y="-27"/>
+      <point x="800" y="0" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="229" y="331" type="qcurve" smooth="yes"/>
+      <point x="257" y="331"/>
+      <point x="299" y="350"/>
+      <point x="314" y="363" type="qcurve"/>
+      <point x="314" y="665" type="line"/>
+      <point x="287" y="665" type="line" smooth="yes"/>
+      <point x="213" y="665"/>
+      <point x="125" y="567"/>
+      <point x="125" y="475" type="qcurve" smooth="yes"/>
+      <point x="125" y="405"/>
+      <point x="179" y="331"/>
+    </contour>
+    <contour>
+      <point x="693" y="410" type="qcurve" smooth="yes"/>
+      <point x="717" y="410" type="line"/>
+      <point x="744" y="483" type="line"/>
+      <point x="752" y="503"/>
+      <point x="763" y="547"/>
+      <point x="763" y="570" type="qcurve" smooth="yes"/>
+      <point x="763" y="616"/>
+      <point x="713" y="665"/>
+      <point x="669" y="665" type="qcurve" smooth="yes"/>
+      <point x="602" y="665" type="line"/>
+      <point x="593" y="616"/>
+      <point x="585" y="541"/>
+      <point x="585" y="514" type="qcurve" smooth="yes"/>
+      <point x="585" y="456"/>
+      <point x="629" y="410"/>
+    </contour>
+    <contour>
+      <point x="1127" y="434" type="qcurve" smooth="yes"/>
+      <point x="1165" y="434"/>
+      <point x="1206" y="487"/>
+      <point x="1206" y="525" type="qcurve" smooth="yes"/>
+      <point x="1206" y="555"/>
+      <point x="1174" y="590"/>
+      <point x="1143" y="590" type="qcurve" smooth="yes"/>
+      <point x="1107" y="590"/>
+      <point x="1066" y="542"/>
+      <point x="1066" y="501" type="qcurve" smooth="yes"/>
+      <point x="1066" y="471"/>
+      <point x="1098" y="434"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/pweeG_urage-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/pweeG_urage-ethiopic.glif
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="pweeGurage-ethiopic" format="2">
+  <advance width="850"/>
+  <unicode hex="1E7FE"/>
+  <anchor x="330" y="714" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="446" y="13" type="qcurve" smooth="yes"/>
+      <point x="528" y="13"/>
+      <point x="528" y="100" type="qcurve" smooth="yes"/>
+      <point x="528" y="133"/>
+      <point x="493" y="162"/>
+      <point x="458" y="162" type="qcurve" smooth="yes"/>
+      <point x="381" y="162" type="line"/>
+      <point x="381" y="98" type="line" smooth="yes"/>
+      <point x="381" y="51"/>
+      <point x="413" y="13"/>
+    </contour>
+    <contour>
+      <point x="642" y="281" type="qcurve" smooth="yes"/>
+      <point x="680" y="281"/>
+      <point x="721" y="334"/>
+      <point x="721" y="372" type="qcurve" smooth="yes"/>
+      <point x="721" y="402"/>
+      <point x="689" y="437"/>
+      <point x="658" y="437" type="qcurve" smooth="yes"/>
+      <point x="610" y="437"/>
+      <point x="581" y="403"/>
+      <point x="581" y="348" type="curve" smooth="yes"/>
+      <point x="581" y="318"/>
+      <point x="613" y="281"/>
+    </contour>
+    <contour>
+      <point x="378" y="-22" type="line"/>
+      <point x="331" y="-12"/>
+      <point x="283" y="40"/>
+      <point x="283" y="91" type="qcurve" smooth="yes"/>
+      <point x="283" y="664" type="line"/>
+      <point x="158" y="664" type="line"/>
+      <point x="159" y="659"/>
+      <point x="160" y="648"/>
+      <point x="160" y="641" type="qcurve" smooth="yes"/>
+      <point x="160" y="607"/>
+      <point x="117" y="559"/>
+      <point x="73" y="559" type="qcurve" smooth="yes"/>
+      <point x="37" y="559"/>
+      <point x="15" y="575" type="qcurve"/>
+      <point x="49" y="603"/>
+      <point x="49" y="658" type="qcurve" smooth="yes"/>
+      <point x="49" y="676"/>
+      <point x="43" y="707"/>
+      <point x="41" y="714" type="qcurve"/>
+      <point x="620" y="714" type="line"/>
+      <point x="618" y="707"/>
+      <point x="612" y="676"/>
+      <point x="612" y="658" type="qcurve" smooth="yes"/>
+      <point x="612" y="603"/>
+      <point x="646" y="575" type="qcurve"/>
+      <point x="624" y="559"/>
+      <point x="588" y="559" type="qcurve" smooth="yes"/>
+      <point x="545" y="559"/>
+      <point x="501" y="607"/>
+      <point x="501" y="641" type="qcurve" smooth="yes"/>
+      <point x="501" y="648"/>
+      <point x="502" y="659"/>
+      <point x="503" y="664" type="qcurve"/>
+      <point x="381" y="664" type="line"/>
+      <point x="381" y="430" type="line"/>
+      <point x="522" y="430" type="line"/>
+      <point x="538" y="452"/>
+      <point x="593" y="476"/>
+      <point x="631" y="476" type="qcurve" smooth="yes"/>
+      <point x="704" y="476" type="line" smooth="yes"/>
+      <point x="754" y="476"/>
+      <point x="804" y="423"/>
+      <point x="804" y="373" type="qcurve" smooth="yes"/>
+      <point x="804" y="340"/>
+      <point x="777" y="282"/>
+      <point x="728" y="246"/>
+      <point x="695" y="246" type="qcurve" smooth="yes"/>
+      <point x="584" y="246" type="line" smooth="yes"/>
+      <point x="545" y="246"/>
+      <point x="498" y="303"/>
+      <point x="498" y="346" type="qcurve" smooth="yes"/>
+      <point x="498" y="364"/>
+      <point x="501" y="380" type="qcurve"/>
+      <point x="381" y="380" type="line"/>
+      <point x="381" y="200" type="line"/>
+      <point x="489" y="200" type="line" smooth="yes"/>
+      <point x="622" y="200"/>
+      <point x="622" y="104" type="qcurve"/>
+      <point x="622" y="52"/>
+      <point x="546" y="-22"/>
+      <point x="475" y="-22" type="qcurve" smooth="yes"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/pwiG_urage-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/pwiG_urage-ethiopic.glif
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="pwiGurage-ethiopic" format="2">
+  <advance width="855"/>
+  <unicode hex="1E7FD"/>
+  <anchor x="330" y="714" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="644" y="215" type="qcurve" smooth="yes"/>
+      <point x="682" y="215"/>
+      <point x="723" y="268"/>
+      <point x="723" y="306" type="qcurve" smooth="yes"/>
+      <point x="723" y="336"/>
+      <point x="691" y="371"/>
+      <point x="660" y="371" type="qcurve" smooth="yes"/>
+      <point x="612" y="371"/>
+      <point x="583" y="337"/>
+      <point x="583" y="282" type="curve" smooth="yes"/>
+      <point x="583" y="252"/>
+      <point x="615" y="215"/>
+    </contour>
+    <contour>
+      <point x="314" y="0" type="line"/>
+      <point x="301" y="13"/>
+      <point x="285" y="50"/>
+      <point x="285" y="78" type="qcurve" smooth="yes"/>
+      <point x="285" y="664" type="line"/>
+      <point x="158" y="664" type="line"/>
+      <point x="159" y="659"/>
+      <point x="160" y="648"/>
+      <point x="160" y="641" type="qcurve" smooth="yes"/>
+      <point x="160" y="607"/>
+      <point x="117" y="559"/>
+      <point x="73" y="559" type="qcurve" smooth="yes"/>
+      <point x="37" y="559"/>
+      <point x="15" y="575" type="qcurve"/>
+      <point x="49" y="603"/>
+      <point x="49" y="658" type="qcurve" smooth="yes"/>
+      <point x="49" y="676"/>
+      <point x="43" y="707"/>
+      <point x="41" y="714" type="qcurve"/>
+      <point x="620" y="714" type="line"/>
+      <point x="618" y="707"/>
+      <point x="612" y="676"/>
+      <point x="612" y="658" type="qcurve" smooth="yes"/>
+      <point x="612" y="603"/>
+      <point x="646" y="575" type="qcurve"/>
+      <point x="624" y="559"/>
+      <point x="588" y="559" type="qcurve" smooth="yes"/>
+      <point x="545" y="559"/>
+      <point x="501" y="607"/>
+      <point x="501" y="641" type="qcurve" smooth="yes"/>
+      <point x="501" y="648"/>
+      <point x="502" y="659"/>
+      <point x="503" y="664" type="qcurve"/>
+      <point x="383" y="664" type="line"/>
+      <point x="383" y="364" type="line"/>
+      <point x="524" y="364" type="line"/>
+      <point x="540" y="386"/>
+      <point x="595" y="410"/>
+      <point x="633" y="410" type="qcurve" smooth="yes"/>
+      <point x="706" y="410" type="line" smooth="yes"/>
+      <point x="756" y="410"/>
+      <point x="806" y="357"/>
+      <point x="806" y="307" type="qcurve" smooth="yes"/>
+      <point x="806" y="274"/>
+      <point x="779" y="216"/>
+      <point x="730" y="180"/>
+      <point x="697" y="180" type="qcurve" smooth="yes"/>
+      <point x="586" y="180" type="line" smooth="yes"/>
+      <point x="547" y="180"/>
+      <point x="500" y="237"/>
+      <point x="500" y="280" type="qcurve" smooth="yes"/>
+      <point x="500" y="298"/>
+      <point x="503" y="314" type="qcurve"/>
+      <point x="383" y="314" type="line"/>
+      <point x="383" y="116" type="line" smooth="yes"/>
+      <point x="383" y="76"/>
+      <point x="409" y="50"/>
+      <point x="432" y="50" type="qcurve" smooth="yes"/>
+      <point x="461" y="50" type="line"/>
+      <point x="466" y="76"/>
+      <point x="506" y="115"/>
+      <point x="546" y="115" type="qcurve" smooth="yes"/>
+      <point x="564" y="115"/>
+      <point x="595" y="106"/>
+      <point x="602" y="101" type="qcurve"/>
+      <point x="586" y="85"/>
+      <point x="571" y="49"/>
+      <point x="571" y="23" type="qcurve" smooth="yes"/>
+      <point x="571" y="-4"/>
+      <point x="589" y="-40"/>
+      <point x="602" y="-51" type="qcurve"/>
+      <point x="595" y="-57"/>
+      <point x="564" y="-67"/>
+      <point x="546" y="-67" type="qcurve" smooth="yes"/>
+      <point x="506" y="-67"/>
+      <point x="466" y="-27"/>
+      <point x="461" y="0" type="qcurve"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/qweG_urage-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/qweG_urage-ethiopic.glif
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="qweGurage-ethiopic" format="2">
+  <advance width="1075"/>
+  <unicode hex="1E7F2"/>
+  <anchor x="314" y="819" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="293" y="-5" type="line"/>
+      <point x="280" y="8"/>
+      <point x="264" y="45"/>
+      <point x="264" y="73" type="qcurve" smooth="yes"/>
+      <point x="264" y="245" type="line"/>
+      <point x="137" y="247"/>
+      <point x="24" y="321"/>
+      <point x="24" y="400" type="qcurve" smooth="yes"/>
+      <point x="24" y="474"/>
+      <point x="138" y="553"/>
+      <point x="264" y="555" type="qcurve"/>
+      <point x="264" y="610" type="line" smooth="yes"/>
+      <point x="264" y="639"/>
+      <point x="244" y="664"/>
+      <point x="218" y="664" type="qcurve" smooth="yes"/>
+      <point x="46" y="664" type="line"/>
+      <point x="48" y="671"/>
+      <point x="54" y="702"/>
+      <point x="54" y="720" type="qcurve" smooth="yes"/>
+      <point x="54" y="775"/>
+      <point x="20" y="803" type="qcurve"/>
+      <point x="42" y="819"/>
+      <point x="78" y="819" type="qcurve" smooth="yes"/>
+      <point x="122" y="819"/>
+      <point x="165" y="772"/>
+      <point x="165" y="737" type="qcurve" smooth="yes"/>
+      <point x="165" y="730"/>
+      <point x="164" y="719"/>
+      <point x="163" y="714" type="qcurve"/>
+      <point x="333" y="714" type="line"/>
+      <point x="347" y="706"/>
+      <point x="362" y="669"/>
+      <point x="362" y="649" type="qcurve" smooth="yes"/>
+      <point x="362" y="555" type="line"/>
+      <point x="492" y="554"/>
+      <point x="550" y="517" type="qcurve" smooth="yes"/>
+      <point x="598" y="486"/>
+      <point x="606" y="425" type="qcurve"/>
+      <point x="746" y="425" type="line"/>
+      <point x="780" y="452"/>
+      <point x="843" y="452" type="qcurve" smooth="yes"/>
+      <point x="916" y="452" type="line" smooth="yes"/>
+      <point x="1016" y="452"/>
+      <point x="1016" y="365" type="qcurve" smooth="yes"/>
+      <point x="1016" y="321"/>
+      <point x="956" y="254"/>
+      <point x="907" y="254" type="qcurve" smooth="yes"/>
+      <point x="796" y="254" type="line" smooth="yes"/>
+      <point x="757" y="254"/>
+      <point x="710" y="303"/>
+      <point x="710" y="341" type="qcurve" smooth="yes"/>
+      <point x="710" y="360"/>
+      <point x="714" y="375" type="qcurve"/>
+      <point x="606" y="375" type="line"/>
+      <point x="598" y="319"/>
+      <point x="550" y="286" type="qcurve" smooth="yes"/>
+      <point x="492" y="246"/>
+      <point x="362" y="245" type="qcurve"/>
+      <point x="362" y="111" type="line" smooth="yes"/>
+      <point x="362" y="71"/>
+      <point x="388" y="44"/>
+      <point x="411" y="44" type="qcurve"/>
+      <point x="411" y="4" type="line"/>
+    </contour>
+    <contour>
+      <point x="511" y="404" type="qcurve" smooth="yes"/>
+      <point x="511" y="435"/>
+      <point x="490" y="480"/>
+      <point x="426" y="506"/>
+      <point x="362" y="506" type="qcurve"/>
+      <point x="362" y="294" type="line"/>
+      <point x="448" y="295"/>
+      <point x="511" y="350"/>
+    </contour>
+    <contour>
+      <point x="120" y="397" type="qcurve" smooth="yes"/>
+      <point x="120" y="367"/>
+      <point x="143" y="322"/>
+      <point x="205" y="296"/>
+      <point x="264" y="294" type="qcurve"/>
+      <point x="264" y="506" type="line"/>
+      <point x="182" y="504"/>
+      <point x="120" y="450"/>
+    </contour>
+    <contour>
+      <point x="854" y="291" type="qcurve" smooth="yes"/>
+      <point x="892" y="291"/>
+      <point x="933" y="333"/>
+      <point x="933" y="363" type="qcurve" smooth="yes"/>
+      <point x="933" y="387"/>
+      <point x="901" y="415"/>
+      <point x="870" y="415" type="qcurve" smooth="yes"/>
+      <point x="834" y="415"/>
+      <point x="793" y="378"/>
+      <point x="793" y="344" type="qcurve" smooth="yes"/>
+      <point x="793" y="321"/>
+      <point x="825" y="291"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/qweeG_urage-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/qweeG_urage-ethiopic.glif
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="qweeGurage-ethiopic" format="2">
+  <advance width="1075"/>
+  <unicode hex="1E7F1"/>
+  <anchor x="312" y="718" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="116" y="430" type="qcurve" smooth="yes"/>
+      <point x="116" y="404"/>
+      <point x="141" y="363"/>
+      <point x="206" y="340"/>
+      <point x="266" y="340" type="qcurve"/>
+      <point x="266" y="526" type="line"/>
+      <point x="180" y="525"/>
+      <point x="116" y="477"/>
+    </contour>
+    <contour>
+      <point x="507" y="437" type="qcurve" smooth="yes"/>
+      <point x="507" y="462"/>
+      <point x="487" y="501"/>
+      <point x="426" y="525"/>
+      <point x="364" y="526" type="qcurve"/>
+      <point x="364" y="340" type="line"/>
+      <point x="446" y="342"/>
+      <point x="507" y="390"/>
+    </contour>
+    <contour>
+      <point x="429" y="35" type="qcurve" smooth="yes"/>
+      <point x="511" y="35"/>
+      <point x="511" y="112" type="qcurve" smooth="yes"/>
+      <point x="511" y="141"/>
+      <point x="476" y="167"/>
+      <point x="441" y="167" type="qcurve" smooth="yes"/>
+      <point x="364" y="167" type="line"/>
+      <point x="364" y="110" type="line" smooth="yes"/>
+      <point x="364" y="68"/>
+      <point x="398" y="35"/>
+    </contour>
+    <contour>
+      <point x="850" y="324" type="qcurve" smooth="yes"/>
+      <point x="888" y="324"/>
+      <point x="929" y="366"/>
+      <point x="929" y="396" type="qcurve" smooth="yes"/>
+      <point x="929" y="420"/>
+      <point x="897" y="448"/>
+      <point x="866" y="448" type="qcurve" smooth="yes"/>
+      <point x="830" y="448"/>
+      <point x="789" y="411"/>
+      <point x="789" y="377" type="qcurve" smooth="yes"/>
+      <point x="789" y="354"/>
+      <point x="821" y="324"/>
+    </contour>
+    <contour>
+      <point x="361" y="0" type="line"/>
+      <point x="314" y="9"/>
+      <point x="266" y="57"/>
+      <point x="266" y="103" type="qcurve" smooth="yes"/>
+      <point x="266" y="291" type="line"/>
+      <point x="135" y="292"/>
+      <point x="20" y="360"/>
+      <point x="20" y="433" type="qcurve" smooth="yes"/>
+      <point x="20" y="503"/>
+      <point x="139" y="575"/>
+      <point x="266" y="575" type="qcurve"/>
+      <point x="266" y="610" type="line" smooth="yes"/>
+      <point x="266" y="669"/>
+      <point x="220" y="669" type="qcurve"/>
+      <point x="220" y="709" type="line"/>
+      <point x="335" y="718" type="line"/>
+      <point x="349" y="710"/>
+      <point x="364" y="670"/>
+      <point x="364" y="647" type="qcurve" smooth="yes"/>
+      <point x="364" y="575" type="line"/>
+      <point x="492" y="574"/>
+      <point x="548" y="540" type="qcurve" smooth="yes"/>
+      <point x="594" y="513"/>
+      <point x="602" y="458" type="qcurve"/>
+      <point x="742" y="458" type="line"/>
+      <point x="776" y="485"/>
+      <point x="839" y="485" type="qcurve" smooth="yes"/>
+      <point x="912" y="485" type="line" smooth="yes"/>
+      <point x="1012" y="485"/>
+      <point x="1012" y="398" type="qcurve" smooth="yes"/>
+      <point x="1012" y="354"/>
+      <point x="952" y="287"/>
+      <point x="903" y="287" type="qcurve" smooth="yes"/>
+      <point x="792" y="287" type="line" smooth="yes"/>
+      <point x="753" y="287"/>
+      <point x="706" y="336"/>
+      <point x="706" y="374" type="qcurve" smooth="yes"/>
+      <point x="706" y="393"/>
+      <point x="710" y="408" type="qcurve"/>
+      <point x="602" y="408" type="line"/>
+      <point x="593" y="360"/>
+      <point x="547" y="330" type="qcurve" smooth="yes"/>
+      <point x="490" y="294"/>
+      <point x="364" y="291" type="qcurve"/>
+      <point x="364" y="203" type="line"/>
+      <point x="472" y="203" type="line" smooth="yes"/>
+      <point x="605" y="203"/>
+      <point x="605" y="115" type="qcurve" smooth="yes"/>
+      <point x="605" y="68"/>
+      <point x="529" y="0"/>
+      <point x="458" y="0" type="qcurve" smooth="yes"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/qwiG_urage-ethiopic.glif
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/glyphs/qwiG_urage-ethiopic.glif
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glyph name="qwiGurage-ethiopic" format="2">
+  <advance width="1075"/>
+  <unicode hex="1E7F0"/>
+  <anchor x="314" y="718" name="t.uni0308"/>
+  <outline>
+    <contour>
+      <point x="284" y="0" type="line"/>
+      <point x="258" y="27"/>
+      <point x="258" y="98" type="qcurve" smooth="yes"/>
+      <point x="258" y="237" type="line"/>
+      <point x="132" y="239"/>
+      <point x="20" y="313"/>
+      <point x="20" y="392" type="qcurve" smooth="yes"/>
+      <point x="20" y="466"/>
+      <point x="133" y="545"/>
+      <point x="258" y="547" type="qcurve"/>
+      <point x="258" y="610" type="line" smooth="yes"/>
+      <point x="258" y="669"/>
+      <point x="212" y="669" type="qcurve"/>
+      <point x="212" y="709" type="line"/>
+      <point x="327" y="718" type="line"/>
+      <point x="341" y="710"/>
+      <point x="358" y="670"/>
+      <point x="358" y="647" type="qcurve" smooth="yes"/>
+      <point x="358" y="547" type="line"/>
+      <point x="488" y="546"/>
+      <point x="546" y="509" type="qcurve" smooth="yes"/>
+      <point x="594" y="478"/>
+      <point x="602" y="417" type="qcurve"/>
+      <point x="742" y="417" type="line"/>
+      <point x="776" y="444"/>
+      <point x="839" y="444" type="qcurve" smooth="yes"/>
+      <point x="912" y="444" type="line" smooth="yes"/>
+      <point x="1012" y="444"/>
+      <point x="1012" y="357" type="qcurve" smooth="yes"/>
+      <point x="1012" y="313"/>
+      <point x="952" y="246"/>
+      <point x="903" y="246" type="qcurve" smooth="yes"/>
+      <point x="792" y="246" type="line" smooth="yes"/>
+      <point x="753" y="246"/>
+      <point x="706" y="295"/>
+      <point x="706" y="333" type="qcurve" smooth="yes"/>
+      <point x="706" y="352"/>
+      <point x="710" y="367" type="qcurve"/>
+      <point x="602" y="367" type="line"/>
+      <point x="594" y="311"/>
+      <point x="546" y="278" type="qcurve" smooth="yes"/>
+      <point x="488" y="238"/>
+      <point x="358" y="237" type="qcurve"/>
+      <point x="358" y="123" type="line" smooth="yes"/>
+      <point x="358" y="79"/>
+      <point x="386" y="50"/>
+      <point x="417" y="50" type="qcurve" smooth="yes"/>
+      <point x="468" y="50" type="line"/>
+      <point x="473" y="76"/>
+      <point x="513" y="115"/>
+      <point x="553" y="115" type="qcurve" smooth="yes"/>
+      <point x="571" y="115"/>
+      <point x="602" y="106"/>
+      <point x="609" y="101" type="qcurve"/>
+      <point x="593" y="85"/>
+      <point x="578" y="49"/>
+      <point x="578" y="23" type="qcurve" smooth="yes"/>
+      <point x="578" y="-4"/>
+      <point x="596" y="-40"/>
+      <point x="609" y="-51" type="qcurve"/>
+      <point x="602" y="-57"/>
+      <point x="571" y="-67"/>
+      <point x="553" y="-67" type="qcurve" smooth="yes"/>
+      <point x="513" y="-67"/>
+      <point x="473" y="-27"/>
+      <point x="468" y="0" type="qcurve"/>
+    </contour>
+    <contour>
+      <point x="507" y="396" type="qcurve" smooth="yes"/>
+      <point x="507" y="427"/>
+      <point x="486" y="472"/>
+      <point x="422" y="498"/>
+      <point x="358" y="498" type="qcurve"/>
+      <point x="358" y="286" type="line"/>
+      <point x="444" y="287"/>
+      <point x="507" y="342"/>
+    </contour>
+    <contour>
+      <point x="116" y="389" type="qcurve" smooth="yes"/>
+      <point x="116" y="359"/>
+      <point x="139" y="314"/>
+      <point x="200" y="288"/>
+      <point x="258" y="286" type="qcurve"/>
+      <point x="258" y="498" type="line"/>
+      <point x="177" y="495"/>
+      <point x="116" y="441"/>
+    </contour>
+    <contour>
+      <point x="850" y="283" type="qcurve" smooth="yes"/>
+      <point x="888" y="283"/>
+      <point x="929" y="325"/>
+      <point x="929" y="355" type="qcurve" smooth="yes"/>
+      <point x="929" y="379"/>
+      <point x="897" y="407"/>
+      <point x="866" y="407" type="qcurve" smooth="yes"/>
+      <point x="830" y="407"/>
+      <point x="789" y="370"/>
+      <point x="789" y="336" type="qcurve" smooth="yes"/>
+      <point x="789" y="313"/>
+      <point x="821" y="283"/>
+    </contour>
+  </outline>
+</glyph>

--- a/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/lib.plist
+++ b/src/NotoSerifEthiopic/NotoSerifEthiopic-Regular.ufo/lib.plist
@@ -3712,6 +3712,36 @@
       <string>zzi-ethiopic</string>
       <string>zzo-ethiopic</string>
       <string>zzu-ethiopic</string>
+      <!-- BEGIN: Unicode 14 Ethiopic Extended-B Entries -->
+      <string>hhya-ethiopic</string>
+      <string>hhyu-ethiopic</string>
+      <string>hhyi-ethiopic</string>
+      <string>hhyaa-ethiopic</string>
+      <string>hhyee-ethiopic</string>
+      <string>hhye-ethiopic</string>
+      <string>hhyo-ethiopic</string>
+      <string>hhwaGurage-ethiopic</string>
+      <string>hhwi-ethiopic</string>
+      <string>hwee-ethiopic</string>
+      <string>hhwe-ethiopic</string>
+      <string>mwiGurage-ethiopic</string>
+      <string>mweeGurage-ethiopic</string>
+      <string>qwiGurage-ethiopic</string>
+      <string>qweeGurage-ethiopic</string>
+      <string>qweGurage-ethiopic</string>
+      <string>bwiGurage-ethiopic</string>
+      <string>bweeGurage-ethiopic</string>
+      <string>kwiGurage-ethiopic</string>
+      <string>kweeGurage-ethiopic</string>
+      <string>kweGurage-ethiopic</string>
+      <string>gwiGurage-ethiopic</string>
+      <string>gweeGurage-ethiopic</string>
+      <string>gweGurage-ethiopic</string>
+      <string>fwiGurage-ethiopic</string>
+      <string>fweeGurage-ethiopic</string>
+      <string>pwiGurage-ethiopic</string>
+      <string>pweeGurage-ethiopic</string>
+      <!-- END: Unicode 14 Ethiopic Extended-B Entries -->
       <string>lollipop</string>
       <string>nose</string>
       <string>baashort</string>


### PR DESCRIPTION
This branch adds the 28 new glyphs introduced in the Unicode 14 "Ethiopic Extended-B" block. The glyphs added are for the Regular typeface of the Noto Sans Ethiopic and Noto Serif Ethiopic.  The new glyphs have been added to the` lib.plist `file, unfortunately, I do not have the Glyphs app available to test with, they were developed with FontLab 7.2 .

My hope is that these glyphs will help save some work effort for a professional type designer working on the Noto team.  I am available to support in anyway that I can.

Ref:  https://www.unicode.org/charts/PDF/Unicode-14.0/