### PR TITLE
Fix Sinhala Ra regression

### DIFF
--- a/test/fontbakery/sinhala.json
+++ b/test/fontbakery/sinhala.json
@@ -917,6 +917,10 @@
             "input": "ශ‍්ඤඑදටි",
             "note": "Added by SIESTA",
             "only": "NotoSansSinhala-Regular.ttf"
+        },
+        {
+            "input": "සුරැරු",
+            "expectation": "suvowelsinh=0+824|rasinh=2+702|raevowelsinh=2+248|rasinh=4+702|aevowelsignsinh=4+309"
         }
     ]
 }


### PR DESCRIPTION
Somehow a rogue lookupflag found its way into the ra+vowel fix lookup, preventing short ae vowels after ra.