### PR TITLE
Noto Sans Myanmar 2.105

### DIFF
--- a/test/fontbakery/lepcha.json
+++ b/test/fontbakery/lepcha.json
@@ -3,13 +3,15 @@
         {
             "input": "ᰀ᰷ᰬᰀ᰷ᰤᰬ",
             "expectation": "uni1C00=0+602|uni1C37_uni1C2C=0@-272,0+0|uni1C00_1C24=3+840|uni1C37_uni1C2C=3@-510,0+0",
-            "note": "Nukta-e ligature; googlefonts/noto-fonts#2321"
-        }
+            "note": "Nukta-e ligature; googlefonts/noto-fonts#2321",
+            "only": "NotoSansLepcha-Regular.ttf"
+        },
         {
             "input": "ᰁᰩᰁᰤᰩ",
             "expectation": "uni1C29.short=0+200|uni1C01=0+541|uni1C29.short=2+200|uni1C01_1C24=2+783",
-            "note": "uni1C01_1C24 should get a short O; googlefonts/noto-fonts#1734"
-        }
+            "note": "uni1C01_1C24 should get a short O; googlefonts/noto-fonts#1734",
+            "only": "NotoSansLepcha-Regular.ttf"
+        },
         {
             "expectation": "uni1C29=0+220|uni1C1E=0+590|uni1C15=2+741|uni1C2F=2@-370,0+0",
             "input": "ᰞᰩᰕᰯ",

--- a/test/fontbakery/myanmar.json
+++ b/test/fontbakery/myanmar.json
@@ -36,6 +36,24 @@
 			"note": "googlefonts/noto-fonts#1926",
 			"only": "NotoSansMyanmar-Regular.ttf",
 			"expectation": "ka=0+1124|_ai=0@-27,20+0|_tall_aa=0+267|space=3+260|ka=4+1124|anusvara=4@-27,0+0|_tall_aa=4+267"
+		},
+		{
+			"input": "ကြု ကြူ ကြို ကြီု ကြဵုကြုဲ ကြုံ",
+			"note": "googlefonts/noto-fonts#1926",
+			"only": "NotoSansMyanmar-Regular.ttf",
+			"expectation": "medial_ra.w2=0+229|ka=0+1124|_u_spacing=0+261|dummymarkmymr=0+0|space=3+260|medial_ra.w2=4+229|ka=4+1124|_uu_spacing=4+461|dummymarkmymr=4+0|space=7+260|medial_ra_tt.w2=8+229|ka=8+1124|_i=8@-27,0+0|_u_spacing=8+261|dummymarkmymr=8+0|space=12+260|medial_ra_tt.w2=13+229|ka=13+1124|_ii=13@-27,0+0|_u_spacing=13+261|dummymarkmymr=13+0|space=17+260|medial_ra_tt.w2=18+229|ka=18+1124|_e_above=18@-27,0+0|_u_spacing=18+261|dummymarkmymr=18+0|medial_ra_tt.w2=22+229|ka=22+1124|_ai=22@-27,20+0|_u_spacing=22+261|dummymarkmymr=22+0|space=26+260|medial_ra.w2=27+229|ka=27+1124|anusvara=27@-27,0+0|_u_spacing=27+261|dummymarkmymr=27+0"
+		},
+		{
+			"input": "ခြု ခြူ ခြို ခြီု ခြဵု ခြုဲ ခြုံ",
+			"note": "googlefonts/noto-fonts#1926",
+			"only": "NotoSansMyanmar-Regular.ttf",
+			"expectation": "medial_ra=0+229|kha=0+676|_u_spacing=0+261|dummymarkmymr=0+0|space=3+260|medial_ra=4+229|kha=4+676|_uu_spacing=4+461|dummymarkmymr=4+0|space=7+260|medial_ra_tt=8+229|kha=8+676|_i=8@-44,0+0|_u_spacing=8+261|dummymarkmymr=8+0|space=12+260|medial_ra_tt=13+229|kha=13+676|_ii=13@-44,0+0|_u_spacing=13+261|dummymarkmymr=13+0|space=17+260|medial_ra_tt=18+229|kha=18+676|_e_above=18@-44,0+0|_u_spacing=18+261|dummymarkmymr=18+0|space=22+260|medial_ra_tt=23+229|kha=23+676|_ai=23@-44,20+0|_u_spacing=23+261|dummymarkmymr=23+0|space=27+260|medial_ra=28+229|kha=28+676|anusvara=28@-44,0+0|_u_spacing=28+261|dummymarkmymr=28+0"
+		},
+		{
+			"input": "ကာံ ကာဲ ကောံ ကောဲ ကေုာံ",
+			"note": "googlefonts/noto-fonts#1926",
+			"only": "NotoSansMyanmar-Regular.ttf",
+			"expectation": "ka=0+1124|_aa=0+455|anusvara=0@-36,0+0|space=3+260|ka=4+1124|_aa=4+455|_ai=4@-36,20+0|space=7+260|_e=8+618|ka=8+1124|_aa=8+455|anusvara=8@-36,0+0|space=12+260|_e=13+618|ka=13+1124|_aa=13+455|_ai=13@-36,20+0|space=17+260|_e=18+618|ka=18+1124|_u=18@-5,0+0|_aa=18+455|anusvara=18@-36,0+0"
 		}
 	]
 }

--- a/test/fontbakery/myanmar.json
+++ b/test/fontbakery/myanmar.json
@@ -1,0 +1,41 @@
+{
+	"tests": [
+		{
+			"input": "သ္ကြ",
+			"note": "googlefonts/noto-fonts#2357",
+			"expectation": "medial_ra_bt2.w2=0+229|sa=0+1127|ka.sub=0@-263,0+0",
+			"only": "NotoSansMyanmar-Regular.ttf"
+		},
+		{
+			"input": "ၚ်",
+			"note": "googlefonts/noto-fonts#1926",
+			"only": "NotoSansMyanmar-Regular.ttf",
+			"expectation": "nga=0+650|asat=0@-7,0+0"
+		},
+		{
+			"input": "ၚု",
+			"note": "googlefonts/noto-fonts#1926",
+			"only": "NotoSansMyanmar-Regular.ttf",
+			"expectation": "nga_mon=0+618|_u_spacing=0+261|dummymarkmymr=0+0"
+		},
+		{
+			"input": "ည္ည",
+			"note": "googlefonts/noto-fonts#1926",
+			"only": "NotoSansMyanmar-Regular.ttf",
+			"expectation": "nnya.notail=0+1110|nnya.sub2=0@-57,0+0"
+		},
+		{
+			"input": "ည္ည",
+			"note": "googlefonts/noto-fonts#1926",
+			"language": "mnw",
+			"only": "NotoSansMyanmar-Regular.ttf",
+			"expectation": "greatNnya-mon=0+1559"
+		},
+		{
+			"input": "ကါဲ ကါံ",
+			"note": "googlefonts/noto-fonts#1926",
+			"only": "NotoSansMyanmar-Regular.ttf",
+			"expectation": "ka=0+1124|_ai=0@-27,20+0|_tall_aa=0+267|space=3+260|ka=4+1124|anusvara=4@-27,0+0|_tall_aa=4+267"
+		}
+	]
+}


### PR DESCRIPTION
Fixes some bugs introduced by 2.104:

- Fixes googlefonts/noto-fonts#2357
- Bump version (both places this time)
- Add Myanmar test suite
- Fix tests
- Fix tests
- More tests (which fail)
- Fix aa swap issue
