### PR TITLE
Noto Sans Elbasan 2.003

### DIFF
--- a/src/NotoSansElbasan.glyphs
+++ b/src/NotoSansElbasan.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "1357";
+.appVersion = "3072";
 copyright = "Copyright 2018-2021 Google Inc. All Rights Reserved.";
 customParameters = (
 {
@@ -77,6 +77,7 @@ Omega,
 uni03DA,
 uni03DC,
 uni03DE,
+uni03E0,
 uni25CC,
 periodcentered,
 overlinecmb,
@@ -3790,6 +3791,56 @@ unicode = 03DE;
 script = greek;
 category = Letter;
 subCategory = Uppercase;
+},
+{
+glyphname = uni03E0;
+lastChange = "2022-04-18 09:22:09 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"466 0 LINE",
+"507 99 OFFCURVE",
+"525 195 OFFCURVE",
+"525 287 CURVE SMOOTH",
+"525 562 OFFCURVE",
+"411 725 OFFCURVE",
+"197 725 CURVE SMOOTH",
+"103 725 OFFCURVE",
+"42 703 OFFCURVE",
+"-10 664 CURVE",
+"32 594 LINE",
+"67 623 OFFCURVE",
+"127 646 OFFCURVE",
+"197 646 CURVE SMOOTH",
+"246 646 OFFCURVE",
+"288 633 OFFCURVE",
+"321 610 CURVE",
+"99 480 LINE",
+"139 412 LINE",
+"376 551 LINE",
+"394 521 OFFCURVE",
+"407 484 OFFCURVE",
+"416 441 CURVE",
+"198 313 LINE",
+"237 246 LINE",
+"427 358 LINE",
+"429 336 OFFCURVE",
+"430 313 OFFCURVE",
+"430 289 CURVE SMOOTH",
+"430 193 OFFCURVE",
+"411 101 OFFCURVE",
+"369 0 CURVE"
+);
+}
+);
+width = 593;
+}
+);
+unicode = 03E0;
 },
 {
 glyphname = uni25CC;

--- a/src/NotoSansElbasan.glyphs
+++ b/src/NotoSansElbasan.glyphs
@@ -1,6 +1,6 @@
 {
 .appVersion = "3072";
-copyright = "Copyright 2018-2022 Google Inc. All Rights Reserved.";
+copyright = "Copyright 2018-2022 The Noto Project Authors (https://github.com/googlefonts/noto-source/)";
 customParameters = (
 {
 name = glyphOrder;
@@ -112,6 +112,10 @@ name = codePageRanges;
 value = (
 1252
 );
+},
+{
+name = "Use Typo Metrics";
+value = 1;
 },
 {
 name = description;

--- a/src/NotoSansElbasan.glyphs
+++ b/src/NotoSansElbasan.glyphs
@@ -1,6 +1,6 @@
 {
 .appVersion = "3072";
-copyright = "Copyright 2018-2021 Google Inc. All Rights Reserved.";
+copyright = "Copyright 2018-2022 Google Inc. All Rights Reserved.";
 customParameters = (
 {
 name = glyphOrder;
@@ -135,7 +135,7 @@ value = "Noto is a trademark of Google Inc.";
 },
 {
 name = versionString;
-value = "Version 2.002";
+value = "Version 2.003";
 }
 );
 date = "2021-12-16 18:42:46 +0000";
@@ -4350,5 +4350,5 @@ manufacturer = "Monotype Imaging Inc.";
 manufacturerURL = "http://www.google.com/get/noto/";
 unitsPerEm = 1000;
 versionMajor = 2;
-versionMinor = 2;
+versionMinor = 3;
 }


### PR DESCRIPTION
- Add Greek Sampi. Fixes googlefonts/noto-fonts#1363
- Bump version/copyright
- Pass notofonts fontbakery profile
