### PR TITLE
Noto Nastaliq Urdu 3.002

### DIFF
--- a/src/NotoNastaliqUrdu.glyphs
+++ b/src/NotoNastaliqUrdu.glyphs
@@ -1,6 +1,9 @@
 {
 .appVersion = "3109";
 .formatVersion = 3;
+DisplayStrings = (
+"/GafIni"
+);
 axes = (
 {
 name = Weight;
@@ -134140,7 +134143,6 @@ shapes = (
 ref = KafIni;
 },
 {
-pos = (386,0);
 ref = _Gaf.sarkash;
 }
 );
@@ -134257,7 +134259,6 @@ shapes = (
 ref = KafIni;
 },
 {
-pos = (367,0);
 ref = _Gaf.sarkash;
 }
 );

--- a/src/NotoNastaliqUrdu.glyphs
+++ b/src/NotoNastaliqUrdu.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "3108";
+.appVersion = "3109";
 .formatVersion = 3;
 axes = (
 {
@@ -161,10 +161,6 @@ code = "AinMed AinMed.inT3 AinMed.inT3outD1 AinMed.inT3outD11 AinMed.inT3outD2 A
 name = YBMedis;
 },
 {
-code = "BehxIni.outD2WQ BehxIni.outD4 BehxIni.outT2 BehxIni.outT2K FehxIni.outD2MM FehxIni.outD4 GafIni.outD2MM GafInvIni.outD2MM HehIni KafIni.outD2MM LamIni.outD2MM MeemIni.r";
-name = class594;
-},
-{
 code = "GafInvMed.outD2HYB GafMed.outD2HYB HehDoMed.inD2outD2YB KafMed.outD2HYB LamMed.outD2HYB SeenMed.inT2outD2YB";
 name = class603;
 },
@@ -215,14 +211,6 @@ name = class726;
 {
 code = "AinIni AinIni.outD1 AinIni.outD11 AinIni.outD2 AinIni.outD2D AinIni.outD2H AinIni.outD2MM AinIni.outD2long AinIni.outD3 AinIni.outD5 AinIni.outT2 AinIni.outT3 AinIni.tall BehxIni BehxIni.A BehxIni.outD1 BehxIni.outD11 BehxIni.outD2D BehxIni.outD2H BehxIni.outD2M BehxIni.outD2MM BehxIni.outD2WQ BehxIni.outD2Y BehxIni.outD4 BehxIni.outD5 BehxIni.outS1 BehxIni.outT2 BehxIni.outT2K BehxIni.outT2N BehxIni.outT2tall BehxIni.outT3 BehxIni.outT3F FehxIni FehxIni.outD1 FehxIni.outD2 FehxIni.outD2D FehxIni.outD2H FehxIni.outD2MM FehxIni.outD2WQ FehxIni.outD2Y FehxIni.outD4 FehxIni.outD5 FehxIni.outS1 FehxIni.outT2 FehxIni.outT2N FehxIni.outT3 GafIni GafIni.HRk GafIni.HRlow GafIni.HRoutD1 GafIni.HRoutD2 GafIni.HRoutD2H GafIni.HRoutD5 GafIni.HRoutT2 GafIni.HRoutT2N GafIni.HRoutT3 GafIni.k GafIni.outD1 GafIni.outD11 GafIni.outD2 GafIni.outD2D GafIni.outD2H GafIni.outD2MM GafIni.outD2Y GafIni.outD5 GafIni.outS1 GafIni.outT2 GafIni.outT2N GafIni.outT3 GafInvIni GafInvIni.HRk GafInvIni.HRlow GafInvIni.HRoutD1 GafInvIni.HRoutD2 GafInvIni.HRoutD2H GafInvIni.HRoutD5 GafInvIni.HRoutT2 GafInvIni.HRoutT2N GafInvIni.HRoutT3 GafInvIni.k GafInvIni.outD1 GafInvIni.outD11 GafInvIni.outD2 GafInvIni.outD2D GafInvIni.outD2H GafInvIni.outD2MM GafInvIni.outD2Y GafInvIni.outD5 GafInvIni.outS1 GafInvIni.outT2 GafInvIni.outT2N GafInvIni.outT3 HahIni HahIni.outD1 HahIni.outD11 HahIni.outD2 HahIni.outD2D HahIni.outD2H HahIni.outD2MM HahIni.outD2Y HahIni.outD3 HahIni.outD5 HahIni.outS1 HahIni.outT2 HahIni.outT3 HahIni.outT3short HehDoIni HehDoIni.outD1 HehDoIni.outD11 HehDoIni.outD2 HehDoIni.outD2D HehDoIni.outD2H HehDoIni.outD2MM HehDoIni.outD2Y HehDoIni.outD3 HehDoIni.outD5 HehDoIni.outS1 HehDoIni.outT2 HehDoIni.outT2wide HehDoIni.outT3 HehIni HehIni.outD1 HehIni.outD11 HehIni.outD2D HehIni.outD2H HehIni.outD2M HehIni.outD2MM HehIni.outD2Y HehIni.outD5 HehIni.outS1 HehIni.outT2 HehIni.outT3 HehIni.r HehIniAF HehIniAF.outD1 HehIniAF.outD11 HehIniAF.outD2 HehIniAF.outD2D HehIniAF.outD2H HehIniAF.outD2MM HehIniAF.outD2Y HehIniAF.outD3 HehIniAF.outD5 HehIniAF.outS1 HehIniAF.outT2 HehIniAF.outT3 KafIni KafIni.HRk KafIni.HRlow KafIni.HRoutD1 KafIni.HRoutD2 KafIni.HRoutD2H KafIni.HRoutD5 KafIni.HRoutT2 KafIni.HRoutT2N KafIni.HRoutT3 KafIni.k KafIni.outD1 KafIni.outD11 KafIni.outD2 KafIni.outD2D KafIni.outD2H KafIni.outD2MM KafIni.outD2Y KafIni.outD5 KafIni.outS1 KafIni.outT2 KafIni.outT2N KafIni.outT3 LamIni LamIni.HRlow LamIni.low LamIni.outD1 LamIni.outD11 LamIni.outD2 LamIni.outD2D LamIni.outD2H LamIni.outD2MM LamIni.outD2Y LamIni.outD5 LamIni.outS1 LamIni.outT2 LamIni.outT2N LamIni.outT3 MeemIni MeemIni.outD1 MeemIni.outD11 MeemIni.outD2 MeemIni.outD2D MeemIni.outD2H MeemIni.outD2MM MeemIni.outD2Y MeemIni.outD5 MeemIni.outS1 MeemIni.outT2 MeemIni.outT2B MeemIni.outT3 MeemIni.r SadIni SadIni.outD1 SadIni.outD11 SadIni.outD2D SadIni.outD2H SadIni.outD2M SadIni.outD2MM SadIni.outD2Y SadIni.outD5 SadIni.outS1 SadIni.outT2 SadIni.outT3 SadIni.r SeenIni SeenIni.SWoutT2 SeenIni.outD1 SeenIni.outD11 SeenIni.outD2D SeenIni.outD2H SeenIni.outD2M SeenIni.outD2MM SeenIni.outD2Y SeenIni.outD5 SeenIni.outS1 SeenIni.outT2 SeenIni.outT2short SeenIni.outT3 SeenIni.r TahIni TahIni.HRlow TahIni.low TahIni.outD1 TahIni.outD11 TahIni.outD2 TahIni.outD2D TahIni.outD2H TahIni.outD2M TahIni.outD2MM TahIni.outD3 TahIni.outD5 TahIni.outT2 TahIni.outT3";
 name = class766;
-},
-{
-code = "GafInvMed.HRk GafInvMed.k GafMed.HRk GafMed.k HahMed.inD2outD3 HahMed.inD2outD5 KafMed.HRk KafMed.k TahMed.inD1outD3";
-name = class793;
-},
-{
-code = "BehxMed.inS1outS1 MeemMed.inD2outD3 SeenMed.SWinCoutT2 TahMed TahMed.HRlow TahMed.inD1 TahMed.inD1outS1 TahMed.inD1outT1 TahMed.inD1outT2 TahMed.low";
-name = class815;
 },
 {
 code = "FehxMed.inT3outD3 HahMed HahMed.inD2outD2MM HahMed.inD2outT1 HahMed.inD2outT2 SeenMed.SWinAoutT2 SeenMed.SWinBoutT2 SeenMed.SWinFFoutT2 SeenMed.SWinFoutT2 SeenMed.SWinGoutT2 TahMed.inD1outD2MM TahMed.inD1outD5";
@@ -6098,7 +6086,7 @@ lookup YBaddAnchors {
     sub @Inits' @SimpleMedis' YehBarreeFin' lookup YBanchor1;
     sub @Inits' @SimpleMedis' @SimpleMedis' YehBarreeFin' lookup YBanchor2;
     sub @Inits' @SimpleMedis' @SimpleMedis' @SimpleMedis' YehBarreeFin' lookup YBanchor3;
-    sub @SimpleMedis' @SimpleMedis' @SimpleMedis' @SimpleMedis' @SimpleMedis' lookup YBanchor3;
+    sub @SimpleMedis' @SimpleMedis' @SimpleMedis' @SimpleMedis' YehBarreeFin' lookup YBanchor3;
 } YBaddAnchors;
 ";
 name = "Add counter glyphs for bari-ye";
@@ -7672,26 +7660,7 @@ name = "- Bari Ye Handling (part 2) -";
 },
 {
 code = "lookup AnnullMk {
-    sub AlefInferiorYB by NullMk;
-    sub HamzaBelowYB by NullMk;
-    sub KasraYB by NullMk;
-    sub KasratanYB by NullMk;
-    sub OneDotBelowYB by NullMk;
-    sub ThreeDotsDownBelowYB by NullMk;
-    sub TwoDotsBelowYB by NullMk;
-    sub HehCommaYB by NullMk;
-    sub FourDotsBelowYB by NullMk;
-    sub WavyHamzaBelowYB by NullMk;
-    sub Small4UrduBelowYB by NullMk;
-    sub TwoDotsVertBelowYB by NullMk;
-    sub HamzaBelowAF_YB by NullMk;
-    sub Tah2DotsBelowYB by NullMk;
-    sub TahSmallBelowYB by NullMk;
-    sub RingDistYB by NullMk;
-    sub ArSevenBelowYB by NullMk;
-    sub ThreeDotsFlatBelowYB by NullMk;
-    sub ThreeDotsUpBelowYB by NullMk;
-    sub ArEightBelowYB by NullMk;
+    sub @YBMarks by NullMk;
 } AnnullMk;
 ";
 name = "Replace mark with null";
@@ -9892,7 +9861,10 @@ code = "lookup TransferMarks {
 name = "Transfer YB Mark sequences to End";
 },
 {
-code = "
+code = "@class594 = [BehxIni.outD2WQ BehxIni.outD4 BehxIni.outT2 BehxIni.outT2K FehxIni.outD2MM FehxIni.outD4 GafIni.outD2MM GafInvIni.outD2MM HehIni KafIni.outD2MM LamIni.outD2MM MeemIni.r];
+@class793 = [GafInvMed.HRk GafInvMed.k GafMed.HRk GafMed.k HahMed.inD2outD3 HahMed.inD2outD5 KafMed.HRk KafMed.k TahMed.inD1outD3];
+@class815 = [BehxMed.inS1outS1 MeemMed.inD2outD3 SeenMed.SWinCoutT2 TahMed TahMed.HRlow TahMed.inD1 TahMed.inD1outS1 TahMed.inD1outT1 TahMed.inD1outT2 TahMed.low];
+
 lookup YBcombis3 {
     lookupflag IgnoreLigatures IgnoreMarks;
     ;
@@ -10053,6 +10025,7 @@ name = "Handle 3-glyph YB sequences";
 },
 {
 code = "lookup TransferMarks2 {
+lookupflag UseMarkFilteringSet @YBMarksAndPre;
 sub @AllSpacers' [NullMk ybPre]' [NullMk ybPre]' @YBMedis' lookup TransferMarks;
 sub @AllSpacers' [NullMk ybPre]' @YBMedis' lookup TransferMarks;
 sub @AllSpacers' @YBMedis' lookup TransferMarks;
@@ -10060,6 +10033,10 @@ sub [NullMk ybPre]' [NullMk ybPre]' @YBMedis' lookup TransferMarks;
 sub [NullMk ybPre]' @YBMedis' lookup TransferMarks;
 sub @YBMedis' lookup TransferMarks;
 }TransferMarks2;
+
+@class594 = [BehxIni.outD2WQ BehxIni.outD4 BehxIni.outT2 BehxIni.outT2K FehxIni.outD2MM FehxIni.outD4 GafIni.outD2MM GafInvIni.outD2MM HehIni KafIni.outD2MM LamIni.outD2MM MeemIni.r];
+@class793 = [GafInvMed.HRk GafInvMed.k GafMed.HRk GafMed.k HahMed.inD2outD3 HahMed.inD2outD5 KafMed.HRk KafMed.k TahMed.inD1outD3];
+@class815 = [BehxMed.inS1outS1 MeemMed.inD2outD3 SeenMed.SWinCoutT2 TahMed TahMed.HRlow TahMed.inD1 TahMed.inD1outS1 TahMed.inD1outT1 TahMed.inD1outT2 TahMed.low];
 
 lookup YBcombis4i_5i {
     lookupflag IgnoreMarks;

--- a/src/NotoNastaliqUrdu.glyphs
+++ b/src/NotoNastaliqUrdu.glyphs
@@ -201782,7 +201782,7 @@ value = "Noto is a trademark of Google Inc.";
 },
 {
 key = versionString;
-value = "Version 3.001";
+value = "Version 3.002";
 }
 );
 settings = {
@@ -203646,5 +203646,5 @@ O,
 };
 };
 versionMajor = 3;
-versionMinor = 1;
+versionMinor = 2;
 }

--- a/test/fontbakery/nastaliq.json
+++ b/test/fontbakery/nastaliq.json
@@ -32,6 +32,30 @@
             "note": "googlefonts/noto-fonts#2181"
         },
         {
+            "expectation": "ThreeDotsDownBelowYB=6@659,-193+0|YBc1=6@659,-291+0|YBc2=6@966,-154+0|TwoDotsBelowYB=6@1274,-148+0|YBc3=6@1274,-247+0|YehBarreeFin_5=6+355|TwoDotsAboveNS=5@-16,-158+0|BehxMed.inT2outD2YB=5@0,349+182|NullMk=4+0|HahMed.inD2outT2=4@0,406+79|OneDotAboveAltNS=3@217,444+0|ybPre=3+0|BehxMed.inT2outD2H=3@0,781+413|NullMk=2+0|BehxMed.inT1outT2=2@0,891+184|HehDoMed.inD2outT1=1@0,956+327|sp0=0+0|KafIni.HRoutD2=0@0,1351+250",
+            "input": "کھینچتے",
+            "only": "NotoNastaliqUrdu-Regular.ttf",
+            "note": "googlefonts/noto-fonts#2232"
+        },
+        {
+            "expectation": "OneDotBelowYB=5@659,-192+0|YBc1=5@659,-291+0|TwoDotsBelowYB=5@966,-55+0|YBc2=5@966,-154+0|YBc3=5@1274,-247+0|YehBarreeFin_5=5+355|TwoDotsAboveNS=4@-16,-158+0|BehxMed.inT2outD2YB=4@0,349+182|NullMk=3+0|HahMed.inD2outT2=3@0,406+79|NullMk=2+0|BehxMed.inT2outD2H=2@0,781+413|ybPre=1+0|HehDoMed.inD2outT2=1@0,891+311|OneDotBelowNS=0@244,949+0|sp0=0+0|BehxIni.outD2D=0@0,1235+404",
+            "input": "بھیجتے",
+            "only": "NotoNastaliqUrdu-Regular.ttf",
+            "note": "googlefonts/noto-fonts#2232"
+        },
+        {
+            "expectation": "YBc1=5@659,-291+0|ThreeDotsDownBelowYB=5@966,-56+0|YBc2=5@966,-154+0|YBc3=5@1274,-247+0|YehBarreeFin_5=5+355|TwoDotsAboveNS=4@-16,-158+0|BehxMed.inT2outD2YB=4@0,349+182|TahSmallAltNS=3@101,186+0|ybPre=3+0|BehxMed.inT1outT2=3@0,406+184|NullMk=2+0|BehxMed.inT2outT1=2@0,471+267|ybPre=1+0|HehDoMed.inD2outT2=1@0,616+311|OneDotBelowNS=0@423,928+0|sp0=0+0|HahIni.outD2D=0@0,960+617",
+            "input": "جھپٹتے",
+            "only": "NotoNastaliqUrdu-Regular.ttf",
+            "note": "googlefonts/noto-fonts#2232"
+        },
+        {
+            "expectation": "TwoDotsBelowYB=3@764,-183+0|YBc1=3@764,-282+0|YBc2=3@1098,-159+0|YehBarreeFin.2_4=3+64|ThreeDotsDownBelowNS=2@322,-123+0|HahMed.inD2outD2YB=2@0,195+211|NullMk=1+0|BehxMed.inT2outD2H=1@0,527+413|OneDotAboveNS=0@101,117+0|ybPre=0+0|sp7=0+0|BehxIni.outT2=0@0,637+583",
+            "input": "نیچے",
+            "only": "NotoNastaliqUrdu-Regular.ttf",
+            "note": "googlefonts/noto-fonts#2232"
+        },
+        {
             "expectation": "ArEightAboveNS=2@518,53+0|AlefInferiorNS=2@296,-466+0|TwoDotsAboveNS=2@518,-198+0|QafxFin.cut=2+692|TwoDotsVertAboveNS=1@77,701+0|BehxMed.inT2outD2WQ=1@0,272+331|sp0=0+0|KafIni.outT2=0@0,433+302",
             "input": "كٺقٖٛ",
             "note": "Added by SIESTA",


### PR DESCRIPTION
This fixes two significant bugs:

- Fix googlefonts/noto-fonts#2231 (gaf sarkash alignment)
- Fix googlefonts/noto-fonts#2232 (bari ye handling)
- Update version to 3.002

Sorry for the regression. :-( (But in my defence the bari ye code *is* a pit of snakes.)