### PR TITLE
Fixed issue reported in googlefonts/noto-fonts#2046

### DIFF
--- a/src/NotoSansGeorgian/NotoSansGeorgian-Bold.ufo/glyphs/A_n-georgian.glif
+++ b/src/NotoSansGeorgian/NotoSansGeorgian-Bold.ufo/glyphs/A_n-georgian.glif
@@ -28,14 +28,12 @@
       <point x="264" y="145"/>
       <point x="240" y="186"/>
       <point x="240" y="246" type="curve" smooth="yes"/>
-      <point x="240" y="276"/>
-      <point x="243" y="320"/>
-      <point x="262" y="373" type="curve"/>
-      <point x="334" y="352" type="line"/>
-      <point x="-33" y="352" type="line"/>
-      <point x="71" y="378" type="line"/>
-      <point x="45" y="314"/>
-      <point x="41" y="274"/>
+      <point x="240" y="272"/>
+      <point x="242" y="308"/>
+      <point x="255" y="352" type="curve"/>
+      <point x="61" y="352" type="line"/>
+      <point x="44" y="303"/>
+      <point x="41" y="269"/>
       <point x="41" y="237" type="curve" smooth="yes"/>
       <point x="41" y="79"/>
       <point x="153" y="-10"/>

--- a/src/NotoSansGeorgian/NotoSansGeorgian-Condensed.ufo/glyphs/A_n-georgian.glif
+++ b/src/NotoSansGeorgian/NotoSansGeorgian-Condensed.ufo/glyphs/A_n-georgian.glif
@@ -28,14 +28,12 @@
       <point x="163" y="66"/>
       <point x="128" y="120"/>
       <point x="128" y="212" type="curve" smooth="yes"/>
-      <point x="128" y="262"/>
-      <point x="138" y="317"/>
-      <point x="162" y="379" type="curve"/>
-      <point x="189" y="352" type="line"/>
-      <point x="32" y="352" type="line"/>
-      <point x="79" y="379" type="line"/>
-      <point x="53" y="315"/>
-      <point x="41" y="262"/>
+      <point x="128" y="255"/>
+      <point x="135" y="301"/>
+      <point x="152" y="352" type="curve"/>
+      <point x="69" y="352" type="line"/>
+      <point x="50" y="300"/>
+      <point x="41" y="254"/>
       <point x="41" y="208" type="curve" smooth="yes"/>
       <point x="41" y="74"/>
       <point x="115" y="-10"/>

--- a/src/NotoSansGeorgian/NotoSansGeorgian-CondensedBold.ufo/glyphs/A_n-georgian.glif
+++ b/src/NotoSansGeorgian/NotoSansGeorgian-CondensedBold.ufo/glyphs/A_n-georgian.glif
@@ -28,14 +28,12 @@
       <point x="226" y="137"/>
       <point x="210" y="175"/>
       <point x="210" y="249" type="curve" smooth="yes"/>
-      <point x="210" y="292"/>
-      <point x="217" y="344"/>
-      <point x="240" y="419" type="curve"/>
-      <point x="298" y="352" type="line"/>
-      <point x="-24" y="352" type="line"/>
-      <point x="69" y="410" type="line"/>
-      <point x="46" y="338"/>
-      <point x="36" y="293"/>
+      <point x="210" y="278"/>
+      <point x="213" y="311"/>
+      <point x="222" y="352" type="curve"/>
+      <point x="52" y="352" type="line"/>
+      <point x="41" y="310"/>
+      <point x="36" y="275"/>
       <point x="36" y="232" type="curve" smooth="yes"/>
       <point x="36" y="86"/>
       <point x="120" y="-10"/>

--- a/src/NotoSansGeorgian/NotoSansGeorgian-CondensedLight.ufo/glyphs/A_n-georgian.glif
+++ b/src/NotoSansGeorgian/NotoSansGeorgian-CondensedLight.ufo/glyphs/A_n-georgian.glif
@@ -28,14 +28,12 @@
       <point x="124" y="15"/>
       <point x="71" y="72"/>
       <point x="71" y="209" type="curve" smooth="yes"/>
-      <point x="71" y="261"/>
-      <point x="81" y="311"/>
-      <point x="95" y="360" type="curve"/>
-      <point x="105" y="352" type="line"/>
-      <point x="54" y="352" type="line"/>
-      <point x="68" y="359" type="line"/>
-      <point x="54" y="315"/>
-      <point x="44" y="260"/>
+      <point x="71" y="258"/>
+      <point x="80" y="306"/>
+      <point x="93" y="352" type="curve"/>
+      <point x="66" y="352" type="line"/>
+      <point x="53" y="309"/>
+      <point x="44" y="257"/>
       <point x="44" y="209" type="curve" smooth="yes"/>
       <point x="44" y="53"/>
       <point x="113" y="-10"/>

--- a/src/NotoSansGeorgian/NotoSansGeorgian-CondensedSemiBold.ufo/glyphs/A_n-georgian.glif
+++ b/src/NotoSansGeorgian/NotoSansGeorgian-CondensedSemiBold.ufo/glyphs/A_n-georgian.glif
@@ -28,14 +28,12 @@
       <point x="205" y="109"/>
       <point x="182" y="155"/>
       <point x="182" y="235" type="curve" smooth="yes"/>
-      <point x="182" y="279"/>
-      <point x="190" y="334"/>
-      <point x="213" y="404" type="curve"/>
-      <point x="260" y="352" type="line"/>
-      <point x="1" y="352" type="line"/>
-      <point x="76" y="398" type="line"/>
-      <point x="52" y="329"/>
-      <point x="41" y="280"/>
+      <point x="182" y="267"/>
+      <point x="186" y="306"/>
+      <point x="198" y="352" type="curve"/>
+      <point x="61" y="352" type="line"/>
+      <point x="47" y="305"/>
+      <point x="41" y="267"/>
       <point x="41" y="223" type="curve" smooth="yes"/>
       <point x="41" y="81"/>
       <point x="122" y="-10"/>

--- a/src/NotoSansGeorgian/NotoSansGeorgian-Light.ufo/glyphs/A_n-georgian.glif
+++ b/src/NotoSansGeorgian/NotoSansGeorgian-Light.ufo/glyphs/A_n-georgian.glif
@@ -28,14 +28,12 @@
       <point x="164" y="15"/>
       <point x="86" y="91"/>
       <point x="86" y="221" type="curve" smooth="yes"/>
-      <point x="86" y="261"/>
-      <point x="93" y="316"/>
-      <point x="110" y="359" type="curve"/>
-      <point x="119" y="352" type="line"/>
-      <point x="68" y="352" type="line"/>
-      <point x="83" y="359" type="line"/>
-      <point x="66" y="315"/>
-      <point x="59" y="262"/>
+      <point x="86" y="259"/>
+      <point x="92" y="310"/>
+      <point x="107" y="352" type="curve"/>
+      <point x="80" y="352" type="line"/>
+      <point x="65" y="309"/>
+      <point x="59" y="260"/>
       <point x="59" y="220" type="curve" smooth="yes"/>
       <point x="59" y="77"/>
       <point x="144" y="-10"/>

--- a/src/NotoSansGeorgian/NotoSansGeorgian-Regular.ufo/glyphs/A_n-georgian.glif
+++ b/src/NotoSansGeorgian/NotoSansGeorgian-Regular.ufo/glyphs/A_n-georgian.glif
@@ -28,14 +28,12 @@
       <point x="198" y="69"/>
       <point x="148" y="137"/>
       <point x="148" y="228" type="curve" smooth="yes"/>
-      <point x="148" y="262"/>
-      <point x="152" y="310"/>
-      <point x="176" y="369" type="curve"/>
-      <point x="209" y="352" type="line"/>
-      <point x="41" y="352" type="line"/>
-      <point x="85" y="369" type="line"/>
-      <point x="56" y="302"/>
-      <point x="55" y="264"/>
+      <point x="148" y="258.667"/>
+      <point x="151.307" y="300.756"/>
+      <point x="169.556" y="352" type="curve"/>
+      <point x="78.0348" y="352" type="line"/>
+      <point x="55.8314" y="295.251"/>
+      <point x="55" y="260.12"/>
       <point x="55" y="220" type="curve" smooth="yes"/>
       <point x="55" y="83"/>
       <point x="153" y="-9"/>

--- a/src/NotoSansGeorgian/NotoSansGeorgian-SemiBold.ufo/glyphs/A_n-georgian.glif
+++ b/src/NotoSansGeorgian/NotoSansGeorgian-SemiBold.ufo/glyphs/A_n-georgian.glif
@@ -28,14 +28,12 @@
       <point x="236" y="116"/>
       <point x="202" y="168"/>
       <point x="202" y="239" type="curve" smooth="yes"/>
-      <point x="202" y="268"/>
-      <point x="205" y="315"/>
-      <point x="226" y="371" type="curve"/>
-      <point x="283" y="352" type="line"/>
-      <point x="-7" y="352" type="line"/>
-      <point x="74" y="375" type="line"/>
-      <point x="47" y="309"/>
-      <point x="44" y="272"/>
+      <point x="202" y="265"/>
+      <point x="204" y="304"/>
+      <point x="219" y="352" type="curve"/>
+      <point x="65" y="352" type="line"/>
+      <point x="46" y="300"/>
+      <point x="44" y="267"/>
       <point x="44" y="230" type="curve" smooth="yes"/>
       <point x="44" y="81"/>
       <point x="144" y="-10"/>


### PR DESCRIPTION
I fixed the problem with [#2046](https://github.com/googlefonts/noto-fonts/issues/2046) about two little triangles at one end of the stroke.

The outline of uni1C90 was modified. The range of influence is the 4 glyphs used as components.
uni1C900301, uni1C900308, uni1C900304, uni1C9003040308

A total of 5 glyphs have been adjusted.

I ran `./build src/NotoSansGeorgian/NotoSansGeorgian.designspace` and verified that 36 ttf files were generated correctly.

I used fontdiff to run the tests in test/Georgian. We have confirmed that there are no unintended adjustments.