### PR TITLE
Noto Sans SignWriting 2.003

### DIFF
--- a/test/fontbakery/devanagari.json
+++ b/test/fontbakery/devanagari.json
@@ -38673,7 +38673,8 @@
         {
             "expectation": "chaaltdeva=0+701|vattuudeva=0@-113,0+0|anudattadeva=0@-104,-234+0",
             "input": "छ्रु॒",
-            "note": "Out-of-order application test"
+            "note": "Out-of-order application test",
+            "only": "NotoSansDevanagari-Regular.ttf"
         }
     ]
 }

--- a/test/fontbakery/signwriting.json
+++ b/test/fontbakery/signwriting.json
@@ -1,0 +1,10 @@
+{
+    "tests": [
+        {
+            "expectation": "u1D800_F2_R2=0+1000",
+            "input": "𝠀𝪛𝪡",
+            "note": "Issue #2263",
+            "only": "NotoSansSignWriting-Regular.ttf"
+        }
+    ]
+}


### PR DESCRIPTION
- Apply Devanagari test only to Devanagari
- Add test for googlefonts/noto-fonts#2263
- Change order of application; fixes googlefonts/noto-fonts#2263
- Actually that deserves a new version
