### PR TITLE
Convert Serif Telugu to pure-Glyphs source

### DIFF
--- a/test/fontbakery/telugu-serif.json
+++ b/test/fontbakery/telugu-serif.json
@@ -1,0 +1,3766 @@
+{
+    "tests": [
+        {
+            "expectation": "parenleft.telu=0+368|patelu=1+670|catelu=2+713|cahalanttelu=3+713|.notdef=5+600|parenright.telu=6+368",
+            "input": "(పచచ్ǵ)",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "parenleft.telu=0+368|satelu=1+658|jatelu=2+686|juvoweltelu=3+906|lasubscripttelu=3@-289,0+0|parenright.telu=7+368",
+            "input": "(సజజ్లు)",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|tsatelu=1+713|uni25CC=2+578|casubscripttelu=2+316|anusvaratelu=2+490|.notdef=6+600|uni25CC=6+578|aavowelsigntelu=6+219",
+            "input": "అౘ◌్చంĦా",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "parenleft.telu=0+368|atelu=1+762|catelu=2+713|cahalanttelu=3+713|anusvaratelu=3+490|.notdef=6+600|uni25CC=6+578|aavowelsigntelu=6+219|parenright.telu=8+368",
+            "input": "(అచచ్ంĦా)",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+489|uuvowelsigntelu=0+600|dzatelu=2+686|uni25CC=3+578|aavowelsigntelu=3+219",
+            "input": "కూౙ◌ా",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "parenleft.telu=0+368|katelu=1+489|uuvowelsigntelu=1+600|jaavoweltelu=3+949|parenright.telu=5+368",
+            "input": "(కూజా)",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|tsatelu=1+713|uni25CC=2+578|casubscripttelu=2+326|.notdef=5+600",
+            "input": "పౘ◌్చǵ",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|dzatelu=1+686|uni25CC=2+578|jasubscripttelu=2+0|latelu=5+665|uvowelsigntelu=5+318",
+            "input": "సౙ◌్జలు",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tsatelu=0+713|uni25CC=1+578|aavowelsigntelu=1+219|katelu=3+481|.notdef=4+600",
+            "input": "ౘ◌ాకȃ",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "parenleft.telu=0+368|.notdef=1+600|aavowelsigntelu=1+0|katelu=3+481|.notdef=4+600|parenright.telu=5+368",
+            "input": "(Ĩాకȃ)",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tsatelu=0+713|uni25CC=1+578|uvowelsigntelu=1+318|katelu=3+481|katelu=4+489|uvowelsigntelu=4+318|lasubscripttelu=4@-292,0+0",
+            "input": "ౘ◌ుకక్లు",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "parenleft.telu=0+368|catelu=1+713|uvowelsigntelu=1+318|katelu=3+481|katelu=4+489|uvowelsigntelu=4+318|lasubscripttelu=4@-292,0+0|parenright.telu=8+368",
+            "input": "(చుకక్లు)",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tsatelu=0+713|uni25CC=1+578|uuvowelsigntelu=1+569|puvoweltelu=3+916|latelu=5+665|uvowelsigntelu=5+318",
+            "input": "ౘ◌ూపులు",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "parenleft.telu=0+368|catelu=1+713|uuvowelsigntelu=1+569|puvoweltelu=3+916|latelu=5+665|uvowelsigntelu=5+318|parenright.telu=7+368",
+            "input": "(చూపులు)",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "dzatelu=0+686|uni25CC=1+578|aavowelsigntelu=1+219|.notdef=3+600|.notdef=4+600",
+            "input": "ౙ◌ాǹȃ",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "parenleft.telu=0+368|jaavoweltelu=1+949|.notdef=3+600|.notdef=4+600|parenright.telu=5+368",
+            "input": "(జాǹȃ)",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "dzatelu=0+686|uni25CC=1+578|uvowelsigntelu=1+318|uni25CC=3+578|anusvaratelu=3+490|ttivoweltelu=5+716",
+            "input": "ౙ◌ు◌ంటి",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "parenleft.telu=0+368|.notdef=1+600|anusvaratelu=1+490|ttatelu=3+716|ivowelsigntelu=3+0|parenright.telu=5+368",
+            "input": "(ǯంటి)",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "dzatelu=0+686|uni25CC=1+578|uuvowelsigntelu=1+600|latelu=3+665|uvowelsigntelu=3+318",
+            "input": "ౙ◌ూలు",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "parenleft.telu=0+368|.notdef=1+600|latelu=2+665|uvowelsigntelu=2+0|parenright.telu=4+368",
+            "input": "(ǰలు)",
+            "note": "fontdiff-346-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "juuvoweltelu=0+1189|nahalanttelu=2+658",
+            "input": "జూన్",
+            "note": "fontdiff-719-NotoSansTeluguUI.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "two.telu=0+559|five.telu=1+559|comma.telu=2+255",
+            "input": "25,",
+            "note": "fontdiff-719-NotoSansTeluguUI.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "shatelu=0+529|nivoweltelu=1+674|vaavoweltelu=3+942|ratelu=5+564|anusvaratelu=5+490",
+            "input": "శనివారం",
+            "note": "fontdiff-719-NotoSansTeluguUI.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tivoweltelu=0+723|tasubscripttelu=0@-76,0+0",
+            "input": "త్తి",
+            "note": "fontdiff-964-NotoSansTelugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "parenleft.telu=0+368|tevoweltelu=1+723|latelu=3+665|uvowelsigntelu=3+318|gatelu=5+562|uvowelsigntelu=5+318|parenright.telu=7+368",
+            "input": "(తెలుగు)",
+            "note": "fontdiff-Telugu-BIS-annex3.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "zero.telu=0+559|.notdef=1+600|one.telu=2+559|eight.telu=3+559",
+            "input": "0C18",
+            "note": "fontdiff-Telugu-BIS-annex3.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ghatelu=0+988",
+            "input": "ఘ",
+            "note": "fontdiff-Telugu-BIS-annex3.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "zero.telu=0+559|.notdef=1+600|two.telu=2+559|four.telu=3+559",
+            "input": "0C24",
+            "note": "fontdiff-Telugu-BIS-annex3.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tatelu=0+723",
+            "input": "త",
+            "note": "fontdiff-Telugu-BIS-annex3.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "zero.telu=0+559|.notdef=1+600|three.telu=2+559|zero.telu=3+559",
+            "input": "0C30",
+            "note": "fontdiff-Telugu-BIS-annex3.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ratelu=0+564",
+            "input": "ర",
+            "note": "fontdiff-Telugu-BIS-annex3.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "zero.telu=0+559|.notdef=1+600|four.telu=2+559|.notdef=3+600",
+            "input": "0C4D",
+            "note": "fontdiff-Telugu-BIS-annex3.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "zero.telu=0+559|.notdef=1+600|five.telu=2+559|nine.telu=3+559",
+            "input": "0C59",
+            "note": "fontdiff-Telugu-BIS-annex3.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "dzatelu=0+686",
+            "input": "ౙ",
+            "note": "fontdiff-Telugu-BIS-annex3.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "zero.telu=0+559|.notdef=1+600|six.telu=2+559|.notdef=3+600",
+            "input": "0C6D",
+            "note": "fontdiff-Telugu-BIS-annex3.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "seventelu=0+481",
+            "input": "౭",
+            "note": "fontdiff-Telugu-BIS-annex3.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "zero.telu=0+559|.notdef=1+600|eight.telu=2+559|three.telu=3+559",
+            "input": "0C83",
+            "note": "fontdiff-Telugu-BIS-annex3.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tatelu=0+723|tarasubscripttelu=0+0",
+            "input": "త్ర",
+            "note": "fontdiff-Telugu-BIS-annex3.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "zero.telu=0+559|.notdef=1+600|four.telu=2+559|.notdef=3+600|plus.telu=4+559|zero.telu=5+559|.notdef=6+600|three.telu=7+559|zero.telu=8+559",
+            "input": "0C4D+0C30",
+            "note": "fontdiff-Telugu-sn-manoj-20171023.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "zero.telu=0+559|.notdef=1+600|four.telu=2+559|.notdef=3+600|plus.telu=4+559|two.telu=5+559|zero.telu=6+559|zero.telu=7+559|.notdef=8+600|plus.telu=9+559|zero.telu=10+559|.notdef=11+600|three.telu=12+559|zero.telu=13+559",
+            "input": "0C4D+200C+0C30",
+            "note": "fontdiff-Telugu-sn-manoj-20171023.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "uni25CC=0+578|viramatelu=0+0|space=1+0|ratelu=2+564",
+            "input": "్‌ర",
+            "note": "fontdiff-Telugu-sn-manoj-20171023.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|parasubscripttelu=0+0|tivoweltelu=3+723",
+            "input": "ప్రతి",
+            "note": "fontdiff-Telugu-sn-manoj-20171023.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "peevoweltelu=0+685|parasubscripttelu=0+0|matelu=4+988",
+            "input": "ప్రేమ",
+            "note": "fontdiff-Telugu-sn-manoj-20171023.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "sheevoweltelu=0+529|khatelu=2+724|rahalanttelu=3+564",
+            "input": "శేఖర్",
+            "note": "fontdiff-Telugu-sn-manoj-20171023.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "maavoweltelu=0+1239|satelu=2+658|ttasubscripttelu=2@-68,0+0|rahalanttelu=5+564",
+            "input": "మాస్టర్",
+            "note": "fontdiff-Telugu-sn-manoj-20171023.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "zero.telu=0+559|.notdef=1+600|two.telu=2+559|.notdef=3+600|plus.telu=4+559|zero.telu=5+559|.notdef=6+600|four.telu=7+559|.notdef=8+600|plus.telu=9+559|zero.telu=10+559|.notdef=11+600|three.telu=12+559|zero.telu=13+559|plus.telu=14+559|zero.telu=15+559|.notdef=16+600|two.telu=17+559|four.telu=18+559|plus.telu=19+559|zero.telu=20+559|.notdef=21+600|three.telu=22+559|.notdef=23+600",
+            "input": "0C2A+0C4D+0C30+0C24+0C3F",
+            "note": "fontdiff-Telugu-sn-manoj-20171023.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "zero.telu=0+559|.notdef=1+600|two.telu=2+559|.notdef=3+600|plus.telu=4+559|zero.telu=5+559|.notdef=6+600|four.telu=7+559|.notdef=8+600|plus.telu=9+559|zero.telu=10+559|.notdef=11+600|three.telu=12+559|zero.telu=13+559|plus.telu=14+559|zero.telu=15+559|.notdef=16+600|four.telu=17+559|seven.telu=18+559|plus.telu=19+559|zero.telu=20+559|.notdef=21+600|two.telu=22+559|.notdef=23+600",
+            "input": "0C2A+0C4D+0C30+0C47+0C2E",
+            "note": "fontdiff-Telugu-sn-manoj-20171023.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "zero.telu=0+559|.notdef=1+600|three.telu=2+559|six.telu=3+559|plus.telu=4+559|zero.telu=5+559|.notdef=6+600|four.telu=7+559|seven.telu=8+559|plus.telu=9+559|zero.telu=10+559|.notdef=11+600|one.telu=12+559|six.telu=13+559|plus.telu=14+559|zero.telu=15+559|.notdef=16+600|three.telu=17+559|zero.telu=18+559|plus.telu=19+559|zero.telu=20+559|.notdef=21+600|four.telu=22+559|.notdef=23+600",
+            "input": "0C36+0C47+0C16+0C30+0C4D",
+            "note": "fontdiff-Telugu-sn-manoj-20171023.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": ".notdef=0+600|.notdef=1+600|.notdef=2+600|.notdef=3+600|parenleft.telu=4+368|.notdef=5+600|.notdef=6+600|.notdef=7+600|.notdef=8+600|.notdef=9+600|.notdef=10+600|.notdef=11+600|parenright.telu=12+368",
+            "input": "main(teacher)",
+            "note": "fontdiff-Telugu-sn-manoj-20171023.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "zero.telu=0+559|.notdef=1+600|two.telu=2+559|.notdef=3+600|plus.telu=4+559|zero.telu=5+559|.notdef=6+600|three.telu=7+559|.notdef=8+600|plus.telu=9+559|zero.telu=10+559|.notdef=11+600|three.telu=12+559|eight.telu=13+559|plus.telu=14+559|zero.telu=15+559|.notdef=16+600|four.telu=17+559|.notdef=18+600|plus.telu=19+559|zero.telu=20+559|.notdef=21+600|one.telu=22+559|.notdef=23+600|plus.telu=24+559|zero.telu=25+559|.notdef=26+600|three.telu=27+559|zero.telu=28+559|plus.telu=29+559|zero.telu=30+559|.notdef=31+600|four.telu=32+559|.notdef=33+600",
+            "input": "0C2E+0C3E+0C38+0C4D+0C1F+0C30+0C4D",
+            "note": "fontdiff-Telugu-sn-manoj-20171023.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": ".notdef=0+600|aatelu=1+739|anusvaratelu=1+490|dhatelu=3+657|dharasubscripttelu=3+0",
+            "input": "\nఆంధ్ర",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|parasubscripttelu=0+0|deevoweltelu=3+657|shahalanttelu=5+529",
+            "input": "ప్రదేశ్",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "matelu=0+988|rivoweltelu=1+564|yatelu=3+1186|uvowelsigntelu=3+318",
+            "input": "మరియు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tevoweltelu=0+723|latelu=2+665|anusvaratelu=2+490|gaavoweltelu=4+842|nnatelu=6+786",
+            "input": "తెలంగాణ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "raavoweltelu=0+818|ssaavoweltelu=2+988|ttasubscripttelu=2@-414,-30+0|rasubscripttelu=2+374|latelu=8+665",
+            "input": "రాష్ట్రాల",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|dhivoweltelu=1+657|kaavoweltelu=3+780|ratelu=5+564",
+            "input": "అధికార",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssatelu=2+674",
+            "input": "భాష",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tevoweltelu=0+723|latelu=2+665|uvowelsigntelu=2+318|gatelu=4+562|uvowelsigntelu=4+318|period.telu=6+250",
+            "input": "తెలుగు.",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+966|ratelu=2+564|tatelu=3+723",
+            "input": "భారత",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "deevoweltelu=0+657|shatelu=2+529|anusvaratelu=2+490",
+            "input": "దేశం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "loovoweltelu=0+922",
+            "input": "లో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tevoweltelu=0+723|latelu=2+665|uvowelsigntelu=2+318|gatelu=4+562|uvowelsigntelu=4+318",
+            "input": "తెలుగు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "maavoweltelu=0+1270|tatelu=2+685|rvocalicvowelsigntelu=2+358|bhaavoweltelu=4+935|ssatelu=6+674|gaavoweltelu=7+842",
+            "input": "మాతృభాషగా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "maavoweltelu=0+1270|ttaavoweltelu=2+988|lasubscripttelu=2@-356,0+0|ddeevoweltelu=6+690",
+            "input": "మాట్లాడే",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "eight.telu=0+559|period.telu=1+250|seven.telu=2+559",
+            "input": "8.7",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "koovoweltelu=0+656|ttatelu=2+716|lasubscripttelu=2@-84,0+0",
+            "input": "కోట్ల",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "parenleft.telu=0+368|two.telu=1+559|zero.telu=2+559|zero.telu=3+559|one.telu=4+559",
+            "input": "(2001",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "parenright.telu=0+368",
+            "input": ")",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "jatelu=0+686|naavoweltelu=1+928|bhaavoweltelu=3+966|toovoweltelu=5+845",
+            "input": "జనాభాతో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bracketleft.telu=0+330|one.telu=1+559|bracketright.telu=2+330",
+            "input": "[1]",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "paavoweltelu=0+946|parasubscripttelu=0@-276,0+0|anusvaratelu=0+490|tiivoweltelu=5+723|yatelu=7+1186",
+            "input": "ప్రాంతీయ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssatelu=2+674|latelu=3+665|loovoweltelu=4+922",
+            "input": "భాషలలో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "movoweltelu=0+1306|datelu=2+657|ttivoweltelu=3+716",
+            "input": "మొదటి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "saavoweltelu=0+937|thasubscripttelu=0@-367,0+0|natelu=4+658|anusvaratelu=4+490|loovoweltelu=6+922",
+            "input": "స్థానంలో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "utelu=0+792|anusvaratelu=0+490|divoweltelu=2+657|period.telu=4+250",
+            "input": "ఉంది.",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|parasubscripttelu=0+0|patelu=3+670|anusvaratelu=3+490|catelu=5+713|anusvaratelu=5+490|loovoweltelu=7+907|nivoweltelu=9+674",
+            "input": "ప్రపంచంలోని",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|parasubscripttelu=0+0|jatelu=3+686|latelu=4+665|uvowelsigntelu=4+318",
+            "input": "ప్రజలు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|tatelu=1+718|yasubscripttelu=1+396|dhivoweltelu=4+657|katelu=6+481|matelu=7+988|uvowelsigntelu=7+318|gaavoweltelu=9+842",
+            "input": "అత్యధికముగా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|datelu=1+657|matelu=2+988|uuvowelsigntelu=2+600|ddatelu=4+690|vatelu=5+670",
+            "input": "పదమూడవ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "saavoweltelu=0+937|thasubscripttelu=0@-367,0+0|natelu=4+658|matelu=5+988|uvowelsigntelu=5+318|loovoweltelu=7+907|natelu=9+658|uuvowelsigntelu=9+600|comma.telu=11+255",
+            "input": "స్థానములోనూ,",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "deevoweltelu=0+657|shatelu=2+529|matelu=3+988|uvowelsigntelu=3+318|loovoweltelu=5+922",
+            "input": "దేశములో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "hivoweltelu=0+928|anusvaratelu=0+490|diivoweltelu=3+657|comma.telu=5+255",
+            "input": "హిందీ,",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bevoweltelu=0+693|anusvaratelu=0+490|gaavoweltelu=3+842|liivoweltelu=5+690",
+            "input": "బెంగాలీ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tatelu=0+723|raavoweltelu=1+849|vasubscripttelu=1+396|tatelu=5+723",
+            "input": "తర్వాత",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "matelu=0+988|uuvowelsigntelu=0+600|ddatelu=2+690|vatelu=3+670",
+            "input": "మూడవ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "saavoweltelu=0+937|thasubscripttelu=0@-367,0+0|natelu=4+658|matelu=5+988|uvowelsigntelu=5+318|loovoweltelu=7+907|natelu=9+658|uvowelsigntelu=9+318",
+            "input": "స్థానములోను",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "nivoweltelu=0+674|latelu=2+665|uvowelsigntelu=2+318|satelu=4+658|uvowelsigntelu=4+318|tasubscripttelu=4@-362,0+0|anusvaratelu=4+490|divoweltelu=9+657|period.telu=11+250",
+            "input": "నిలుస్తుంది.",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "paavoweltelu=0+968|tatelu=2+723|vaivoweltelu=3+670|natelu=5+658",
+            "input": "పాతవైన",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|parasubscripttelu=0+0|patelu=3+670|anusvaratelu=3+490|catelu=5+713",
+            "input": "ప్రపంచ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "gatelu=0+570|nnaavoweltelu=1+1038|anusvaratelu=1+490|kaavoweltelu=4+780|latelu=6+665",
+            "input": "గణాంకాల",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "parenleft.telu=0+368|etelu=1+671|thoovoweltelu=2+796|nasubscripttelu=2+302|laavoweltelu=6+952|gahalanttelu=8+570|parenright.telu=10+368",
+            "input": "(ఎథ్నోలాగ్)",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|parasubscripttelu=0+0|kaavoweltelu=3+780|ratelu=5+564|anusvaratelu=5+490",
+            "input": "ప్రకారం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|parasubscripttelu=0+0|patelu=3+670|anusvaratelu=3+490|catelu=5+713|vaavoweltelu=6+942|yasubscripttelu=6+396|patelu=10+670|tasubscripttelu=10@-50,0+0|anusvaratelu=10+490|gaavoweltelu=14+842",
+            "input": "ప్రపంచవ్యాప్తంగా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "seven.telu=0+559|period.telu=1+250|four.telu=2+559",
+            "input": "7.4",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "koovoweltelu=0+656|ttatelu=2+716|uvowelsigntelu=2+318|lasubscripttelu=2@-402,0+0",
+            "input": "కోట్లు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "matelu=0+988|anusvaratelu=0+490|divoweltelu=2+657|kivoweltelu=4+481",
+            "input": "మందికి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "utelu=0+792|anusvaratelu=0+490|divoweltelu=2+657|period.telu=4+250|bracketleft.telu=5+330|two.telu=6+559|bracketright.telu=7+330",
+            "input": "ఉంది.[2]",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssatelu=2+674|gaavoweltelu=3+842",
+            "input": "భాషగా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "maavoweltelu=0+1270|ttaavoweltelu=2+988|lasubscripttelu=2@-356,0+0|ddatelu=6+690|taavoweltelu=7+988|ratelu=9+550|uvowelsigntelu=9+318|period.telu=11+250",
+            "input": "మాట్లాడతారు.",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|tivoweltelu=1+723",
+            "input": "అతి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "paavoweltelu=0+968|parasubscripttelu=0@-298,0+0|ciivoweltelu=4+723|natelu=6+658",
+            "input": "ప్రాచీన",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "deevoweltelu=0+657|shatelu=2+529",
+            "input": "దేశ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|anusvaratelu=0+490|satelu=2+643|kasubscripttelu=2+303|rvocalicvowelsign1telu=2+487|tatelu=6+723|matelu=7+988|uvowelsigntelu=7+318|comma.telu=9+255",
+            "input": "సంస్కృతము,",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tatelu=0+723|mivoweltelu=1+1027|llatelu=3+622|matelu=4+988|uvowelsigntelu=4+318|latelu=6+665|toovoweltelu=7+845",
+            "input": "తమిళములతో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "baavoweltelu=0+966|ttatelu=2+716|uvowelsigntelu=2+318",
+            "input": "బాటు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssatelu=2+674|natelu=3+658|uvowelsigntelu=3+318",
+            "input": "భాషను",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|koovoweltelu=1+687|ttasubscripttelu=1@-185,0+0|batelu=5+693|ratelu=6+550|uvowelsigntelu=6+318",
+            "input": "అక్టోబరు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "three.telu=0+559|one.telu=1+559|comma.telu=2+255",
+            "input": "31,",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "two.telu=0+559|zero.telu=1+559|zero.telu=2+559|eight.telu=3+559|natelu=4+658",
+            "input": "2008న",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|parasubscripttelu=0+0|bhatelu=3+693|uvowelsigntelu=3+318|tatelu=5+718|vasubscripttelu=5+396|matelu=8+988|uvowelsigntelu=8+318",
+            "input": "ప్రభుత్వము",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ceevoweltelu=0+713|rivoweltelu=2+544|casubscripttelu=2+316|anusvaratelu=2+490|divoweltelu=7+657|period.telu=9+250|.notdef=10+600|iitelu=11+912|.notdef=12+600",
+            "input": "చేర్చింది.\tఈ\n",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "iitelu=0+912",
+            "input": "ఈ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "eetelu=0+671",
+            "input": "ఏ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ootelu=0+684",
+            "input": "ఓ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "datelu=0+657",
+            "input": "ద",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "otelu=0+684|katelu=1+481",
+            "input": "ఒక",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "gatelu=0+570|latelu=1+665",
+            "input": "గల",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "gaavoweltelu=0+842",
+            "input": "గా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "jevoweltelu=0+686",
+            "input": "జె",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tatelu=0+723|matelu=1+988",
+            "input": "తమ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "natelu=0+658|uvowelsigntelu=0+318",
+            "input": "ను",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bivoweltelu=0+709",
+            "input": "బి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|divoweltelu=1+657",
+            "input": "అది",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|nivoweltelu=1+674",
+            "input": "అని",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|ratelu=1+564|vatelu=2+670",
+            "input": "అరవ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|veevoweltelu=1+670",
+            "input": "అవే",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "aatelu=0+739|phahalanttelu=1+670",
+            "input": "ఆఫ్",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "itelu=0+629|anusvaratelu=0+490|katelu=2+481",
+            "input": "ఇంక",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "itelu=0+629|anusvaratelu=0+490|tatelu=2+723",
+            "input": "ఇంత",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "itelu=0+629|tatelu=1+723|ratelu=2+564",
+            "input": "ఇతర",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "itelu=0+629|divoweltelu=1+657",
+            "input": "ఇది",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "etelu=0+671|sahalanttelu=1+658",
+            "input": "ఎస్",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+489|uuvowelsigntelu=0+600|ddatelu=2+690",
+            "input": "కూడ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "koovoweltelu=0+648|yatelu=2+1186",
+            "input": "కోయ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "teevoweltelu=0+723|ttatelu=2+716",
+            "input": "తేట",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "toovoweltelu=0+789|ddatelu=2+690",
+            "input": "తోడ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|vatelu=2+670",
+            "input": "భావ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "matelu=0+988|natelu=1+658|anusvaratelu=1+490",
+            "input": "మనం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "miivoweltelu=0+1027|datelu=2+657",
+            "input": "మీద",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "matelu=0+988|uuvowelsigntelu=0+600|latelu=2+665",
+            "input": "మూల",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "latelu=0+665|toovoweltelu=1+845",
+            "input": "లతో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vatelu=0+670|latelu=1+665|natelu=2+658",
+            "input": "వలన",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|katelu=1+481|latelu=2+665",
+            "input": "సకల",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|haavoweltelu=1+950",
+            "input": "సహా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssatelu=2+674|quotesingle.telu=3+272",
+            "input": "భాష'",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|anusvaratelu=0+490|tteevoweltelu=2+716",
+            "input": "అంటే",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|natelu=1+658|gaavoweltelu=2+842",
+            "input": "అనగా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|yivoweltelu=1+1192|natelu=3+658",
+            "input": "అయిన",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "aatelu=0+739|ratelu=1+556|yasubscripttelu=1+396",
+            "input": "ఆర్య",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "itelu=0+629|anusvaratelu=0+490|ddoovoweltelu=2+809",
+            "input": "ఇండో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "utelu=0+792|anusvaratelu=0+490|divoweltelu=2+657",
+            "input": "ఉంది",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "utelu=0+768|natelu=1+616|nasubscripttelu=1+302",
+            "input": "ఉన్న",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "otelu=0+684|katelu=1+481|ttivoweltelu=2+716",
+            "input": "ఒకటి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "otelu=0+684|katelu=1+489|kasubscripttelu=1+421",
+            "input": "ఒక్క",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+481|anusvaratelu=0+490|tteevoweltelu=2+716",
+            "input": "కంటే",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "kaavoweltelu=0+780|datelu=2+657|uvowelsigntelu=2+318",
+            "input": "కాదు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "kaavoweltelu=0+749|niivoweltelu=2+674",
+            "input": "కానీ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+489|uvowelsigntelu=0+318|yivoweltelu=2+1192",
+            "input": "కుయి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+489|uuvowelsigntelu=0+600|ddaavoweltelu=2+942",
+            "input": "కూడా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "gaavoweltelu=0+842|ratelu=2+550|uvowelsigntelu=2+318",
+            "input": "గారు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "caavoweltelu=0+985|laavoweltelu=2+952",
+            "input": "చాలా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "jatelu=0+686|gatelu=1+570|tivoweltelu=2+723",
+            "input": "జగతి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "jatelu=0+686|natelu=1+658|nivoweltelu=2+674",
+            "input": "జనని",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tatelu=0+723|mivoweltelu=1+1027|llatelu=3+622",
+            "input": "తమిళ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tatelu=0+703|uvowelsigntelu=0+318|llatelu=2+622|uvowelsign1telu=2+359",
+            "input": "తుళు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "natelu=0+658|anusvaratelu=0+490|datelu=2+657|uvowelsigntelu=2+318",
+            "input": "నందు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|daavoweltelu=1+929|latelu=3+665",
+            "input": "పదాల",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "poovoweltelu=0+966|ttiivoweltelu=2+716",
+            "input": "పోటీ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|vatelu=2+670|anusvaratelu=2+490",
+            "input": "భావం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssaavoweltelu=2+968",
+            "input": "భాషా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|sseevoweltelu=2+689",
+            "input": "భాషే",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "matelu=0+988|anusvaratelu=0+490|civoweltelu=2+723",
+            "input": "మంచి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "matelu=0+988|dhatelu=1+650|yasubscripttelu=1+396",
+            "input": "మధ్య",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "meevoweltelu=0+988|latelu=2+665|uvowelsigntelu=2+318",
+            "input": "మేలు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "leevoweltelu=0+665|datelu=2+657|uvowelsigntelu=2+318",
+            "input": "లేదు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "loovoweltelu=0+907|nivoweltelu=2+674",
+            "input": "లోని",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vatelu=0+670|ratelu=1+550|uvowelsigntelu=1+318|satelu=3+658",
+            "input": "వరుస",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vatelu=0+670|latelu=1+665|lasubscripttelu=1@-58,0+0",
+            "input": "వల్ల",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vaavoweltelu=0+942|datelu=2+657|natelu=3+658",
+            "input": "వాదన",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vaavoweltelu=0+942|rivoweltelu=2+564",
+            "input": "వారి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vaavoweltelu=0+942|ratelu=2+550|uvowelsigntelu=2+318",
+            "input": "వారు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vaavoweltelu=0+911|satelu=2+658|natelu=3+658",
+            "input": "వాసన",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "viivoweltelu=0+687|rivoweltelu=2+564",
+            "input": "వీరి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+481|ratelu=1+564|tasubscriptnarrowtelu=1@-32,0+0|hyphen.telu=4+320|katelu=5+481|ratelu=6+527|masubscripttelu=6+212|hyphen.telu=9+320|kivoweltelu=10+481|karasubscripttelu=10+0|yatelu=14+1186",
+            "input": "కర్త-కర్మ-క్రియ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+481|ratelu=1+564|tasubscriptnarrowtelu=1@-32,0+0|hyphen.telu=4+320|kivoweltelu=5+481|karasubscripttelu=5+0|yatelu=9+1186|hyphen.telu=10+320|katelu=11+481|ratelu=12+527|masubscripttelu=12+212",
+            "input": "కర్త-క్రియ-కర్మ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "gaavoweltelu=0+842|devoweltelu=2+657|question.telu=4+504|.notdef=5+600|quotedblright.telu=6+476",
+            "input": "గాదె?\t”",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|nivoweltelu=1+669|nasubscripttelu=1+302",
+            "input": "అన్ని",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "aatelu=0+739|anusvaratelu=0+490|gatelu=2+570|lasubscripttelu=2@-11,0+0",
+            "input": "ఆంగ్ల",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "utelu=0+792|anusvaratelu=0+490|ddatelu=2+690|ddatelu=3+690|anusvaratelu=3+490",
+            "input": "ఉండడం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "utelu=0+798|ratelu=1+550|uuvowelsigntelu=1+600|dasubscripttelu=1@-627,0+0",
+            "input": "ఉర్దూ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+481|natelu=1+616|nasubscripttelu=1+302|ddatelu=4+690",
+            "input": "కన్నడ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+489|uuvowelsigntelu=0+600|ratelu=2+564|khahalanttelu=3+724",
+            "input": "కూరఖ్",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "keevoweltelu=0+481|vatelu=2+670|latelu=3+665|anusvaratelu=3+490",
+            "input": "కేవలం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "koovoweltelu=0+687|satelu=2+658|meevoweltelu=3+988",
+            "input": "కోసమే",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "govoweltelu=0+689|latelu=2+665|uvowelsigntelu=2+318|vatelu=4+670",
+            "input": "గొలువ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "jatelu=0+686|natelu=1+658|uvowelsigntelu=1+307|yasubscripttelu=1+396",
+            "input": "జన్యు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "jaavoweltelu=0+949|tiivoweltelu=2+723|yatelu=4+1186",
+            "input": "జాతీయ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tevoweltelu=0+723|latelu=2+665|uvowelsigntelu=2+318|gatelu=4+570",
+            "input": "తెలుగ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "datelu=0+657|gatelu=1+570|gasubscripttelu=1@-78,0+0|ratelu=4+564",
+            "input": "దగ్గర",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "natelu=0+658|uvowelsigntelu=0+318|anusvaratelu=0+490|ddivoweltelu=3+690",
+            "input": "నుండి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|daavoweltelu=1+929|latelu=3+665|uvowelsigntelu=3+318",
+            "input": "పదాలు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssatelu=2+674|nivoweltelu=3+674",
+            "input": "భాషని",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssatelu=2+674|paivoweltelu=3+685",
+            "input": "భాషపై",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssatelu=2+674|latelu=3+665|uvowelsigntelu=3+318",
+            "input": "భాషలు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssatelu=2+674|latelu=3+665|uuvowelsigntelu=3+600",
+            "input": "భాషలూ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssatelu=2+674|loovoweltelu=3+922",
+            "input": "భాషలో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "matelu=0+988|llatelu=1+622|yaavoweltelu=2+1479|llatelu=4+622",
+            "input": "మళయాళ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "matelu=0+988|uvowelsigntelu=0+318|anusvaratelu=0+490|datelu=3+657|uvowelsigntelu=3+318",
+            "input": "ముందు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "raavoweltelu=0+849|yatelu=2+1186|latelu=3+665|uvowelsigntelu=3+318",
+            "input": "రాయలు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "revoweltelu=0+564|anusvaratelu=0+490|ddatelu=3+695|uvowelsigntelu=3+318",
+            "input": "రెండు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "levoweltelu=0+665|satelu=2+622|sasubscripttelu=2+326",
+            "input": "లెస్స",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vivoweltelu=0+687|ssatelu=2+674|yatelu=3+1186|anusvaratelu=3+490",
+            "input": "విషయం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vaivoweltelu=0+670|divoweltelu=2+657|katelu=4+481",
+            "input": "వైదిక",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "sivoweltelu=0+658|thasubscripttelu=0@-88,0+0|ratelu=4+564",
+            "input": "స్థిర",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "hivoweltelu=0+928|anusvaratelu=0+490|diivoweltelu=3+657",
+            "input": "హిందీ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "emdash.telu=0+1000|shiivoweltelu=1+529|sharasubscripttelu=1+0",
+            "input": "—శ్రీ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "levoweltelu=0+665|satelu=2+622|sasubscripttelu=2+326|.notdef=5+600|quotedblright.telu=6+476",
+            "input": "లెస్స\t”",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "iitelu=0+912|sahalanttelu=1+658|ttasubscripttelu=1@-68,0+0|quotedbl.telu=5+460",
+            "input": "ఈస్ట్\"",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "aatelu=0+739|ratelu=1+556|yasubscripttelu=1+396|nahalanttelu=4+658",
+            "input": "ఆర్యన్",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "itelu=0+629|katelu=1+489|kasubscripttelu=1+421|ddivoweltelu=4+690",
+            "input": "ఇక్కడి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "itelu=0+629|datelu=1+657|dasubscripttelu=1@-87,0+0|ratelu=4+550|uvowelsigntelu=4+318",
+            "input": "ఇద్దరు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "utelu=0+792|anusvaratelu=0+490|ttaavoweltelu=2+988|yivoweltelu=4+1192",
+            "input": "ఉంటాయి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "utelu=0+768|natelu=1+616|nasubscripttelu=1+302|vivoweltelu=4+687",
+            "input": "ఉన్నవి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "etelu=0+671|katelu=1+489|uvowelsigntelu=1+303|kasubscripttelu=1+421|vatelu=5+670",
+            "input": "ఎక్కువ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "kiivoweltelu=0+481|ratelu=2+564|tasubscriptnarrowtelu=2@-32,0+0|natelu=5+658",
+            "input": "కీర్తన",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+491|rvocalicvowelsigntelu=0+358|tatelu=2+703|uvowelsigntelu=2+318|latelu=4+665|uvowelsigntelu=4+318",
+            "input": "కృతులు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "kovoweltelu=0+653|divoweltelu=2+657|dasubscripttelu=2@-87,0+0",
+            "input": "కొద్ది",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "kovoweltelu=0+652|laavoweltelu=2+921|mivoweltelu=4+1027",
+            "input": "కొలామి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "koovoweltelu=0+648|saavoweltelu=2+968|tasubscripttelu=2@-354,0+0",
+            "input": "కోస్తా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "giivoweltelu=0+570|garasubscripttelu=0+0|katelu=4+489|uvowelsigntelu=4+318",
+            "input": "గ్రీకు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "catelu=0+713|kevoweltelu=1+489|kasubscripttelu=1+397|ratelu=5+564",
+            "input": "చక్కెర",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "cevoweltelu=0+713|anusvaratelu=0+490|divoweltelu=3+657|natelu=5+658",
+            "input": "చెందిన",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tatelu=0+723|mivoweltelu=1+1027|llatelu=3+622|matelu=4+988|uvowelsigntelu=4+318",
+            "input": "తమిళము",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "datelu=0+657|uuvowelsigntelu=0+600|ratelu=2+564|anusvaratelu=2+490|loovoweltelu=4+922",
+            "input": "దూరంలో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "deevoweltelu=0+657|shatelu=2+529|anusvaratelu=2+490|batelu=4+693|uvowelsigntelu=4+318",
+            "input": "దేశంబు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "natelu=0+658|matelu=1+964|masubscripttelu=1+212|katelu=4+481|anusvaratelu=4+490",
+            "input": "నమ్మకం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "nivoweltelu=0+674|mivoweltelu=2+1027|ssatelu=4+674|anusvaratelu=4+490",
+            "input": "నిమిషం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "nivoweltelu=0+674|vaavoweltelu=2+911|satelu=4+658|anusvaratelu=4+490",
+            "input": "నివాసం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|daavoweltelu=1+929|latelu=3+665|natelu=4+658|uvowelsigntelu=4+318",
+            "input": "పదాలను",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "paavoweltelu=0+972|katelu=2+481|anusvaratelu=2+490|batelu=4+693|uvowelsigntelu=4+318",
+            "input": "పాకంబు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "paavoweltelu=0+968|ttatelu=2+716|uvowelsigntelu=2+318|gaavoweltelu=4+842",
+            "input": "పాటుగా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "povoweltelu=0+966|ratelu=2+550|uvowelsigntelu=2+318|gatelu=4+562|uvowelsigntelu=4+318",
+            "input": "పొరుగు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|parasubscripttelu=0+0|matelu=3+988|uvowelsigntelu=3+318|khatelu=5+724",
+            "input": "ప్రముఖ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssatelu=2+674|latelu=3+665|toovoweltelu=4+845",
+            "input": "భాషలతో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "maavoweltelu=0+1270|loovoweltelu=2+922|tasubscripttelu=2@-304,0+0",
+            "input": "మాల్తో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "mevoweltelu=0+988|catelu=2+713|uvowelsigntelu=2+282|casubscripttelu=2+326",
+            "input": "మెచ్చు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "movoweltelu=0+1306|tatelu=2+723|tasubscripttelu=2@-76,0+0|anusvaratelu=2+490",
+            "input": "మొత్తం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "movoweltelu=0+1306|datelu=2+657|latelu=3+665|gatelu=4+562|uvowelsigntelu=4+318",
+            "input": "మొదలగు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "laavoweltelu=0+952|ttivoweltelu=2+716|natelu=4+658|uvowelsigntelu=4+318",
+            "input": "లాటిను",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "livoweltelu=0+690|pivoweltelu=2+670|loovoweltelu=4+922",
+            "input": "లిపిలో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vatelu=0+670|ratelu=1+550|uvowelsigntelu=1+318|satelu=3+658|loovoweltelu=4+922",
+            "input": "వరుసలో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vaavoweltelu=0+946|katelu=2+466|yasubscripttelu=2+384|anusvaratelu=2+490",
+            "input": "వాక్యం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "shaavoweltelu=0+818|shatelu=2+508|vasubscripttelu=2+396|tatelu=5+723",
+            "input": "శాశ్వత",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|anusvaratelu=0+490|giivoweltelu=2+570|tatelu=4+723|anusvaratelu=4+490",
+            "input": "సంగీతం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|anusvaratelu=0+490|batelu=2+693|anusvaratelu=2+490|dhatelu=4+657|anusvaratelu=4+490",
+            "input": "సంబంధం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "saavoweltelu=0+937|hivoweltelu=2+950|tiivoweltelu=4+723",
+            "input": "సాహితీ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "saavoweltelu=0+937|thasubscripttelu=0@-367,0+0|natelu=4+658|anusvaratelu=4+490",
+            "input": "స్థానం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|catelu=1+713|uvowelsigntelu=1+282|casubscripttelu=1+326|toovoweltelu=5+845",
+            "input": "అచ్చుతో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|ratelu=1+564|hasubscripttelu=1@61,0+0|tatelu=4+723|latelu=5+665|uvowelsigntelu=5+318",
+            "input": "అర్హతలు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "aatelu=0+739|anusvaratelu=0+490|gatelu=2+570|lasubscripttelu=2@-11,0+0|matelu=5+988|uvowelsigntelu=5+318",
+            "input": "ఆంగ్లము",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "itelu=0+629|ssatelu=1+674|ttasubscripttelu=1@-100,-30+0|maivoweltelu=4+988|natelu=6+658",
+            "input": "ఇష్టమైన",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "utelu=0+792|anusvaratelu=0+490|ttatelu=2+716|uvowelsigntelu=2+318|anusvaratelu=2+490|divoweltelu=5+657",
+            "input": "ఉంటుంది",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "utelu=0+792|anusvaratelu=0+490|ddeevoweltelu=2+690|vatelu=4+670|nivoweltelu=5+674",
+            "input": "ఉండేవని",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "utelu=0+798|caavoweltelu=1+1015|casubscripttelu=1+326|ratelu=5+564|nnatelu=6+786",
+            "input": "ఉచ్చారణ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "utelu=0+798|chaavoweltelu=1+1015|chasubscripttelu=1+326|ratelu=5+564|nnatelu=6+786",
+            "input": "ఉఛ్ఛారణ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "utelu=0+768|naavoweltelu=1+958|nasubscripttelu=1+302|yivoweltelu=5+1192",
+            "input": "ఉన్నాయి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "rvocalictelu=0+1325|juvoweltelu=1+875|vuvoweltelu=3+916|latelu=5+665|uvowelsigntelu=5+318",
+            "input": "ఋజువులు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "eetelu=0+671|miivoweltelu=1+1027|leevoweltelu=3+665|datelu=5+657|uvowelsigntelu=5+318",
+            "input": "ఏమీలేదు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+481|natelu=1+616|nasubscripttelu=1+302|ddatelu=4+690|matelu=5+988|uvowelsigntelu=5+318",
+            "input": "కన్నడము",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+481|raavoweltelu=1+849|nnasubscripttelu=1@-277,0+0|ttatelu=5+716|katelu=6+481",
+            "input": "కర్ణాటక",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+481|ratelu=1+527|masubscripttelu=1+212|latelu=4+665|natelu=5+658|uvowelsigntelu=5+318",
+            "input": "కర్మలను",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+481|satelu=1+658|uuvowelsigntelu=1+600|tasubscripttelu=1@-644,0+0|rivoweltelu=5+564",
+            "input": "కస్తూరి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+491|rvocalicvowelsigntelu=0+358|tatelu=2+703|uvowelsigntelu=2+318|latelu=4+665|toovoweltelu=5+845",
+            "input": "కృతులతో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "gatelu=0+562|uvowelsigntelu=0+318|rivoweltelu=2+564|anusvaratelu=2+490|civoweltelu=5+723",
+            "input": "గురించి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "catelu=0+713|uuvowelsigntelu=0+569|patelu=2+670|leevoweltelu=3+665|datelu=5+657|uvowelsigntelu=5+318",
+            "input": "చూపలేదు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "cevoweltelu=0+713|patelu=2+634|pasubscripttelu=2+326|ddatelu=5+690|anusvaratelu=5+490",
+            "input": "చెప్పడం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tatelu=0+703|uuvowelsigntelu=0+600|ratelu=2+550|uvowelsigntelu=2+282|pasubscripttelu=2+326|natelu=6+658",
+            "input": "తూర్పున",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "deevoweltelu=0+657|latelu=2+665|yatelu=3+1186|natelu=4+616|nasubscripttelu=4+302",
+            "input": "దేలయన్న",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "daavoweltelu=0+898|darasubscripttelu=0@-239,0+0|vivoweltelu=4+687|ddatelu=6+690",
+            "input": "ద్రావిడ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|anusvaratelu=0+490|ddivoweltelu=2+690|tatelu=4+703|uvowelsigntelu=4+318|latelu=6+665",
+            "input": "పండితుల",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|datelu=1+657|matelu=2+988|uvowelsigntelu=2+318|latelu=4+665|natelu=5+658|uvowelsigntelu=5+318",
+            "input": "పదములను",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|ratelu=1+564|anusvaratelu=1+490|gaavoweltelu=3+811|natelu=5+658|uuvowelsigntelu=5+600",
+            "input": "పరంగానూ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|parasubscripttelu=0+0|tiivoweltelu=3+723|tivoweltelu=5+723",
+            "input": "ప్రతీతి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|parasubscripttelu=0+0|bhaavoweltelu=3+935|vatelu=5+670|anusvaratelu=5+490",
+            "input": "ప్రభావం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "batelu=0+693|barasubscripttelu=0+0|hatelu=3+950|uuvowelsign2telu=3+657|yivoweltelu=5+1192",
+            "input": "బ్రహూయి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhatelu=0+693|daavoweltelu=1+929|darasubscripttelu=1@-270,0+0|catelu=5+713|latelu=6+665",
+            "input": "భద్రాచల",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssatelu=2+674|latelu=3+665|anusvaratelu=3+490|datelu=5+657|uvowelsigntelu=5+318",
+            "input": "భాషలందు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssatelu=2+674|loovoweltelu=3+907|nivoweltelu=5+674",
+            "input": "భాషలోని",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssatelu=2+674|loovoweltelu=3+922|neevoweltelu=5+658",
+            "input": "భాషలోనే",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "matelu=0+988|latelu=1+665|yaavoweltelu=2+1479|llatelu=4+622|matelu=5+988|uvowelsigntelu=5+318",
+            "input": "మలయాళము",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "maavoweltelu=0+1270|tatelu=2+723|tarasubscripttelu=2+0|matelu=5+988|uvowelsigntelu=5+318",
+            "input": "మాత్రము",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "mivoweltelu=0+1027|rivoweltelu=2+564|yaavoweltelu=4+1468|latelu=6+665",
+            "input": "మిరియాల",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "raavoweltelu=0+818|matelu=2+988|daavoweltelu=3+898|satelu=5+658|uvowelsigntelu=5+318",
+            "input": "రామదాసు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "leevoweltelu=0+665|katelu=2+489|uvowelsigntelu=2+318|anusvaratelu=2+490|ddaavoweltelu=5+942",
+            "input": "లేకుండా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vatelu=0+670|saavoweltelu=1+968|tasubscripttelu=1@-354,0+0|yivoweltelu=5+1192",
+            "input": "వస్తాయి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vaavoweltelu=0+942|ddatelu=2+695|uvowelsigntelu=2+318|katelu=4+481|loovoweltelu=5+922",
+            "input": "వాడుకలో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vivoweltelu=0+687|patelu=2+670|lasubscripttelu=2@-61,0+0|vatelu=5+670|anusvaratelu=5+490",
+            "input": "విప్లవం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vaavoweltelu=0+942|yasubscripttelu=0+396|katelu=4+481|ratelu=5+564|nnatelu=6+786",
+            "input": "వ్యాకరణ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|anusvaratelu=0+490|satelu=2+643|kasubscripttelu=2+303|rvocalicvowelsign1telu=2+487|tatelu=6+723",
+            "input": "సంస్కృత",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|uvowelsigntelu=0+318|latelu=2+665|bhatelu=3+693|anusvaratelu=3+490|gaavoweltelu=5+842",
+            "input": "సులభంగా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "hatelu=0+950|latelu=1+665|uvowelsigntelu=1+318|lasubscripttelu=1@-376,0+0|latelu=5+665|uvowelsigntelu=5+318",
+            "input": "హల్లులు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "utelu=0+768|naavoweltelu=1+958|nasubscripttelu=1+302|yivoweltelu=5+1192|bracketleft.telu=7+330|five.telu=8+559|bracketright.telu=9+330",
+            "input": "ఉన్నాయి[5]",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|vatelu=1+670|loovoweltelu=2+922|katelu=4+481|natelu=5+658|anusvaratelu=5+490|bracketleft.telu=7+330|maavoweltelu=8+1270|ratelu=10+550|uvowelsigntelu=10+282|casubscripttelu=10+326|bracketright.telu=14+330",
+            "input": "అవలోకనం[మార్చు]",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|anusvaratelu=0+490|tatelu=2+723|matelu=3+988|yeevoweltelu=4+1175|yasubscripttelu=4+396",
+            "input": "అంతమయ్యే",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|natelu=1+616|nasubscripttelu=1+302|matelu=4+988|yatelu=5+1175|yasubscripttelu=5+396",
+            "input": "అన్నమయ్య",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|matelu=1+957|rvocalicvowelsigntelu=1+358|tatelu=3+723|raavoweltelu=4+849|shivoweltelu=6+529",
+            "input": "అమృతరాశి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|vatelu=1+670|kaavoweltelu=2+780|shaavoweltelu=4+818|latelu=6+665|uvowelsigntelu=6+318",
+            "input": "అవకాశాలు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|vatelu=1+670|ttaavoweltelu=2+957|nivoweltelu=4+674|kivoweltelu=6+481",
+            "input": "అవటానికి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "itelu=0+629|anusvaratelu=0+490|giivoweltelu=2+570|lasubscripttelu=2@-11,0+0|ssatelu=6+674|uvowelsigntelu=6+318",
+            "input": "ఇంగ్లీషు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "itelu=0+629|ttaavoweltelu=1+988|livoweltelu=3+690|yatelu=5+1186|nahalanttelu=6+658",
+            "input": "ఇటాలియన్",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "itelu=0+629|patelu=1+634|pasubscripttelu=1+326|ttivoweltelu=4+716|kiivoweltelu=6+481",
+            "input": "ఇప్పటికీ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "etelu=0+671|anusvaratelu=0+490|datelu=2+657|uvowelsigntelu=2+318|katelu=4+481|natelu=5+658|gaavoweltelu=6+842",
+            "input": "ఎందుకనగా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "etelu=0+671|katelu=1+489|uvowelsigntelu=1+303|kasubscripttelu=1+421|vatelu=5+670|nivoweltelu=6+674",
+            "input": "ఎక్కువని",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+491|rvocalicvowelsigntelu=0+358|ssatelu=2+674|nnasubscripttelu=2@-73,-30+0|deevoweltelu=5+657|vatelu=7+670",
+            "input": "కృష్ణదేవ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "kovoweltelu=0+545|anusvaratelu=0+490|tatelu=3+723|matelu=4+988|anusvaratelu=4+490|divoweltelu=6+657",
+            "input": "కొంతమంది",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "gatelu=0+570|matelu=1+988|nivoweltelu=2+674|seevoweltelu=4+673|tasubscripttelu=4@-52,0+0",
+            "input": "గమనిస్తే",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ceevoweltelu=0+713|sivoweltelu=2+658|naavoweltelu=4+928|ratelu=6+550|uvowelsigntelu=6+318",
+            "input": "చేసినారు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tevoweltelu=0+723|latelu=2+665|uvowelsigntelu=2+318|gatelu=4+562|uvowelsigntelu=4+318|kivoweltelu=6+481",
+            "input": "తెలుగుకి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tevoweltelu=0+723|latelu=2+665|uvowelsigntelu=2+318|gatelu=4+562|uvowelsigntelu=4+318|toovoweltelu=6+845",
+            "input": "తెలుగుతో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tevoweltelu=0+723|latelu=2+665|uvowelsigntelu=2+318|gatelu=4+562|uvowelsigntelu=4+318|natelu=6+658|uvowelsigntelu=6+318",
+            "input": "తెలుగును",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tevoweltelu=0+723|latelu=2+665|uvowelsigntelu=2+318|gatelu=4+562|uvowelsigntelu=4+318|loovoweltelu=6+922",
+            "input": "తెలుగులో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tevoweltelu=0+723|latelu=2+665|uvowelsigntelu=2+318|geevoweltelu=4+570|natelu=6+658|uvowelsigntelu=6+318",
+            "input": "తెలుగేను",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "datelu=0+657|kassivoweltelu=1+481|nnaavoweltelu=5+1038|natelu=7+658",
+            "input": "దక్షిణాన",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "deevoweltelu=0+657|shaavoweltelu=2+787|nivoweltelu=4+674|kivoweltelu=6+481",
+            "input": "దేశానికి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "nivoweltelu=0+674|jaavoweltelu=2+918|nivoweltelu=4+674|kivoweltelu=6+481",
+            "input": "నిజానికి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|ddatelu=1+695|uvowelsigntelu=1+318|tatelu=3+703|uvowelsigntelu=3+318|anusvaratelu=3+490|divoweltelu=6+657",
+            "input": "పడుతుంది",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|rivoweltelu=1+564|ssasubscripttelu=1@-20,0+0|yatelu=5+1186|natelu=6+658|uvowelsigntelu=6+318",
+            "input": "పర్షియను",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|parasubscripttelu=0+0|bhaavoweltelu=3+935|vatelu=5+670|matelu=6+988|uvowelsigntelu=6+318",
+            "input": "ప్రభావము",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "baavoweltelu=0+935|barasubscripttelu=0@-242,0+0|hatelu=4+950|uvowelsign2telu=4+375|yivoweltelu=6+1192",
+            "input": "బ్రాహుయి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bivoweltelu=0+709|barasubscripttelu=0@-16,0+0|ttiivoweltelu=4+716|ssatelu=6+674|uvowelsigntelu=6+318",
+            "input": "బ్రిటీషు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+966|ratelu=2+564|tatelu=3+723|deevoweltelu=4+657|shatelu=6+529|anusvaratelu=6+490",
+            "input": "భారతదేశం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssatelu=2+674|latelu=3+665|katelu=4+489|uvowelsigntelu=4+318|natelu=6+658|uvowelsigntelu=6+318",
+            "input": "భాషలకును",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "matelu=0+988|haavoweltelu=1+919|paavoweltelu=3+968|parasubscripttelu=3@-298,0+0|nnatelu=7+786",
+            "input": "మహాప్రాణ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "raavoweltelu=0+818|matelu=2+988|katelu=3+491|rvocalicvowelsigntelu=3+358|ssatelu=5+674|nnasubscripttelu=5@-73,-30+0",
+            "input": "రామకృష్ణ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "roovoweltelu=0+714|juvoweltelu=2+906|loovoweltelu=4+922|lasubscripttelu=4@-315,0+0",
+            "input": "రోజుల్లో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vatelu=0+670|anusvaratelu=0+490|ttivoweltelu=2+716|vaavoweltelu=4+942|ratelu=6+550|uvowelsigntelu=6+318",
+            "input": "వంటివారు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vatelu=0+670|latelu=1+665|lasubscripttelu=1@-58,0+0|bhatelu=4+693|uvowelsigntelu=4+318|anusvaratelu=4+490|ddatelu=7+690",
+            "input": "వల్లభుండ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vaavoweltelu=0+942|yatelu=2+1186|vaavoweltelu=3+942|yasubscripttelu=3+396|natelu=7+658",
+            "input": "వాయవ్యాన",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vivoweltelu=0+687|natelu=2+658|uvowelsigntelu=2+318|kovoweltelu=4+545|anusvaratelu=4+490|ddatelu=7+690",
+            "input": "వినుకొండ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|anusvaratelu=0+490|satelu=2+643|kasubscripttelu=2+303|rvocalicvowelsign1telu=2+487|tatelu=6+723|anusvaratelu=6+490",
+            "input": "సంస్కృతం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|tatelu=1+718|yasubscripttelu=1+396|datelu=4+657|uuvowelsigntelu=4+600|ratelu=6+564|anusvaratelu=6+490",
+            "input": "సత్యదూరం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "saavoweltelu=0+946|anusvaratelu=0+490|keevoweltelu=3+481|tivoweltelu=5+723|katelu=7+481",
+            "input": "సాంకేతిక",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "sivoweltelu=0+658|anusvaratelu=0+490|dhatelu=3+657|uvowelsigntelu=3+318|loovoweltelu=5+883|yatelu=7+1186",
+            "input": "సింధులోయ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "haavoweltelu=0+950|leevoweltelu=2+665|ddasubscripttelu=2@-78,0+0|nahalanttelu=6+658",
+            "input": "హాల్డేన్",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vivoweltelu=0+687|natelu=2+658|vatelu=3+670|catelu=4+713|uvowelsigntelu=4+282|casubscripttelu=4+326|quotedbl.telu=8+460",
+            "input": "వినవచ్చు\"",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|kassatelu=1+481|ratelu=4+564|matelu=5+988|uvowelsigntelu=5+318|latelu=7+665|uvowelsigntelu=7+318",
+            "input": "అక్షరములు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|bhivoweltelu=1+709|paavoweltelu=3+968|parasubscripttelu=3@-298,0+0|yatelu=7+1186|anusvaratelu=7+490",
+            "input": "అభిప్రాయం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "aatelu=0+739|ratelu=1+556|yasubscripttelu=1+396|bhaavoweltelu=4+935|ssatelu=6+674|latelu=7+665|uvowelsigntelu=7+318",
+            "input": "ఆర్యభాషలు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "aatelu=0+739|shatelu=1+529|casubscripttelu=1+326|ratelu=4+556|yasubscripttelu=4+396|matelu=7+988|uvowelsigntelu=7+318",
+            "input": "ఆశ్చర్యము",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+481|livoweltelu=1+690|sivoweltelu=3+658|poovoweltelu=5+966|yevoweltelu=7+1186",
+            "input": "కలిసిపోయె",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "kaavoweltelu=0+749|vatelu=2+670|ddaavoweltelu=3+911|nivoweltelu=5+674|kivoweltelu=7+481",
+            "input": "కావడానికి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "khatelu=0+724|civoweltelu=1+718|casubscripttelu=1+326|tatelu=5+723|anusvaratelu=5+490|gaavoweltelu=7+842",
+            "input": "ఖచ్చితంగా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "cevoweltelu=0+713|anusvaratelu=0+490|datelu=3+657|katelu=4+489|uvowelsigntelu=4+318|anusvaratelu=4+490|ddaavoweltelu=7+942",
+            "input": "చెందకుండా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "cevoweltelu=0+713|anusvaratelu=0+490|divoweltelu=3+657|natelu=5+658|datelu=6+657|nivoweltelu=7+674",
+            "input": "చెందినదని",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "jatelu=0+686|ratelu=1+564|patelu=2+670|ddaavoweltelu=3+911|nivoweltelu=5+674|kivoweltelu=7+481",
+            "input": "జరపడానికి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ttaavoweltelu=0+988|ddatelu=2+695|uvowelsigntelu=2+318|bivoweltelu=4+709|ddatelu=6+690|ddasubscripttelu=6@-91,0+0",
+            "input": "టాడుబిడ్డ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tatelu=0+723|livoweltelu=1+690|lasubscripttelu=1@-83,0+0|katelu=5+481|anusvaratelu=5+490|ttevoweltelu=7+716",
+            "input": "తల్లికంటె",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tevoweltelu=0+723|latelu=2+665|uvowelsigntelu=2+318|govoweltelu=4+724|katelu=6+481|anusvaratelu=6+490|ddatelu=8+690",
+            "input": "తెలుగొకండ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "teevoweltelu=0+723|livoweltelu=2+690|katelu=4+481|gaavoweltelu=5+811|natelu=7+658|uuvowelsigntelu=7+600",
+            "input": "తేలికగానూ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "taavoweltelu=0+988|yasubscripttelu=0+396|gatelu=4+570|raavoweltelu=5+849|juvoweltelu=7+906",
+            "input": "త్యాగరాజు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|anusvaratelu=0+490|ddivoweltelu=2+690|tatelu=4+703|uvowelsigntelu=4+318|latelu=6+665|natelu=7+658|uvowelsigntelu=7+318",
+            "input": "పండితులను",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "puvoweltelu=0+916|ttivoweltelu=2+716|ttasubscripttelu=2@-97,0+0|natelu=6+658|divoweltelu=7+657",
+            "input": "పుట్టినది",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|parasubscripttelu=0+0|patelu=3+670|anusvaratelu=3+490|catelu=5+713|anusvaratelu=5+490|loovoweltelu=7+922",
+            "input": "ప్రపంచంలో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|parasubscripttelu=0+0|satelu=3+658|uvowelsigntelu=3+318|tasubscripttelu=3@-362,0+0|tatelu=7+723|anusvaratelu=7+490",
+            "input": "ప్రస్తుతం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "matelu=0+988|uvowelsigntelu=0+318|khatelu=2+713|yasubscripttelu=2+396|matelu=5+988|uvowelsigntelu=5+318|gaavoweltelu=7+842",
+            "input": "ముఖ్యముగా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vatelu=0+670|ratelu=1+564|gasubscripttelu=1@-75,0+0|matelu=4+988|uvowelsigntelu=4+318|natelu=6+658|katelu=7+489|uvowelsigntelu=7+318",
+            "input": "వర్గమునకు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vaavoweltelu=0+942|yasubscripttelu=0+396|katelu=4+481|ratelu=5+564|nnatelu=6+786|matelu=7+988|uvowelsigntelu=7+318",
+            "input": "వ్యాకరణము",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|anusvaratelu=0+490|satelu=2+643|kasubscripttelu=2+303|rvocalicvowelsign1telu=2+487|tatelu=6+723|matelu=7+988|uvowelsigntelu=7+318",
+            "input": "సంస్కృతము",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|uvowelsigntelu=0+318|satelu=2+658|anusvaratelu=2+490|patelu=4+670|natelu=5+616|nasubscripttelu=5+290|anusvaratelu=5+490",
+            "input": "సుసంపన్నం",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+647|vasubscripttelu=0+396|chatelu=3+677|chasubscripttelu=3+316|anusvaratelu=3+490|gaavoweltelu=7+842",
+            "input": "స్వఛ్ఛంగా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|tivoweltelu=1+723|shatelu=3+529|yoovoweltelu=4+1472|kivoweltelu=6+481|tasubscriptnarrowtelu=6@10,0+0",
+            "input": "అతిశయోక్తి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "etelu=0+671|latelu=1+665|lasubscripttelu=1@-58,0+0|natelu=4+619|rvocalicvowelsigntelu=4+358|puvoweltelu=6+916|latelu=8+665|uvowelsigntelu=8+318",
+            "input": "ఎల్లనృపులు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+489|uvowelsigntelu=0+318|ttatelu=2+716|uvowelsigntelu=2+318|anusvaratelu=2+490|batelu=5+693|matelu=6+988|uvowelsigntelu=6+318|loovoweltelu=8+922",
+            "input": "కుటుంబములో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "kasseevoweltelu=0+481|tatelu=4+723|tarasubscripttelu=4+0|yatelu=7+1175|yasubscripttelu=7+396",
+            "input": "క్షేత్రయ్య",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "catelu=0+713|uuvowelsigntelu=0+569|pivoweltelu=2+670|anusvaratelu=2+490|civoweltelu=5+723|natelu=7+658|anusvaratelu=7+490|tatelu=9+723",
+            "input": "చూపించినంత",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "cevoweltelu=0+713|anusvaratelu=0+490|divoweltelu=3+657|natelu=5+658|divoweltelu=6+657|gaavoweltelu=8+842",
+            "input": "చెందినదిగా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "cevoweltelu=0+713|patelu=2+634|pasubscripttelu=2+326|ddatelu=5+690|matelu=6+988|uvowelsigntelu=6+318|loovoweltelu=8+922",
+            "input": "చెప్పడములో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tatelu=0+723|latelu=1+665|pivoweltelu=2+670|saavoweltelu=4+968|tasubscripttelu=4@-354,0+0|yivoweltelu=8+1192",
+            "input": "తలపిస్తాయి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "deevoweltelu=0+657|shatelu=2+529|bhaavoweltelu=3+935|ssatelu=5+674|latelu=6+665|anusvaratelu=6+490|datelu=8+657|uvowelsigntelu=8+318",
+            "input": "దేశభాషలందు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|anusvaratelu=0+490|dovoweltelu=2+753|mivoweltelu=4+1003|masubscripttelu=4+212|datelu=8+657|vatelu=9+670",
+            "input": "పందొమ్మిదవ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|datelu=1+657|batelu=2+693|anusvaratelu=2+490|dhatelu=4+657|matelu=5+988|uvowelsigntelu=5+318|latelu=7+665|loovoweltelu=8+922",
+            "input": "పదబంధములలో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "paavoweltelu=0+972|kivoweltelu=2+481|saavoweltelu=4+932|tasubscripttelu=4@-318,0+0|nahalanttelu=8+658",
+            "input": "పాకిస్తాన్",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "pivoweltelu=0+670|latelu=2+665|uvowelsigntelu=2+318|catelu=4+713|uvowelsigntelu=4+318|kovoweltelu=6+672|nivoweltelu=8+674",
+            "input": "పిలుచుకొని",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|parasubscripttelu=0+0|veevoweltelu=3+670|shivoweltelu=5+529|anusvaratelu=5+490|catelu=8+713|katelu=9+481",
+            "input": "ప్రవేశించక",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+966|ratelu=2+564|tatelu=3+723|deevoweltelu=4+657|shatelu=6+529|anusvaratelu=6+490|loovoweltelu=8+922",
+            "input": "భారతదేశంలో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "maavoweltelu=0+1270|tatelu=2+685|rvocalicvowelsigntelu=2+358|matelu=4+988|uuvowelsigntelu=4+600|rivoweltelu=6+564|tasubscriptnarrowtelu=6@-32,0+0",
+            "input": "మాతృమూర్తి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "livoweltelu=0+690|pivoweltelu=2+670|loovoweltelu=4+907|nivoweltelu=6+674|kivoweltelu=8+481",
+            "input": "లిపిలోనికి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vatelu=0+670|latelu=1+665|lasubscripttelu=1@-58,0+0|bhatelu=4+693|raavoweltelu=5+849|yatelu=7+1186|ddatelu=8+695|uvowelsigntelu=8+318",
+            "input": "వల్లభరాయడు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vivoweltelu=0+687|satelu=2+658|tasubscripttelu=2@-44,0+0|rivoweltelu=5+564|anusvaratelu=5+490|civoweltelu=8+723",
+            "input": "విస్తరించి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vevoweltelu=0+670|lleevoweltelu=2+622|llasubscripttelu=2+365|vaavoweltelu=6+942|ratelu=8+550|uvowelsigntelu=8+318",
+            "input": "వెళ్ళేవారు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|anusvaratelu=0+490|giivoweltelu=2+570|tatelu=4+723|patelu=5+670|ratelu=6+564|anusvaratelu=6+490|gaavoweltelu=8+842",
+            "input": "సంగీతపరంగా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|anusvaratelu=0+490|datelu=2+657|ratelu=3+544|bhasubscripttelu=3+336|matelu=6+988|uvowelsigntelu=6+318|loovoweltelu=8+922",
+            "input": "సందర్భములో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|anusvaratelu=0+490|satelu=2+643|kasubscripttelu=2+303|rvocalicvowelsign1telu=2+487|tatelu=6+723|anusvaratelu=6+490|batelu=8+693|uvowelsigntelu=8+318",
+            "input": "సంస్కృతంబు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tevoweltelu=0+723|latelu=2+665|uvowelsigntelu=2+318|gatelu=4+562|uvowelsigntelu=4+318|natelu=6+658|anusvaratelu=6+490|datelu=8+657|uvowelsigntelu=8+318|question.telu=10+504|.notdef=11+600|quotedblright.telu=12+476",
+            "input": "తెలుగునందు?\t”",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|anusvaratelu=0+490|teevoweltelu=2+723|kaavoweltelu=4+784|katelu=6+489|uvowelsigntelu=6+318|anusvaratelu=6+490|ddaavoweltelu=9+942",
+            "input": "అంతేకాకుండా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "utelu=0+792|anusvaratelu=0+490|ttatelu=2+716|uvowelsigntelu=2+318|anusvaratelu=2+490|datelu=5+657|natelu=6+658|ttatelu=7+716|anusvaratelu=7+490|loovoweltelu=9+922",
+            "input": "ఉంటుందనటంలో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "utelu=0+768|natelu=1+616|nasubscripttelu=1+302|patelu=4+634|pasubscripttelu=4+326|ttivoweltelu=7+716|kiivoweltelu=9+481",
+            "input": "ఉన్నప్పటికీ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "gatelu=0+570|matelu=1+988|nivoweltelu=2+674|anusvaratelu=2+490|catelu=5+713|vatelu=6+670|chatelu=7+713|uvowelsigntelu=7+282|chasubscripttelu=7+326",
+            "input": "గమనించవఛ్ఛు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "naavoweltelu=0+928|gatelu=2+570|rivoweltelu=3+564|katelu=5+481|tatelu=6+723|loovoweltelu=7+907|nivoweltelu=9+674",
+            "input": "నాగరికతలోని",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|rivoweltelu=1+564|paavoweltelu=3+968|latelu=5+665|natelu=6+658|vatelu=7+670|latelu=8+665|lasubscripttelu=8@-58,0+0",
+            "input": "పరిపాలనవల్ల",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|parasubscripttelu=0+0|teevoweltelu=3+718|yasubscripttelu=3+396|katelu=7+481|anusvaratelu=7+490|gaavoweltelu=9+842",
+            "input": "ప్రత్యేకంగా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "batelu=0+693|latelu=1+665|uuvowelsigntelu=1+600|civoweltelu=3+723|saavoweltelu=5+932|tasubscripttelu=5@-318,0+0|nahalanttelu=9+658",
+            "input": "బలూచిస్తాన్",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+966|ratelu=2+564|tatelu=3+723|deevoweltelu=4+657|shatelu=6+529|matelu=7+988|anusvaratelu=7+490|taavoweltelu=9+988",
+            "input": "భారతదేశమంతా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssatelu=2+674|latelu=3+665|nivoweltelu=4+669|nasubscripttelu=4+290|anusvaratelu=4+490|ttivoweltelu=9+716",
+            "input": "భాషలన్నింటి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "yatelu=0+1186|uuvowelsigntelu=0+600|roovoweltelu=2+742|pivoweltelu=4+670|yatelu=6+1186|natelu=7+658|uvowelsigntelu=7+318|latelu=9+665|uvowelsigntelu=9+318",
+            "input": "యూరోపియనులు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "shatelu=0+529|taavoweltelu=1+988|baavoweltelu=3+935|dasubscripttelu=3@-347,0+0|nivoweltelu=7+674|kivoweltelu=9+481",
+            "input": "శతాబ్దానికి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "saavoweltelu=0+937|hivoweltelu=2+950|tatelu=4+718|yasubscripttelu=4+396|matelu=7+988|uvowelsigntelu=7+318|paivoweltelu=9+685",
+            "input": "సాహిత్యముపై",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "sauvoweltelu=0+966|bhaavoweltelu=2+966|gatelu=4+559|yasubscripttelu=4+396|satelu=7+658|anusvaratelu=7+490|patelu=9+670|datelu=10+657",
+            "input": "సౌభాగ్యసంపద",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|nivoweltelu=1+674|pivoweltelu=3+670|satelu=5+658|uvowelsigntelu=5+318|tasubscripttelu=5@-362,0+0|anusvaratelu=5+490|divoweltelu=10+657",
+            "input": "అనిపిస్తుంది",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "etelu=0+671|ratelu=1+550|uvowelsigntelu=1+318|gatelu=3+570|veevoweltelu=4+670|baavoweltelu=6+935|saavoweltelu=8+968|ddivoweltelu=10+690",
+            "input": "ఎరుగవేబాసాడి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+481|natelu=1+616|nasubscripttelu=1+302|ddatelu=4+690|anusvaratelu=4+490|batelu=6+693|uvowelsigntelu=6+318|loovoweltelu=8+907|nivoweltelu=10+674",
+            "input": "కన్నడంబులోని",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tevoweltelu=0+723|latelu=2+665|uvowelsigntelu=2+318|gatelu=4+562|uvowelsigntelu=4+318|vaavoweltelu=6+942|rivoweltelu=8+564|kivoweltelu=10+481",
+            "input": "తెలుగువారికి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tevoweltelu=0+723|latelu=2+665|uvowelsigntelu=2+318|gatelu=4+562|uvowelsigntelu=4+318|vaavoweltelu=6+953|llatelu=8+622|uvowelsign1telu=8+323|llasubscripttelu=8+365",
+            "input": "తెలుగువాళ్ళు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "nivoweltelu=0+674|raavoweltelu=2+867|masubscripttelu=2+212|nnatelu=6+786|patelu=7+670|ratelu=8+564|anusvaratelu=8+490|gaavoweltelu=10+842",
+            "input": "నిర్మాణపరంగా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "paavoweltelu=0+946|parasubscripttelu=0@-276,0+0|anusvaratelu=0+490|tatelu=5+723|matelu=6+988|uvowelsigntelu=6+318|loovoweltelu=8+907|nivoweltelu=10+674",
+            "input": "ప్రాంతములోని",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vatelu=0+659|yasubscripttelu=0+396|kiivoweltelu=3+481|tasubscriptnarrowtelu=3@10,0+0|katelu=7+481|ratelu=8+564|nnatelu=9+786|loovoweltelu=10+922",
+            "input": "వ్యక్తీకరణలో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "shaavoweltelu=0+787|satelu=2+658|tarasubscriptligtelu=2@-1,0+0|veevoweltelu=7+670|tatelu=9+723|tasubscripttelu=9@-76,0+0",
+            "input": "శాస్త్రవేత్త",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|anusvaratelu=0+490|giivoweltelu=2+570|tatelu=4+723|kaavoweltelu=5+780|ratelu=7+550|uvowelsigntelu=7+318|latelu=9+665|katelu=10+489|uvowelsigntelu=10+318",
+            "input": "సంగీతకారులకు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|anusvaratelu=0+490|satelu=2+643|kasubscripttelu=2+303|rvocalicvowelsign1telu=2+487|tatelu=6+723|matelu=7+988|uvowelsigntelu=7+318|natelu=9+658|katelu=10+489|uvowelsigntelu=10+318",
+            "input": "సంస్కృతమునకు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|tivoweltelu=1+723|shatelu=3+533|uvowelsigntelu=3+318|datelu=5+657|dhasubscripttelu=5@-87,0+0|anusvaratelu=5+490|gaavoweltelu=9+811|natelu=11+658|uuvowelsigntelu=11+600",
+            "input": "అతిశుద్ధంగానూ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "eetelu=0+671|ratelu=1+544|pasubscripttelu=1+326|ratelu=4+550|uvowelsigntelu=4+318|catelu=6+713|uvowelsigntelu=6+318|katelu=8+489|uvowelsigntelu=8+318|natelu=10+616|nasubscripttelu=10+302",
+            "input": "ఏర్పరుచుకున్న",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "kaavoweltelu=0+780|ratelu=2+556|yasubscripttelu=2+396|nivoweltelu=5+674|raavoweltelu=7+849|vasubscripttelu=7+396|hatelu=11+954|katelu=12+481",
+            "input": "కార్యనిర్వాహక",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssaavoweltelu=2+937|vatelu=4+670|ratelu=5+564|gasubscripttelu=5@-75,0+0|matelu=8+988|uvowelsigntelu=8+318|natelu=10+658|katelu=11+489|uvowelsigntelu=11+318",
+            "input": "భాషావర్గమునకు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vatelu=0+659|yasubscripttelu=0+396|tivoweltelu=3+723|reevoweltelu=5+564|katelu=7+481|divoweltelu=8+657|shatelu=10+529|loovoweltelu=11+922",
+            "input": "వ్యతిరేకదిశలో",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "shaavoweltelu=0+787|satelu=2+658|tarasubscriptligtelu=2@-1,0+0|kaavoweltelu=7+780|ratelu=9+550|uvowelsigntelu=9+318|latelu=11+665|uvowelsigntelu=11+318",
+            "input": "శాస్త్రకారులు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|anusvaratelu=0+490|satelu=2+643|kasubscripttelu=2+303|rvocalicvowelsign1telu=2+487|tiivoweltelu=6+723|patelu=8+670|ratelu=9+564|anusvaratelu=9+490|gaavoweltelu=11+842",
+            "input": "సంస్కృతీపరంగా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|anusvaratelu=0+490|giivoweltelu=2+570|katelu=4+481|rivoweltelu=5+564|satelu=7+658|uvowelsigntelu=7+318|tasubscripttelu=7@-362,0+0|anusvaratelu=7+490|divoweltelu=12+657",
+            "input": "అంగీకరిస్తుంది",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tiivoweltelu=0+723|satelu=2+658|uvowelsigntelu=2+318|kovoweltelu=4+672|natelu=6+658|batelu=7+693|ddivoweltelu=8+690|naavoweltelu=10+928|yivoweltelu=12+1192",
+            "input": "తీసుకొనబడినాయి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "pivoweltelu=0+670|latelu=2+665|uvowelsigntelu=2+318|catelu=4+713|uvowelsigntelu=4+318|katelu=6+489|uvowelsigntelu=6+318|naavoweltelu=8+958|nasubscripttelu=8+302|ratelu=12+550|uvowelsigntelu=12+318",
+            "input": "పిలుచుకున్నారు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "maavoweltelu=0+1270|ttaavoweltelu=2+988|lasubscripttelu=2@-356,0+0|ddatelu=6+695|uvowelsigntelu=6+318|koovoweltelu=8+687|leevoweltelu=10+665|ratelu=12+550|uvowelsigntelu=12+318",
+            "input": "మాట్లాడుకోలేరు",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "maavoweltelu=0+1270|ttaavoweltelu=2+988|lasubscripttelu=2@-356,0+0|ddatelu=6+695|uvowelsigntelu=6+318|vaavoweltelu=8+942|rivoweltelu=10+564|kivoweltelu=12+481",
+            "input": "మాట్లాడువారికి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|anusvaratelu=0+490|satelu=2+643|kasubscripttelu=2+303|rvocalicvowelsign1telu=2+487|tatelu=6+723|anusvaratelu=6+490|batelu=8+693|uvowelsigntelu=8+318|loovoweltelu=10+907|nivoweltelu=12+674",
+            "input": "సంస్కృతంబులోని",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "eetelu=0+671|ratelu=1+544|pasubscripttelu=1+326|ratelu=4+550|uvowelsigntelu=4+318|catelu=6+713|uvowelsigntelu=6+318|katelu=8+489|uvowelsigntelu=8+318|natelu=10+616|nasubscripttelu=10+302|vivoweltelu=13+687",
+            "input": "ఏర్పరుచుకున్నవి",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssatelu=2+674|latelu=3+665|nivoweltelu=4+669|nasubscripttelu=4+290|anusvaratelu=4+490|ttivoweltelu=9+716|toovoweltelu=11+830|natelu=13+658|uuvowelsigntelu=13+600",
+            "input": "భాషలన్నింటితోనూ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssaavoweltelu=2+968|catelu=4+713|rivoweltelu=5+564|tatelu=7+723|tarasubscripttelu=7+0|kaavoweltelu=10+780|ratelu=12+550|uvowelsigntelu=12+318|latelu=14+665",
+            "input": "భాషాచరిత్రకారుల",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "leevoweltelu=0+665|katelu=2+481|poovoweltelu=3+966|yivoweltelu=5+1192|natelu=7+658|patelu=8+634|pasubscripttelu=8+326|ttivoweltelu=11+716|kiivoweltelu=13+481",
+            "input": "లేకపోయినప్పటికీ",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vatelu=0+670|riivoweltelu=1+564|gasubscripttelu=1@-75,0+0|katelu=5+481|rivoweltelu=6+564|anusvaratelu=6+490|civoweltelu=9+723|naavoweltelu=11+928|ratelu=13+550|uvowelsigntelu=13+318|bracketleft.telu=15+330|four.telu=16+559|bracketright.telu=17+330",
+            "input": "వర్గీకరించినారు[4]",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssaavoweltelu=2+968|shaavoweltelu=4+787|satelu=6+658|tarasubscriptligtelu=6@-1,0+0|juvoweltelu=11+906|nyasubscripttelu=11@-239,0+0|latelu=15+665",
+            "input": "భాషాశాస్త్రజ్ఞుల",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhaavoweltelu=0+935|ssaavoweltelu=2+968|shaavoweltelu=4+787|satelu=6+658|tarasubscriptligtelu=6@-1,0+0|patelu=11+670|ratelu=12+564|anusvaratelu=12+490|gaavoweltelu=14+842",
+            "input": "భాషాశాస్త్రపరంగా",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "eetelu=0+671|ratelu=1+544|pasubscripttelu=1+326|ratelu=4+550|uvowelsigntelu=4+318|catelu=6+713|uvowelsigntelu=6+318|katelu=8+489|uvowelsigntelu=8+318|natelu=10+616|nasubscripttelu=10+302|tteevoweltelu=13+716|lasubscripttelu=13@-84,0+0",
+            "input": "ఏర్పరుచుకున్నట్లే",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+481|karasubscripttelu=0+0|matelu=3+988|batelu=4+693|diivoweltelu=5+657|dhasubscripttelu=5@-87,0+0|katelu=9+481|rivoweltelu=10+564|anusvaratelu=10+490|catelu=13+713|batelu=14+693|ddivoweltelu=15+690|natelu=17+658",
+            "input": "క్రమబద్ధీకరించబడిన",
+            "note": "fontdiff-Telugu.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "maavoweltelu=0+1270|ratelu=2+550|uvowelsigntelu=2+282|casubscripttelu=2+326",
+            "input": "మార్చు",
+            "note": "fontdiff-te-20180314.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|natelu=1+658|uvowelsigntelu=1+318|vatelu=3+670|ratelu=4+564|tasubscriptnarrowtelu=4@-32,0+0|natelu=7+658|anusvaratelu=7+490",
+            "input": "అనువర్తనం",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "miivoweltelu=0+1027|katelu=2+489|uvowelsigntelu=2+318",
+            "input": "మీకు",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "etelu=0+671|patelu=1+634|pasubscripttelu=1+326|ttivoweltelu=4+716|katelu=6+481|puvoweltelu=7+936|pasubscripttelu=7+326|ddatelu=11+695|uvowelsigntelu=11+318",
+            "input": "ఎప్పటికప్పుడు",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vaavoweltelu=0+942|taavoweltelu=2+957|vatelu=4+670|ratelu=5+564|nnatelu=6+786|anusvaratelu=6+490|comma.telu=8+255",
+            "input": "వాతావరణం,",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|parasubscripttelu=0+0|jaavoweltelu=3+949|ratelu=5+564|vaavoweltelu=6+942|nnaavoweltelu=8+1069",
+            "input": "ప్రజారవాణా",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vaavoweltelu=0+911|hatelu=2+919|naavoweltelu=3+928|latelu=5+665",
+            "input": "వాహనాల",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|matelu=1+988|yaavoweltelu=2+1468|latelu=4+665|uvowelsigntelu=4+318",
+            "input": "సమయాలు",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tatelu=0+723|datelu=1+657|uvowelsigntelu=1+318|patelu=3+670|rivoweltelu=4+564",
+            "input": "తదుపరి",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vivoweltelu=0+687|maavoweltelu=2+1239|naavoweltelu=4+928|latelu=6+665|uvowelsigntelu=6+318",
+            "input": "విమానాలు",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "leevoweltelu=0+665|daavoweltelu=2+929",
+            "input": "లేదా",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|paavoweltelu=1+968|yivoweltelu=3+1192|anusvaratelu=3+490|ttahalanttelu=6+716|space=8+0|mevoweltelu=9+988|anusvaratelu=9+490|ttahalanttelu=12+716|space=14+0|latelu=15+665",
+            "input": "అపాయింట్‌మెంట్‌ల",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vatelu=0+670|anusvaratelu=0+490|ttivoweltelu=2+716",
+            "input": "వంటి",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vatelu=0+659|yasubscripttelu=0+396|kivoweltelu=3+481|tasubscriptnarrowtelu=3@10,0+0|gatelu=7+570|tiivoweltelu=8+723|katelu=10+491|rvocalicvowelsigntelu=10+358|tatelu=12+723",
+            "input": "వ్యక్తిగతీకృత",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "satelu=0+658|maavoweltelu=1+1270|caavoweltelu=3+985|ratelu=5+564|anusvaratelu=5+490",
+            "input": "సమాచారం",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|anusvaratelu=0+490|divoweltelu=2+657|anusvaratelu=2+490|catelu=5+713|vatelu=6+670|catelu=7+713|uvowelsigntelu=7+282|casubscripttelu=7+326|period.telu=11+250",
+            "input": "అందించవచ్చు.",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "miivoweltelu=0+1027|ratelu=2+550|uvowelsigntelu=2+318",
+            "input": "మీరు",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "diivoweltelu=0+657|nivoweltelu=2+669|nasubscripttelu=2+302",
+            "input": "దీన్ని",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "etelu=0+671|anusvaratelu=0+490|tatelu=2+723",
+            "input": "ఎంత",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "etelu=0+671|katelu=1+489|uvowelsigntelu=1+303|kasubscripttelu=1+421|vatelu=5+670|gaavoweltelu=6+842",
+            "input": "ఎక్కువగా",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "utelu=0+765|patelu=1+670|yoovoweltelu=2+1468|givoweltelu=4+570|seevoweltelu=6+673|tasubscripttelu=6@-52,0+0|comma.telu=10+255",
+            "input": "ఉపయోగిస్తే,",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|anusvaratelu=0+490|tatelu=2+723",
+            "input": "అంత",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "patelu=0+670|parasubscripttelu=0+0|yoovoweltelu=3+1468|jatelu=5+686|natelu=6+658|katelu=7+481|ratelu=8+564|anusvaratelu=8+490",
+            "input": "ప్రయోజనకరం",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "atelu=0+762|vuvoweltelu=1+916|tatelu=3+703|uvowelsigntelu=3+318|anusvaratelu=3+490|divoweltelu=6+657|period.telu=8+250",
+            "input": "అవుతుంది.",
+            "note": "fontdiff-te-google-app-info.html",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "llleevoweltelu=0+773|rrratelu=2+657|uni0952=2@-42,-463+0",
+            "input": "ఴేౚ॒",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "nyauvoweltelu=0+1096|hatelu=2+919|phatelu=3+670|uni0C04=3@-49,293+0",
+            "input": "ఞౌహఫఄ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "yaavoweltelu=0+1468|viramatelu=0+0|vatelu=3+670",
+            "input": "యా్వ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "phuuvoweltelu=0+1179|phovoweltelu=2+966",
+            "input": "ఫూఫొ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "leevoweltelu=0+665|uuvowelsigntelu=0+624|rvocalicvowelsigntelu=0+358|patelu=4+670",
+            "input": "లేృూప",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "thovoweltelu=0+768|nnahalanttelu=2+786|rrvocalicvowelsigntelu=2+577|datelu=5+657",
+            "input": "థొణౄ్ద",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "dzuvoweltelu=0+918|uni1CDA=0@-289,293+0|visargatelu=0+284",
+            "input": "ౙుః᳚",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+489|uuvowelsigntelu=0+612|visargatelu=0+284|hevoweltelu=3+934|ssauvoweltelu=5+966",
+            "input": "కూఃహెషౌ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tthatelu=0+550|uuvowelsigntelu=0+600|govoweltelu=2+724|katelu=4+481|ssatelu=5+674|bhasubscripttelu=5+336|quotedblright.telu=8+476|katelu=9+491|rrvocalicvowelsigntelu=9+577",
+            "input": "ఠూగొకష్భ”కౄ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "theevoweltelu=0+657|ddhaavoweltelu=2+942",
+            "input": "థేఢా",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "taavoweltelu=0+988|daavoweltelu=2+947|kasubscripttelu=2+421|utelu=6+765|matelu=7+988|vovoweltelu=8+775",
+            "input": "తాద్కాఉమవొ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+481|uni1CDA=0@46,293+0|hatelu=2+950|uuvowelsign2telu=2+657",
+            "input": "క᳚హూ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "dzevoweltelu=0+686|ddhatelu=2+690|uni0C00=2@-59,293+0|gheevoweltelu=4+1003|nyatelu=6+877|uuvowelsign3telu=6+640",
+            "input": "ౙెఢఀఘేఞూ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "utelu=0+798|uni0952=0@-144,-463+0|llatelu=2+662|bracketright.telu=3+330|ttatelu=4+716|uni1CDA=4@-72,293+0|shatelu=6+529|uni0C04=6@66,293+0|tthatelu=8+544|rvocalicvowelsigntelu=8+358",
+            "input": "ఉ॒ళ]ట᳚శఄఠృ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "rrvocalictelu=0+1618|llatelu=1+622|shovoweltelu=2+764",
+            "input": "ౠళశొ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "chahalanttelu=0+713|uni1CDA=0@-51,293+0|vatelu=3+670|choovoweltelu=4+869",
+            "input": "ఛ్᳚వఛో",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ghovoweltelu=0+1321|hatelu=2+919|vatelu=3+670|cheevoweltelu=4+713|yatelu=6+1155|rrvocalicvowelsigntelu=6+577",
+            "input": "ఘొహవఛేయౄ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "nnivoweltelu=0+786|autelu=2+684|uni0951=2@-56,293+0|tatelu=4+723|uni0C04=4@-75,293+0|ddatelu=6+661|rrvocalicvowelsigntelu=6+577|rrvocalicvowelsigntelu=6+577",
+            "input": "ణిఔ॑తఄడౄౄ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "natelu=0+658|uni0952=0@-43,-463+0|hatelu=2+962|visargatelu=2+284|goovoweltelu=4+724|yaavoweltelu=6+1468",
+            "input": "న॒హఃగోయా",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "daavoweltelu=0+898|matelu=2+957|rvocalicvowelsigntelu=2+358|ddhatelu=4+690|uni0C04=4@-59,293+0|tthoovoweltelu=6+714|hatelu=8+919|ghatelu=9+988",
+            "input": "దామృఢఄఠోహఘ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ssatelu=0+715|semicolon.telu=1+275|lvocalictelu=2+792|uni0952=2@-110,-463+0",
+            "input": "ష;ఌ॒",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "nnatelu=0+772|rvocalicvowelsigntelu=0+358|viivoweltelu=2+687|ghatelu=4+957|rvocalicvowelsigntelu=4+358",
+            "input": "ణృవీఘృ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "shatelu=0+569|quotedbl.telu=1+460|ghatelu=2+988|uni0C00=2@-108,293+0|vaavoweltelu=4+942|tthasubscripttelu=4@-398,0+0",
+            "input": "శ\"ఘఀవ్ఠా",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "nnauvoweltelu=0+951|lvocalictelu=2+792|uni1CDA=2@-110,293+0|katelu=4+487|uni1CDA=4@40,293+0|koovoweltelu=6+687",
+            "input": "ణౌఌ᳚క᳚కో",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "khauvoweltelu=0+905|jhasubscripttelu=0@-216,0+0|nyahalanttelu=4+877",
+            "input": "ఖ్ఝౌఞ్",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "utelu=0+798|uni1CDA=0@-144,293+0|giivoweltelu=2+570",
+            "input": "ఉ᳚గీ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ghauvoweltelu=0+1168|sheevoweltelu=2+529|uvowelsigntelu=2+318|uni0951=2@-252,293+0|iitelu=6+912|uni0952=6@-314,-463+0",
+            "input": "ఘౌశేు॑ఈ॒",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "diivoweltelu=0+657|ttasubscripttelu=0@-67,0+0|nauvoweltelu=4+850|peevoweltelu=6+685|hoovoweltelu=8+1183",
+            "input": "ద్టీనౌపేహో",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "uni0951=0+0|uni1CF2=0+449|shevoweltelu=2+529",
+            "input": "ᳲ॑శె",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "sevoweltelu=0+637|chasubscripttelu=0+326",
+            "input": "స్ఛె",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "latelu=0+665|uni0952=0@-46,-463+0|hatelu=2+928|candrabindutelu=2+287",
+            "input": "ల॒హఁ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "pahalanttelu=0+670|space=0+0|katelu=3+489|uvowelsigntelu=3+318|rrvocalictelu=5+1607|uni1CDA=5@-517,293+0|ddevoweltelu=7+690",
+            "input": "ప్‍కుౠ᳚డె",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "dzahalanttelu=0+686|basubscripttelu=0+336|autelu=4+684|viramatelu=4+0|uni1CDA=4+0|ratelu=7+564",
+            "input": "ౙ్బ్ఔ్᳚ర",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "thevoweltelu=0+657|ssevoweltelu=2+689|uni0C00=2@-75,293+0",
+            "input": "థెషెఀ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ddhiivoweltelu=0+690|ratelu=2+556|yasubscripttelu=2+396|uni0951=2@-384,293+0|shatelu=6+569|quoteright.telu=7+276|hivoweltelu=8+950",
+            "input": "ఢీర్య॑శ’హి",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "nyovoweltelu=0+1077|dhatelu=2+657|uni1CDA=2@-42,293+0|jovoweltelu=4+897|bhatelu=6+733|quoteright.telu=7+276|ratelu=8+564|uni0C04=8@4,293+0",
+            "input": "ఞొధ᳚జొభ’రఄ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "uni0C04=0+0|uni1CF2=0+449|gatelu=2+570|uni0C04=2@1,293+0|ngatelu=4+623|rrvocalicvowelsigntelu=4+577|rratelu=6+757|uuvowelsigntelu=6+600",
+            "input": "ᳲఄగఄఙౄఱూ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vatelu=0+670|uni0951=0@-49,293+0|rrrivoweltelu=2+657|ddhatelu=4+690|uni0951=4@-59,293+0",
+            "input": "వ॑ౚిఢ॑",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ghahalanttelu=0+988|itelu=2+629|uni0952=2@-29,-463+0|atelu=4+762|uni1CDA=4@-95,293+0|saavoweltelu=6+968",
+            "input": "ఘ్ఇ॒అ᳚సా",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ddiivoweltelu=0+690|hevoweltelu=2+965|jahalanttelu=4+686",
+            "input": "డీహెజ్",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "sovoweltelu=0+966|ddatelu=2+661|rvocalicvowelsigntelu=2+358|rrvocalictelu=4+1611|katelu=5+481|candrabindutelu=5+287|datelu=7+657|uni1CDA=7@-42,293+0",
+            "input": "సొడృౠకఁద᳚",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "jivoweltelu=0+692|neevoweltelu=2+658|uni0C00=2@-43,293+0|visargatelu=2+284|dhahalanttelu=6+657",
+            "input": "జినేఃఀధ్",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "thivoweltelu=0+657|khatelu=2+724|uni0C00=2@-76,293+0",
+            "input": "థిఖఀ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "llaavoweltelu=0+931|lllatelu=2+773|uni0952=2@-100,-463+0|katelu=4+489|uuvowelsigntelu=4+600|yivoweltelu=6+1192",
+            "input": "ళాఴ॒కూయి",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "shatelu=0+569|quotedblright.telu=1+476|yauvoweltelu=2+1333|livoweltelu=4+690|jhasubscripttelu=4@-30,0+0|tthatelu=8+564|uni0C00=8@4,293+0",
+            "input": "శ”యౌల్ఝిఠఀ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "nnaavoweltelu=0+1069|tseevoweltelu=2+713|goovoweltelu=4+752|llasubscripttelu=4+365",
+            "input": "ణాౘేగ్ళో",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "hahalanttelu=0+919|space=0+0|puuvoweltelu=3+1179|uutelu=5+1027|uni0951=5@-373,293+0",
+            "input": "హ్‍పూఊ॑",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "llvocalictelu=0+1047|hatelu=1+919|ghatelu=2+988|uni1CDA=2@-108,293+0|shatelu=4+569|bracketright.telu=5+330|heevoweltelu=6+965|dhatelu=8+625|rvocalicvowelsigntelu=8+358",
+            "input": "ౡహఘ᳚శ]హేధృ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "sovoweltelu=0+966|rratelu=2+757|uvowelsigntelu=2+318|soovoweltelu=4+935|natelu=6+619|rrvocalicvowelsigntelu=6+577|yovoweltelu=8+1504",
+            "input": "సొఱుసోనౄయొ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ngivoweltelu=0+684|viramatelu=0+0|catelu=3+713|rrvocalictelu=4+1618|llatelu=5+622|llatelu=6+622|uni0951=6@-25,293+0|hatelu=8+954|katelu=9+481",
+            "input": "ఙి్చౠళళ॑హక",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "nnauvoweltelu=0+951|tthasubscripttelu=0@-349,0+0|rrraavoweltelu=4+929",
+            "input": "ణ్ఠౌౚా",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "lllivoweltelu=0+773|latelu=2+665|uni0952=2@-46,-463+0|patelu=4+670|uni1CDA=4@-49,293+0|uutelu=6+1027|uni0C00=6@-373,293+0",
+            "input": "ఴిల॒ప᳚ఊఀ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "lllovoweltelu=0+971|uuvowelsigntelu=0+604|katelu=3+491|rrvocalicvowelsigntelu=3+546|matelu=5+988|tthovoweltelu=6+714|etelu=8+671|uni0C04=8@-49,293+0",
+            "input": "ఴొూకౄమఠొఎఄ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "natelu=0+647|vasubscripttelu=0+406|rvocalicvowelsign1telu=0+487|rrvocalicvowelsigntelu=0+588|llatelu=5+622|utelu=6+765|vatelu=7+670",
+            "input": "న్వృౄళఉవ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "rrvocalictelu=0+1576|hatelu=1+928|uni0952=1@-207,-463+0|candrabindutelu=1+287",
+            "input": "ౠహఁ॒",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "lauvoweltelu=0+845|rrovoweltelu=2+974|tsaavoweltelu=4+985|kheevoweltelu=6+724|shatelu=8+569|asterisk.telu=9+520",
+            "input": "లౌఱొౘాఖేశ*",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "rrrovoweltelu=0+768|satelu=2+658|uni0C00=2@-43,293+0|uni0952=2@-43,-463+0|patelu=5+670|uni0952=5@-49,-463+0",
+            "input": "ౚొసఀ॒ప॒",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "nyevoweltelu=0+877|vovoweltelu=2+719|ddatelu=4+661|rrvocalicvowelsigntelu=4+577",
+            "input": "ఞెవొడౄ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "etelu=0+671|uni0C04=0@-49,293+0|tthatelu=2+550|uvowelsigntelu=2+318|nyovoweltelu=4+1092|shatelu=6+569|quotedbl.telu=7+460|dzovoweltelu=8+897",
+            "input": "ఎఄఠుఞొశ\"ౙొ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "autelu=0+684|uni0951=0@-56,293+0|baavoweltelu=2+970|kovoweltelu=4+687|veevoweltelu=6+670",
+            "input": "ఔ॑బాకొవే",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "phatelu=0+670|uni1CDA=0@-49,293+0|llvocalictelu=2+1089|llatelu=3+622|loovoweltelu=4+845|toovoweltelu=6+875|rrvocalicvowelsigntelu=6+546|natelu=9+658",
+            "input": "ఫ᳚ౡళలోతోౄన",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "dzatelu=0+686|uni0952=0@-57,-463+0|lllaavoweltelu=2+1071|shatelu=4+569|quoteright.telu=5+276|latelu=6+650|rrvocalicvowelsigntelu=6+577|rrvocalictelu=8+1576|hatelu=9+950",
+            "input": "ౙ॒ఴాశ’లౄౠహ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ssoovoweltelu=0+970|katelu=2+491|rvocalicvowelsigntelu=2+358|uni1CF2=4+449|ssahalanttelu=5+674|space=5+0|shatelu=8+569|quotedblright.telu=9+476",
+            "input": "షోకృᳲష్‍శ”",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tthivoweltelu=0+564|rrrauvoweltelu=2+768",
+            "input": "ఠిౚౌ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "rraavoweltelu=0+1069|eetelu=2+671|uni0951=2@-49,293+0|llatelu=4+603|anusvaratelu=4+490|dzaavoweltelu=6+949",
+            "input": "ఱాఏ॑ళంౙా",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tthoovoweltelu=0+708|visargatelu=0+284|latelu=3+665|uni0C04=3@-46,293+0|vuvoweltelu=5+916|rrvocalictelu=7+1607|uni0C00=7@-517,293+0",
+            "input": "ఠోఃలఄవుౠఀ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "nyatelu=0+877|uvowelsign3telu=0+358|aatelu=2+739|uni0952=2@-83,-463+0|hatelu=4+974|rrvocalicvowelsigntelu=4+577",
+            "input": "ఞుఆ॒హౄ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "shevoweltelu=0+529|nyaavoweltelu=2+1167|rrraavoweltelu=4+929",
+            "input": "శెఞాౚా",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "chatelu=0+677|llasubscripttelu=0+365|uni0C00=0@-380,293+0|visargatelu=0+284|tthovoweltelu=5+714|hatelu=7+928|candrabindutelu=7+287",
+            "input": "ఛ్ళఀఃఠొహఁ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "llatelu=0+662|quotedbl.telu=1+460|itelu=2+629|uni0C00=2@-29,293+0|ddhovoweltelu=4+809",
+            "input": "ళ\"ఇఀఢొ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tatelu=0+723|dhasubscripttelu=0@-120,0+0|ghasubscript1telu=0+666|uni0951=0@-741,293+0|dheevoweltelu=6+657",
+            "input": "త్ధ్ఘ॑ధే",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "nniivoweltelu=0+786|jivoweltelu=2+692",
+            "input": "ణీజి",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "chatelu=0+713|uni0C04=0@-51,293+0|llvocalictelu=2+1078|uni0C00=2@-253,293+0|bhovoweltelu=4+897|jatelu=6+686|uni0C04=6@-57,293+0",
+            "input": "ఛఄౡఀభొజఄ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tthauvoweltelu=0+735|ssivoweltelu=2+674|hatelu=4+919|patelu=5+670|gheevoweltelu=6+1003|anusvaratelu=6+490",
+            "input": "ఠౌషిహపఘేం",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ddhevoweltelu=0+690|llvocalicvowelsigntelu=0+223|rrratelu=3+657|uni0C04=3@-42,293+0|candrabindu_1CDAtelu=3@-42,293+0",
+            "input": "ఢెౣౚఄఀ᳚",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ttoovoweltelu=0+920|vuvoweltelu=2+916|catelu=4+682|rrvocalicvowelsigntelu=4+577|dzevoweltelu=6+686",
+            "input": "టోవుచౄౙె",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "hatelu=0+950|uni0C00=0@-229,293+0|aatelu=2+739|uni0951=2@-83,293+0|satelu=4+627|rrvocalicvowelsigntelu=4+577|tthatelu=6+564|ddhasubscripttelu=6@-28,0+0|rvocalicvowelsign1telu=6+487",
+            "input": "హఀఆ॑సౄఠ్ఢృ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ootelu=0+684|uni1CDA=0@-56,293+0|gatelu=2+542|rrvocalicvowelsigntelu=2+577|llvocalictelu=4+1078|uni0951=4@-253,293+0|jatelu=6+660|rvocalicvowelsigntelu=6+358|noovoweltelu=8+769",
+            "input": "ఓ᳚గౄౡ॑జృనో",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "otelu=0+684|uni1CDA=0@-56,293+0|coovoweltelu=2+869",
+            "input": "ఒ᳚చో",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "pheevoweltelu=0+685|gaavoweltelu=2+842|tthevoweltelu=4+564|devoweltelu=6+657|shatelu=8+533|uvowelsigntelu=8+318",
+            "input": "ఫేగాఠెదెశు",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "lvocalictelu=0+792|uni0C00=0@-110,293+0|hatelu=2+919|puuvoweltelu=3+1203|rrvocalicvowelsigntelu=3+577",
+            "input": "ఌఀహపూౄ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "nnivoweltelu=0+786|uni0952=0@-107,-463+0|anusvaratelu=0+490|ngatelu=4+623|rrvocalicvowelsigntelu=4+577|rratelu=6+757|uvowelsigntelu=6+318",
+            "input": "ణిం॒ఙౄఱు",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "gahalanttelu=0+570|rvocalictelu=2+1325|uni0C00=2@-376,293+0|ghaavoweltelu=4+1270|thasubscripttelu=4@-435,0+0",
+            "input": "గ్ఋఀఘ్థా",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "rrrauvoweltelu=0+733|atelu=2+762|uni1CDA=2@-95,293+0|tatelu=4+723|uni0C00=4@-75,293+0|tthahalanttelu=6+564|uni1CDA=6@4,293+0|jhatelu=9+1192",
+            "input": "ౚౌఅ᳚తఀఠ్᳚ఝ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "llvocalictelu=0+1047|patelu=1+670|ddheevoweltelu=2+690|jhauvoweltelu=4+1371|nnoovoweltelu=6+1037|ssevoweltelu=8+689",
+            "input": "ౡపఢేఝౌణోషె",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "choovoweltelu=0+838|tthatelu=2+544|rvocalicvowelsigntelu=2+358|ootelu=4+684|uni0C04=4@-56,293+0|utelu=6+792|anusvaratelu=6+490",
+            "input": "ఛోఠృఓఄఉం",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ngauvoweltelu=0+862|dhaavoweltelu=2+929|ddatelu=4+690|uni1CDA=4@-59,293+0",
+            "input": "ఙౌధాడ᳚",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "theevoweltelu=0+657|nnovoweltelu=2+927|ratelu=4+550|uuvowelsigntelu=4+569|satelu=6+658|uni1CDA=6@-43,293+0|teevoweltelu=8+723",
+            "input": "థేణొరూస᳚తే",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "llivoweltelu=0+632|khatelu=2+693|rvocalicvowelsigntelu=2+358|bhatelu=4+733|asterisk.telu=5+520",
+            "input": "ళిఖృభ*",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "hatelu=0+950|uni0951=0@-229,293+0|nnatelu=2+786|uni0C04=2@-107,293+0|shatelu=4+529|uni0C04=4@66,293+0|ddatelu=6+661|rvocalicvowelsigntelu=6+358",
+            "input": "హ॑ణఄశఄడృ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "jhevoweltelu=0+1192|bhatelu=2+693|uni1CDA=2@-60,293+0|jatelu=4+686|uni0C00=4@-57,293+0",
+            "input": "ఝెభ᳚జఀ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ddhoovoweltelu=0+809|hatelu=2+919|natelu=3+658|rrroovoweltelu=4+768",
+            "input": "ఢోహనౚో",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "llatelu=0+662|question.telu=1+504|nyaavoweltelu=2+1167|datelu=4+657|uni0C00=4@-42,293+0|lloovoweltelu=6+780|tatelu=8+703|uuvowelsigntelu=8+600",
+            "input": "ళ?ఞాదఀళోతూ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tsovoweltelu=0+869|katelu=2+481|uni0952=2@46,-463+0",
+            "input": "ౘొక॒",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "lllatelu=0+773|uni0C00=0@-100,293+0|nyeevoweltelu=2+877|uuvowelsigntelu=2+600|llvocalictelu=5+1078|uni0952=5@-253,-463+0",
+            "input": "ఴఀఞేూౡ॒",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "rrvocalictelu=0+1576|matelu=1+988|khasubscripttelu=1@-231,0+0|ddevoweltelu=4+690|tthahalanttelu=6+564",
+            "input": "ౠమ్ఖడెఠ్",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhatelu=0+662|rvocalicvowelsigntelu=0+358|peevoweltelu=2+685|viramatelu=2+0|ghatelu=5+988|sseevoweltelu=6+689|lovoweltelu=8+922",
+            "input": "భృపే్ఘషేలొ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "jhatelu=0+1192|uni1CDA=0@-400,293+0|rrahalanttelu=2+773",
+            "input": "ఝ᳚ఱ్",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "nniivoweltelu=0+786|jhatelu=2+1161|rrvocalicvowelsigntelu=2+577|thatelu=4+625|rvocalicvowelsigntelu=4+358|khevoweltelu=6+724|vatelu=8+670|uni0952=8@-49,-463+0",
+            "input": "ణీఝౄథృఖెవ॒",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "maavoweltelu=0+1270|otelu=2+684|uni0952=2@-56,-463+0|lllatelu=4+773|uni0952=4@-100,-463+0|sahalanttelu=6+658",
+            "input": "మాఒ॒ఴ॒స్",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "cahalanttelu=0+713|uni1CDA=0@-51,293+0|chatelu=3+713|khaavoweltelu=4+996|jiivoweltelu=6+692|vasubscripttelu=6+396",
+            "input": "చ్᳚ఛఖాజ్వీ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "rriivoweltelu=0+773|tsoovoweltelu=2+792|tovoweltelu=4+845",
+            "input": "ఱీౘోతొ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "thaavoweltelu=0+929|lvocalictelu=2+792|uni0C04=2@-110,293+0|lauvoweltelu=4+880",
+            "input": "థాఌఄలౌ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "eetelu=0+671|uni0951=0@-49,293+0|llvocalictelu=2+1047|hatelu=3+950|ghasubscripttelu=3@-189,0+0",
+            "input": "ఏ॑ౡహ్ఘ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "jhatelu=0+1161|rrvocalicvowelsigntelu=0+546|heevoweltelu=2+965|otelu=4+684|uni1CDA=4@-56,293+0|ciivoweltelu=6+723",
+            "input": "ఝౄహేఒ᳚చీ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "rratelu=0+773|uni0952=0@-100,-463+0|nnivoweltelu=2+786|uni0951=2@-107,293+0|anusvaratelu=2+490|dzuuvoweltelu=6+1194|sevoweltelu=8+673",
+            "input": "ఱ॒ణిం॑ౙూసె",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "hatelu=0+919|phatelu=1+670|tatelu=2+723|uni1CDA=2@-75,293+0|ddhauvoweltelu=4+821",
+            "input": "హఫత᳚ఢౌ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "natelu=0+658|uni0C04=0@-43,293+0|shatelu=2+533|uuvowelsigntelu=2+600",
+            "input": "నఄశూ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "eetelu=0+671|uni0952=0@-49,-463+0|bhoovoweltelu=2+897|viramatelu=2+0|ssatelu=5+674|sheevoweltelu=6+529",
+            "input": "ఏ॒భో్షశే",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "llleevoweltelu=0+773|iitelu=2+912|uni0C00=2@-314,293+0|lllatelu=4+773|uni0951=4@-100,293+0|llvocalictelu=6+1078|uni0951=6@-253,293+0",
+            "input": "ఴేఈఀఴ॑ౡ॑",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "gatelu=0+570|uni0C00=0@1,293+0|nyatelu=2+862|rvocalicvowelsigntelu=2+358|yivoweltelu=4+1192",
+            "input": "గఀఞృయి",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "boovoweltelu=0+841|uutelu=2+1027|uni1CDA=2@-373,293+0|puuvoweltelu=4+1179|ttaavoweltelu=6+988|tthatelu=8+564|uni1CDA=8@4,293+0",
+            "input": "బోఊ᳚పూటాఠ᳚",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "dzatelu=0+686|uni0C04=0@-57,293+0|heevoweltelu=2+965|viramatelu=2+0|patelu=5+670",
+            "input": "ౙఄహే్ప",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ttevoweltelu=0+716|ttahalanttelu=2+716",
+            "input": "టెట్",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "llauvoweltelu=0+848|khasubscripttelu=0@-274,0+0",
+            "input": "ళ్ఖౌ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "rratelu=0+757|uuvowelsigntelu=0+600|jatelu=2+660|rvocalicvowelsigntelu=2+358|jaavoweltelu=4+918|candrabindutelu=4+287|dzaavoweltelu=7+949",
+            "input": "ఱూజృజాఁౙా",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "dzivoweltelu=0+692|thasubscripttelu=0@-108,0+0|lvocalictelu=4+792|uni1CDA=4@-110,293+0|llleevoweltelu=6+773",
+            "input": "ౙ్థిఌ᳚ఴే",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "rrovoweltelu=0+935|yatelu=2+1186|uni1CDA=2@-307,293+0",
+            "input": "ఱొయ᳚",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "nyoovoweltelu=0+1077|llvocalicvowelsigntelu=0+223|ddhatelu=3+661|rrvocalicvowelsigntelu=3+546|patelu=5+639|rrvocalicvowelsigntelu=5+577",
+            "input": "ఞోౣఢౄపౄ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "lllatelu=0+773|uni0C00=0@-100,293+0|thatelu=2+657|uni0952=2@-42,-463+0|ghevoweltelu=4+1003|khaavoweltelu=6+996|tauvoweltelu=8+855",
+            "input": "ఴఀథ॒ఘెఖాతౌ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "thatelu=0+657|uni1CDA=0@-42,293+0|tsoovoweltelu=2+836|llovoweltelu=4+857|rrvocalictelu=6+1576|hatelu=7+950",
+            "input": "థ᳚ౘోళొౠహ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "jeevoweltelu=0+686|lliivoweltelu=2+632|ghatelu=4+988|uni0952=4@-108,-463+0",
+            "input": "జేళీఘ॒",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "jhovoweltelu=0+1510|autelu=2+684|uni0C00=2@-56,293+0|ttatelu=4+685|rrvocalicvowelsigntelu=4+577|ddhevoweltelu=6+690",
+            "input": "ఝొఔఀటౄఢె",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "khaavoweltelu=0+996|baavoweltelu=2+966",
+            "input": "ఖాబా",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "shatelu=0+529|uni0952=0@66,-463+0|aatelu=2+739|uni1CDA=2@-83,293+0|dzauvoweltelu=4+818|tahalanttelu=6+723",
+            "input": "శ॒ఆ᳚ౙౌత్",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "katelu=0+489|uvowelsigntelu=0+318|hovoweltelu=2+1183|jheevoweltelu=4+1192|mevoweltelu=6+988|catelu=8+713|uni0951=8@-51,293+0",
+            "input": "కుహొఝేమెచ॑",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "catelu=0+682|rrvocalicvowelsigntelu=0+577|bhauvoweltelu=2+818|thatelu=4+657|uni0C00=4@-42,293+0|natelu=6+658|uni0C00=6@-43,293+0|ghevoweltelu=8+1003",
+            "input": "చౄభౌథఀనఀఘె",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "eetelu=0+671|uni0C04=0@-49,293+0|lllatelu=2+759|uvowelsigntelu=2+318|lvocalicvowelsigntelu=2+0|jhatelu=5+1192|uni0951=5@-400,293+0",
+            "input": "ఏఄఴుౢఝ॑",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "chiivoweltelu=0+723|uni1CF2=2+449",
+            "input": "ఛీᳲ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "uutelu=0+1027|uni0952=0@-373,-463+0|ngovoweltelu=2+877|autelu=4+684|uni1CDA=4@-56,293+0",
+            "input": "ఊ॒ఙొఔ᳚",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ghovoweltelu=0+1321|lllevoweltelu=2+773|shaavoweltelu=4+818",
+            "input": "ఘొఴెశా",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "kaavoweltelu=0+780|nyahalanttelu=2+877",
+            "input": "కాఞ్",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "leevoweltelu=0+665|tatelu=2+685|rrvocalicvowelsigntelu=2+581|katelu=4+491|rrvocalicvowelsigntelu=4+577",
+            "input": "లేతౄకౄ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "datelu=0+657|uni0C00=0@-42,293+0|soovoweltelu=2+966|llvocalictelu=4+1047|vatelu=5+670|rvocalictelu=6+1325|uni0C00=6@-376,293+0|llvocalictelu=8+1047|natelu=9+658",
+            "input": "దఀసోౡవఋఀౡన",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "rrreevoweltelu=0+657|ssoovoweltelu=2+966",
+            "input": "ౚేషో",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "rrrahalanttelu=0+657|dahalanttelu=2+657|space=2+0|thatelu=5+657|uni1CDA=5@-42,293+0|tahalanttelu=7+723",
+            "input": "ౚ్ద్‍థ᳚త్",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "llatelu=0+622|uni0C00=0@-25,293+0|kiivoweltelu=2+481|tthovoweltelu=4+714|ttheevoweltelu=6+564|jhatelu=8+1192|uni0C00=8@-400,293+0",
+            "input": "ళఀకీఠొఠేఝఀ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ratelu=0+544|rrvocalicvowelsigntelu=0+577|lllevoweltelu=2+773|candrabindutelu=2+287|rrvocalictelu=5+1576|satelu=6+658",
+            "input": "రౄఴెఁౠస",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "hovoweltelu=0+1150|ddasubscripttelu=0@-461,0+0|llatelu=4+662|backslash.telu=5+368|vatelu=6+670|uni0C04=6@-49,293+0",
+            "input": "హ్డొళ\\వఄ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "boovoweltelu=0+841|dhoovoweltelu=2+768",
+            "input": "బోధో",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhoovoweltelu=0+897|hatelu=2+950|uni0952=2@-229,-463+0|bhatelu=4+733|asterisk.telu=5+520|hatelu=6+919|hatelu=7+950|rrrasubscripttelu=7@-273,0+0",
+            "input": "భోహ॒భ*హహ్ౚ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "matelu=0+988|uni1CDA=0@-208,293+0|ttauvoweltelu=2+896|nnoovoweltelu=4+986|casubscripttelu=4+326|llatelu=8+622|uvowelsign1telu=8+359",
+            "input": "మ᳚టౌణ్చోళు",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "tatelu=0+723|uni0C04=0@-75,293+0|roovoweltelu=2+714|uuvowelsigntelu=2+569|natelu=5+658",
+            "input": "తఄరోూన",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ssiivoweltelu=0+674|llvocalicvowelsigntelu=0+223|nyiivoweltelu=3+877",
+            "input": "షీౣఞీ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "rrvocalictelu=0+1607|uni1CDA=0@-517,293+0|nyaavoweltelu=2+1167|tthatelu=4+564|uni0C04=4@4,293+0|llloovoweltelu=6+929|shovoweltelu=8+764",
+            "input": "ౠ᳚ఞాఠఄఴోశొ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ddiivoweltelu=0+690|phoovoweltelu=2+966|rrvocalictelu=4+1576|natelu=5+658",
+            "input": "డీఫోౠన",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ngaavoweltelu=0+899|lllatelu=2+773|uni0C00=2@-100,293+0|matelu=4+957|rvocalicvowelsigntelu=4+358",
+            "input": "ఙాఴఀమృ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "vivoweltelu=0+687|yasubscripttelu=0+396",
+            "input": "వ్యి",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "dhiivoweltelu=0+657|nyauvoweltelu=2+1096",
+            "input": "ధీఞౌ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "hatelu=0+974|rvocalicvowelsigntelu=0+358|lllatelu=2+759|uuvowelsigntelu=2+569|hatelu=4+919|ssatelu=5+674",
+            "input": "హృఴూహష",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "sheevoweltelu=0+529|uvowelsigntelu=0+318|jatelu=3+660|rrvocalicvowelsigntelu=3+577|khatelu=5+693|rvocalicvowelsigntelu=5+358",
+            "input": "శేుజౄఖృ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "llatelu=0+622|uuvowelsign1telu=0+610|matelu=2+957|rrvocalicvowelsigntelu=2+577|uni1CDA=2@-754,293+0|visargatelu=2+284|rrvocalictelu=6+1576|ghatelu=7+988",
+            "input": "ళూమౄః᳚ౠఘ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ghiivoweltelu=0+988|rrratelu=2+657|uni0952=2@-42,-463+0",
+            "input": "ఘీౚ॒",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "pahalanttelu=0+670|space=0+0|ddatelu=3+690|uni0C04=3@-59,293+0|ssovoweltelu=5+978|visargatelu=5+284",
+            "input": "ప్‍డఄషొః",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ssevoweltelu=0+689|kevoweltelu=2+481|katelu=4+491|rvocalicvowelsigntelu=4+358",
+            "input": "షెకెకృ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "nnauvoweltelu=0+951|eetelu=2+671|uni0951=2@-49,293+0|bhatelu=4+693|uni1CDA=4@-60,293+0|kovoweltelu=6+687|thauvoweltelu=8+768",
+            "input": "ణౌఏ॑భ᳚కొథౌ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "thiivoweltelu=0+657|rrvocalictelu=2+1576|vatelu=3+670|nnatelu=4+772|rvocalicvowelsigntelu=4+350|anusvaratelu=4+490",
+            "input": "థీౠవణృం",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "bhatelu=0+693|jhasubscripttelu=0@-19,0+0|rvocalicvowelsign1telu=0+487",
+            "input": "భ్ఝృ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "dhahalanttelu=0+657|space=0+0|uni0951=0@-42,293+0|candrabindutelu=0+287|jhivoweltelu=5+1192|tsevoweltelu=7+713",
+            "input": "ధ్‍ఁ॑ఝిౘె",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "khaavoweltelu=0+996|ngiivoweltelu=2+684|jasubscripttelu=2@-88,0+0|uni1CDA=2@-56,293+0|bhovoweltelu=7+897",
+            "input": "ఖాఙ్జీ᳚భొ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "llahalanttelu=0+622|space=0+0|ddahalanttelu=3+690|space=3+0|catelu=6+682|rrvocalicvowelsigntelu=6+546|hatelu=8+974|rrvocalicvowelsigntelu=8+577|jauvoweltelu=10+895",
+            "input": "ళ్‍డ్‍చౄహౄజౌ",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        },
+        {
+            "expectation": "ddatelu=0+695|uvowelsigntelu=0+318|gatelu=2+570|uni0951=2@1,293+0|rrevoweltelu=4+773|llatelu=6+662|braceright.telu=7+416|aatelu=8+739|uni1CDA=8@-83,293+0",
+            "input": "డుగ॑ఱెళ}ఆ᳚",
+            "note": "Added by SIESTA",
+            "only": "NotoSerifTelugu-Regular.ttf"
+        }
+    ]
+}


### PR DESCRIPTION
There are some small kerning changes but I think these are actually an improvement; the Monotype sources were applying kerning to two bases with a spacing mark in the middle.