### PR TITLE
Fix NotoSansOriya-MM.glyphs GSUB,GDEF

### DIFF
--- a/src/NotoSansOriya-MM.glyphs
+++ b/src/NotoSansOriya-MM.glyphs
@@ -1,5 +1,5 @@
 {
-.appVersion = "1286";
+.appVersion = "1352";
 classes = (
 {
 code = "nukta-oriya uMatra-oriya uuMatra-oriya rVocalicMatra-oriya rrVocalicMatra-oriya lVocalicMatra-oriya llVocalicMatra-oriya halant-oriya ka-oriya.below kha-oriya.below ga-oriya.below gha-oriya.below nga-oriya.below ca-oriya.below cha-oriya.below ja-oriya.below jha-oriya.below tta-oriya.below ttha-oriya.below dda-oriya.below ddha-oriya.below nna-oriya.below ta-oriya.below tha-oriya.below da-oriya.below dha-oriya.below na-oriya.below pa-oriya.below pha-oriya.below ba-oriya.below bha-oriya.below ma-oriya.below ya-oriya.below ra-oriya.below la-oriya.below lla-oriya.below va-oriya.below sha-oriya.below ssa-oriya.below sa-oriya.below ha-oriya.below kassa-oriya.below iMatra-oriya.below rephauLength-oriya rephauLengthcandraBindu-oriya rauMatra-oriya.below rauuMatra-oriya.below rarVocalicMatra-oriya.below rarrVocalicMatra-oriya.below";
@@ -591,7 +591,6 @@ disablesAutomaticAlignment = 1;
 familyName = "Noto Sans Oriya";
 featurePrefixes = (
 {
-automatic = 1;
 code = "languagesystem DFLT dflt;\012\012languagesystem ory2 dflt;\012";
 name = Languagesystems;
 }
@@ -629,20 +628,19 @@ code = "script ory2;\012\012sub yya-oriya ra-oriya.below by yyara-oriya;";
 name = cjct;
 },
 {
-code = "script ory2;\012  lookupflag MarkAttachmentType @NonAboveMarks;\012	sub [ka-oriya kha-oriya ga-oriya gha-oriya nga-oriya ca-oriya cha-oriya ja-oriya jha-oriya nya-oriya tta-oriya ttha-oriya dda-oriya ddha-oriya nna-oriya ta-oriya tha-oriya da-oriya dha-oriya na-oriya pa-oriya pha-oriya ba-oriya bha-oriya ma-oriya ya-oriya ra-oriya la-oriya lla-oriya va-oriya sha-oriya ssa-oriya sa-oriya ha-oriya rra-oriya rha-oriya wa-oriya kassa-oriya]' [ka-oriya.below kha-oriya.below ga-oriya.below gha-oriya.below nga-oriya.below ca-oriya.below cha-oriya.below ja-oriya.below jha-oriya.below tta-oriya.below ttha-oriya.below dda-oriya.below ddha-oriya.below nna-oriya.below ta-oriya.below tha-oriya.below da-oriya.below dha-oriya.below na-oriya.below pa-oriya.below pha-oriya.below ba-oriya.below bha-oriya.below ma-oriya.below ya-oriya.below la-oriya.below lla-oriya.below va-oriya.below sha-oriya.below ssa-oriya.below sa-oriya.below ha-oriya.below kassa-oriya.below] by [ka-oriya.base kha-oriya.base ga-oriya.base gha-oriya.base nga-oriya.base ca-oriya.base cha-oriya.base ja-oriya.base jha-oriya.base nya-oriya.base tta-oriya.base ttha-oriya.base dda-oriya.base ddha-oriya.base nna-oriya.base ta-oriya.base tha-oriya.base da-oriya.base dha-oriya.base na-oriya.base pa-oriya.base pha-oriya.base ba-oriya.base bha-oriya.base ma-oriya.base ya-oriya.base ra-oriya.base la-oriya.base lla-oriya.base va-oriya.base sha-oriya.base ssa-oriya.base sa-oriya.base ha-oriya.base rra-oriya.base rha-oriya.base wa-oriya.base kassa-oriya.base];";
+code = "script ory2;\012  lookupflag MarkAttachmentType @NonAboveMarks;\012    ignore sub [ka-oriya kha-oriya ga-oriya gha-oriya nga-oriya ca-oriya cha-oriya ja-oriya jha-oriya nya-oriya tta-oriya ttha-oriya dda-oriya ddha-oriya nna-oriya ta-oriya tha-oriya da-oriya dha-oriya na-oriya pa-oriya pha-oriya ba-oriya bha-oriya ma-oriya ya-oriya ra-oriya la-oriya lla-oriya va-oriya sha-oriya ssa-oriya sa-oriya ha-oriya rra-oriya rha-oriya wa-oriya kassa-oriya]' [ra-oriya.below]' [uMatra-oriya uuMatra-oriya rVocalicMatra-oriya rrVocalicMatra-oriya lVocalicMatra-oriya llVocalicMatra-oriya];\012    \012	sub [ka-oriya kha-oriya ga-oriya gha-oriya nga-oriya ca-oriya cha-oriya ja-oriya jha-oriya nya-oriya tta-oriya ttha-oriya dda-oriya ddha-oriya nna-oriya ta-oriya tha-oriya da-oriya dha-oriya na-oriya pa-oriya pha-oriya ba-oriya bha-oriya ma-oriya ya-oriya ra-oriya la-oriya lla-oriya va-oriya sha-oriya ssa-oriya sa-oriya ha-oriya rra-oriya rha-oriya wa-oriya kassa-oriya]' [ka-oriya.below kha-oriya.below ga-oriya.below gha-oriya.below nga-oriya.below ca-oriya.below cha-oriya.below ja-oriya.below jha-oriya.below tta-oriya.below ttha-oriya.below dda-oriya.below ddha-oriya.below nna-oriya.below ta-oriya.below tha-oriya.below da-oriya.below dha-oriya.below na-oriya.below pa-oriya.below pha-oriya.below ba-oriya.below bha-oriya.below ma-oriya.below ya-oriya.below la-oriya.below lla-oriya.below va-oriya.below sha-oriya.below ssa-oriya.below sa-oriya.below ha-oriya.below kassa-oriya.below ra-oriya.below] by [ka-oriya.base kha-oriya.base ga-oriya.base gha-oriya.base nga-oriya.base ca-oriya.base cha-oriya.base ja-oriya.base jha-oriya.base nya-oriya.base tta-oriya.base ttha-oriya.base dda-oriya.base ddha-oriya.base nna-oriya.base ta-oriya.base tha-oriya.base da-oriya.base dha-oriya.base na-oriya.base pa-oriya.base pha-oriya.base ba-oriya.base bha-oriya.base ma-oriya.base ya-oriya.base ra-oriya.base la-oriya.base lla-oriya.base va-oriya.base sha-oriya.base ssa-oriya.base sa-oriya.base ha-oriya.base rra-oriya.base rha-oriya.base wa-oriya.base kassa-oriya.base];";
 name = pres;
 },
 {
-code = "script ory2;\012  lookupflag MarkAttachmentType @NonAboveMarks;\012	sub [ka-oriya.below kha-oriya.below ga-oriya.below gha-oriya.below nga-oriya.below ca-oriya.below cha-oriya.below ja-oriya.below jha-oriya.below tta-oriya.below ttha-oriya.below dda-oriya.below ddha-oriya.below nna-oriya.below ta-oriya.below tha-oriya.below da-oriya.below dha-oriya.below na-oriya.below pa-oriya.below pha-oriya.below ba-oriya.below bha-oriya.below ma-oriya.below ya-oriya.below ra-oriya.below la-oriya.below lla-oriya.below va-oriya.below sha-oriya.below ssa-oriya.below sa-oriya.below ha-oriya.below kassa-oriya.below] [ka-oriya.below kha-oriya.below ga-oriya.below gha-oriya.below nga-oriya.below ca-oriya.below cha-oriya.below ja-oriya.below jha-oriya.below tta-oriya.below ttha-oriya.below dda-oriya.below ddha-oriya.below nna-oriya.below ta-oriya.below tha-oriya.below da-oriya.below dha-oriya.below na-oriya.below pa-oriya.below pha-oriya.below ba-oriya.below bha-oriya.below ma-oriya.below ya-oriya.below ra-oriya.below la-oriya.below lla-oriya.below va-oriya.below sha-oriya.below ssa-oriya.below sa-oriya.below ha-oriya.below]' by [ka-oriya.single kha-oriya.single ga-oriya.single gha-oriya.single nga-oriya.single ca-oriya.single cha-oriya.single ja-oriya.single jha-oriya.single tta-oriya.single ttha-oriya.single dda-oriya.single ddha-oriya.single nna-oriya.single ta-oriya.single tha-oriya.single da-oriya.single dha-oriya.single na-oriya.single pa-oriya.single pha-oriya.single ba-oriya.single bha-oriya.single ma-oriya.single ya-oriya.single ra-oriya.single la-oriya.single lla-oriya.single va-oriya.single sha-oriya.single ssa-oriya.single sa-oriya.single ha-oriya.single];\012\012	sub da-oriya.base dha-oriya.below va-oriya.single by dadhava-oriya;\012	sub ja-oriya.base ja-oriya.below va-oriya.single by jajava-oriya;\012	sub ka-oriya.base ta-oriya.below ra-oriya.single by katara-oriya;\012	sub ma-oriya.base bha-oriya.below ra-oriya.single by mabhara-oriya;\012	sub ma-oriya.base pa-oriya.below ra-oriya.single by mapara-oriya;\012	sub na-oriya.base da-oriya.below ra-oriya.single by nadara-oriya;\012	sub na-oriya.base da-oriya.below va-oriya.single by nadava-oriya;\012	sub na-oriya.base dha-oriya.below ra-oriya.single by nadhara-oriya;\012	sub na-oriya.base dha-oriya.below va-oriya.single by nadhava-oriya;\012	sub na-oriya.base ta-oriya.below ra-oriya.single by natara-oriya;\012	sub na-oriya.base ta-oriya.below va-oriya.single by natava-oriya;\012	sub nga-oriya.base ka-oriya.below ssa-oriya.single by ngakassa-oriya;\012	sub nga-oriya.base ka-oriya.below ta-oriya.single by ngakata-oriya;\012	sub nna-oriya.base dda-oriya.below ra-oriya.single by nnaddara-oriya;\012	sub sa-oriya.base ta-oriya.below ra-oriya.single by satara-oriya;\012	sub ssa-oriya.base ka-oriya.below ra-oriya.single by ssakara-oriya;\012	sub ssa-oriya.base tta-oriya.below ra-oriya.single by ssattara-oriya;\012	sub ta-oriya.base ka-oriya.below ra-oriya.single by takara-oriya;\012	sub ta-oriya.base pa-oriya.below ra-oriya.single by tapara-oriya;\012	sub ta-oriya.base sa-oriya.below na-oriya.single by tasana-oriya;\012	sub ta-oriya.base ta-oriya.below ra-oriya.single by tatara-oriya;\012	sub ta-oriya.base ta-oriya.below va-oriya.single by tatava-oriya;\012	sub ba-oriya.base ba-oriya.below by baba-oriya;\012	sub ba-oriya.base da-oriya.below by bada-oriya;\012	sub ba-oriya.base dha-oriya.below by badha-oriya;\012	sub ba-oriya.base ja-oriya.below by baja-oriya;\012	sub ba-oriya.base ra-oriya.below by bara-oriya;\012	sub bha-oriya.base ra-oriya.below by bhara-oriya;\012	sub ca-oriya.base ca-oriya.below by caca-oriya;\012	sub ca-oriya.base cha-oriya.below by cacha-oriya;\012	sub ca-oriya.base ra-oriya.below by cara-oriya;\012	sub cha-oriya.base ra-oriya.below by chara-oriya;\012	sub da-oriya.base bha-oriya.below by dabha-oriya;\012	sub da-oriya.base da-oriya.below by dada-oriya;\012	sub da-oriya.base dha-oriya.below by dadha-oriya;\012	sub da-oriya.base ga-oriya.below by daga-oriya;\012	sub da-oriya.base gha-oriya.below by dagha-oriya;\012	sub da-oriya.base ra-oriya.below by dara-oriya;\012	sub da-oriya.base va-oriya.below by dava-oriya;\012	sub dda-oriya.base dda-oriya.below by ddadda-oriya;\012	sub dda-oriya.base ga-oriya.below by ddaga-oriya;\012	sub dda-oriya.base ra-oriya.below by ddara-oriya;\012	sub ddha-oriya.base ra-oriya.below by ddhara-oriya;\012	sub dha-oriya.base ra-oriya.below by dhara-oriya;\012	sub dha-oriya.base va-oriya.below by dhava-oriya;\012	sub dha-oriya.base ya-oriya.below by dhaya-oriya;\012	sub dha-oriya.base yya-oriya.post by dhayya-oriya;\012	sub ga-oriya.base da-oriya.below by gada-oriya;\012	sub ga-oriya.base dha-oriya.below by gadha-oriya;\012	sub ga-oriya.base lla-oriya.below by galla-oriya;\012	sub ga-oriya.base na-oriya.below by gana-oriya;\012	sub ga-oriya.base ra-oriya.below by gara-oriya;\012	sub gha-oriya.base na-oriya.below by ghana-oriya;\012	sub gha-oriya.base ra-oriya.below by ghara-oriya;\012	sub ha-oriya.base ja-oriya.below by haja-oriya;\012	sub ha-oriya.base ka-oriya.below by haka-oriya;\012	sub ha-oriya.base la-oriya.below by hala-oriya;\012	sub ha-oriya.base lla-oriya.below by halla-oriya;\012	sub ha-oriya.base ma-oriya.below by hama-oriya;\012	sub ha-oriya.base na-oriya.below by hana-oriya;\012	sub ha-oriya.base ra-oriya.below by hara-oriya;\012	sub ha-oriya.base va-oriya.below by hava-oriya;\012	sub ja-oriya.base ja-oriya.below by jaja-oriya;\012	sub ja-oriya.base jha-oriya.below by jajha-oriya;\012	sub ja-oriya.base ra-oriya.below by jara-oriya;\012	sub ja-oriya.base va-oriya.below by java-oriya;\012	sub jha-oriya.base ra-oriya.below by jhara-oriya;\012	sub ka-oriya.base ca-oriya.below by kaca-oriya;\012	sub ka-oriya.base ka-oriya.below by kaka-oriya;\012	sub ka-oriya.base lla-oriya.below by kalla-oriya;\012	sub ka-oriya.base ra-oriya.below by kara-oriya;\012	sub ka-oriya.base sa-oriya.below by kasa-oriya;\012	sub ka-oriya.base ssa-oriya.below by kassa-oriya;\012	sub ka-oriya.base ta-oriya.below by kata-oriya;\012	sub ka-oriya.base tta-oriya.below by katta-oriya;\012	sub ka-oriya.base va-oriya.below by kava-oriya;\012	sub kha-oriya.base ra-oriya.below by khara-oriya;\012	sub la-oriya.base ga-oriya.below by laga-oriya;\012	sub la-oriya.base ka-oriya.below by laka-oriya;\012	sub la-oriya.base la-oriya.below by lala-oriya;\012	sub la-oriya.base lla-oriya.below by lalla-oriya;\012	sub la-oriya.base ma-oriya.below by lama-oriya;\012	sub la-oriya.base pa-oriya.below by lapa-oriya;\012	sub la-oriya.base pha-oriya.below by lapha-oriya;\012	sub la-oriya.base ra-oriya.below by lara-oriya;\012	sub lla-oriya.base ka-oriya.below by llaka-oriya;\012	sub lla-oriya.base lla-oriya.below by llalla-oriya;\012	sub lla-oriya.base pa-oriya.below by llapa-oriya;\012	sub lla-oriya.base pha-oriya.below by llapha-oriya;\012	sub lla-oriya.base ra-oriya.below by llara-oriya;\012	sub ma-oriya.base ba-oriya.below by maba-oriya;\012	sub ma-oriya.base bha-oriya.below by mabha-oriya;\012	sub ma-oriya.base ma-oriya.below by mama-oriya;\012	sub ma-oriya.base pa-oriya.below by mapa-oriya;\012	sub ma-oriya.base pha-oriya.below by mapha-oriya;\012	sub ma-oriya.base ra-oriya.below by mara-oriya;\012	sub na-oriya.base da-oriya.below by nada-oriya;\012	sub na-oriya.base dha-oriya.below by nadha-oriya;\012	sub na-oriya.base na-oriya.below by nana-oriya;\012	sub na-oriya.base ra-oriya.below by nara-oriya;\012	sub na-oriya.base ta-oriya.below by nata-oriya;\012	sub na-oriya.base tha-oriya.below by natha-oriya;\012	sub nga-oriya.base ga-oriya.below by ngaga-oriya;\012	sub nga-oriya.base gha-oriya.below by ngagha-oriya;\012	sub nga-oriya.base ka-oriya.below by ngaka-oriya;\012	sub nga-oriya.base kha-oriya.below by ngakha-oriya;\012	sub nga-oriya.base ra-oriya.below by ngara-oriya;\012	sub nna-oriya.base dda-oriya.below by nnadda-oriya;\012	sub nna-oriya.base ddha-oriya.below by nnaddha-oriya;\012	sub nna-oriya.base nna-oriya.below by nnanna-oriya;\012	sub nna-oriya.base ra-oriya.below by nnara-oriya;\012	sub nna-oriya.base tta-oriya.below by nnatta-oriya;\012	sub nna-oriya.base ttha-oriya.below by nnattha-oriya;\012	sub nya-oriya.base ca-oriya.below by nyaca-oriya;\012	sub nya-oriya.base cha-oriya.below by nyacha-oriya;\012	sub nya-oriya.base ja-oriya.below by nyaja-oriya;\012	sub nya-oriya.base jha-oriya.below by nyajha-oriya;\012	sub nya-oriya.base ra-oriya.below by nyara-oriya;\012	sub pa-oriya.base ka-oriya.below by paka-oriya;\012	sub pa-oriya.base lla-oriya.below by palla-oriya;\012	sub pa-oriya.base pa-oriya.below by papa-oriya;\012	sub pa-oriya.base ra-oriya.below by para-oriya;\012	sub pa-oriya.base sa-oriya.below by pasa-oriya;\012	sub pa-oriya.base ta-oriya.below by pata-oriya;\012	sub pa-oriya.base tta-oriya.below by patta-oriya;\012	sub pha-oriya.base ra-oriya.below by phara-oriya;\012	sub rha-oriya.base ra-oriya.below by rhara-oriya;\012	sub rra-oriya.base ra-oriya.below by rrara-oriya;\012	sub sa-oriya.base ka-oriya.below by saka-oriya;\012	sub sa-oriya.base kha-oriya.below by sakha-oriya;\012	sub sa-oriya.base ma-oriya.below by sama-oriya;\012	sub sa-oriya.base na-oriya.below by sana-oriya;\012	sub sa-oriya.base pa-oriya.below by sapa-oriya;\012	sub sa-oriya.base pha-oriya.below by sapha-oriya;\012	sub sa-oriya.base ra-oriya.below by sara-oriya;\012	sub sa-oriya.base ta-oriya.below by sata-oriya;\012	sub sa-oriya.base tha-oriya.below by satha-oriya;\012	sub sa-oriya.base va-oriya.below by sava-oriya;\012	sub sha-oriya.base ca-oriya.below by shaca-oriya;\012	sub sha-oriya.base cha-oriya.below by shacha-oriya;\012	sub sha-oriya.base lla-oriya.below by shalla-oriya;\012	sub sha-oriya.base ra-oriya.below by shara-oriya;\012	sub sha-oriya.base va-oriya.below by shava-oriya;\012	sub ssa-oriya.base ka-oriya.below by ssaka-oriya;\012	sub ssa-oriya.base nna-oriya.below by ssanna-oriya;\012	sub ssa-oriya.base pa-oriya.below by ssapa-oriya;\012	sub ssa-oriya.base pha-oriya.below by ssapha-oriya;\012	sub ssa-oriya.base ra-oriya.below by ssara-oriya;\012	sub ssa-oriya.base tta-oriya.below by ssatta-oriya;\012	sub ssa-oriya.base ttha-oriya.below by ssattha-oriya;\012	sub ta-oriya.base ka-oriya.below by taka-oriya;\012	sub ta-oriya.base ma-oriya.below by tama-oriya;\012	sub ta-oriya.base na-oriya.below by tana-oriya;\012	sub ta-oriya.base pa-oriya.below by tapa-oriya;\012	sub ta-oriya.base ra-oriya.below by tara-oriya;\012	sub ta-oriya.base sa-oriya.below by tasa-oriya;\012	sub ta-oriya.base ta-oriya.below by tata-oriya;\012	sub ta-oriya.base tha-oriya.below by tatha-oriya;\012	sub ta-oriya.base va-oriya.below by tava-oriya;\012	sub tha-oriya.base ra-oriya.below by thara-oriya;\012	sub tta-oriya.base ra-oriya.below by ttara-oriya;\012	sub tta-oriya.base tta-oriya.below by ttatta-oriya;\012	sub ttha-oriya.base ra-oriya.below by tthara-oriya;\012	sub va-oriya.base ra-oriya.below by vara-oriya;\012	sub wa-oriya.base ra-oriya.below by wara-oriya;\012	sub ya-oriya.base ra-oriya.below by yara-oriya;\012	sub kassa-oriya.base ma-oriya.below by kassama-oriya;\012	sub kassa-oriya.base nna-oriya.below by kassanna-oriya;\012	sub kassa-oriya.base ra-oriya.below by kassara-oriya;\012\012\012	sub dara-oriya uMatra-oriya by darauMatra-oriya;\012	sub nata-oriya uMatra-oriya by natauMatra-oriya;\012	sub sapa-oriya rVocalicMatra-oriya by saparVocalicMatra-oriya;\012	sub tara-oriya uMatra-oriya by tarauMatra-oriya;\012	sub ha-oriya rVocalic-oriya by harVocalic-oriya;\012	sub ha-oriya u-oriya by hau-oriya;\012	sub ha-oriya uu-oriya by hauu-oriya;\012\012\012\012\012	sub ra-oriya.below uMatra-oriya by rauMatra-oriya.below;\012	sub ra-oriya.below uuMatra-oriya by rauuMatra-oriya.below;\012	sub ra-oriya.below rVocalicMatra-oriya by rarVocalicMatra-oriya.below;\012	sub ra-oriya.below rrVocalicMatra-oriya by rarrVocalicMatra-oriya.below;";
+code = "script ory2;\012  lookupflag MarkAttachmentType @NonAboveMarks;\012	sub [ka-oriya.below kha-oriya.below ga-oriya.below gha-oriya.below nga-oriya.below ca-oriya.below cha-oriya.below ja-oriya.below jha-oriya.below tta-oriya.below ttha-oriya.below dda-oriya.below ddha-oriya.below nna-oriya.below ta-oriya.below tha-oriya.below da-oriya.below dha-oriya.below na-oriya.below pa-oriya.below pha-oriya.below ba-oriya.below bha-oriya.below ma-oriya.below ya-oriya.below ra-oriya.below la-oriya.below lla-oriya.below va-oriya.below sha-oriya.below ssa-oriya.below sa-oriya.below ha-oriya.below kassa-oriya.below] [ka-oriya.below kha-oriya.below ga-oriya.below gha-oriya.below nga-oriya.below ca-oriya.below cha-oriya.below ja-oriya.below jha-oriya.below tta-oriya.below ttha-oriya.below dda-oriya.below ddha-oriya.below nna-oriya.below ta-oriya.below tha-oriya.below da-oriya.below dha-oriya.below na-oriya.below pa-oriya.below pha-oriya.below ba-oriya.below bha-oriya.below ma-oriya.below ya-oriya.below ra-oriya.below la-oriya.below lla-oriya.below va-oriya.below sha-oriya.below ssa-oriya.below sa-oriya.below ha-oriya.below]' by [ka-oriya.single kha-oriya.single ga-oriya.single gha-oriya.single nga-oriya.single ca-oriya.single cha-oriya.single ja-oriya.single jha-oriya.single tta-oriya.single ttha-oriya.single dda-oriya.single ddha-oriya.single nna-oriya.single ta-oriya.single tha-oriya.single da-oriya.single dha-oriya.single na-oriya.single pa-oriya.single pha-oriya.single ba-oriya.single bha-oriya.single ma-oriya.single ya-oriya.single ra-oriya.single la-oriya.single lla-oriya.single va-oriya.single sha-oriya.single ssa-oriya.single sa-oriya.single ha-oriya.single];\012\012\012  lookup blws1 {\012	sub da-oriya.base dha-oriya.below va-oriya.single by dadhava-oriya;\012	sub ja-oriya.base ja-oriya.below va-oriya.single by jajava-oriya;\012	sub ka-oriya.base ta-oriya.below ra-oriya.single by katara-oriya;\012	sub ma-oriya.base bha-oriya.below ra-oriya.single by mabhara-oriya;\012	sub ma-oriya.base pa-oriya.below ra-oriya.single by mapara-oriya;\012	sub na-oriya.base da-oriya.below ra-oriya.single by nadara-oriya;\012	sub na-oriya.base da-oriya.below va-oriya.single by nadava-oriya;\012	sub na-oriya.base dha-oriya.below ra-oriya.single by nadhara-oriya;\012	sub na-oriya.base dha-oriya.below va-oriya.single by nadhava-oriya;\012	sub na-oriya.base ta-oriya.below ra-oriya.single by natara-oriya;\012	sub na-oriya.base ta-oriya.below va-oriya.single by natava-oriya;\012	sub nga-oriya.base kassa-oriya.below by ngakassa-oriya;\012	sub nga-oriya.base ka-oriya.below ta-oriya.single by ngakata-oriya;\012	sub nna-oriya.base dda-oriya.below ra-oriya.single by nnaddara-oriya;\012	sub sa-oriya.base ta-oriya.below ra-oriya.single by satara-oriya;\012	sub ssa-oriya.base ka-oriya.below ra-oriya.single by ssakara-oriya;\012	sub ssa-oriya.base tta-oriya.below ra-oriya.single by ssattara-oriya;\012	sub ta-oriya.base ka-oriya.below ra-oriya.single by takara-oriya;\012	sub ta-oriya.base pa-oriya.below ra-oriya.single by tapara-oriya;\012	sub ta-oriya.base sa-oriya.below na-oriya.single by tasana-oriya;\012	sub ta-oriya.base ta-oriya.below ra-oriya.single by tatara-oriya;\012	sub ta-oriya.base ta-oriya.below va-oriya.single by tatava-oriya;\012	sub ba-oriya.base ba-oriya.below by baba-oriya;\012	sub ba-oriya.base da-oriya.below by bada-oriya;\012	sub ba-oriya.base dha-oriya.below by badha-oriya;\012	sub ba-oriya.base ja-oriya.below by baja-oriya;\012	sub ba-oriya.base ra-oriya.below by bara-oriya;\012	sub bha-oriya.base ra-oriya.below by bhara-oriya;\012	sub ca-oriya.base ca-oriya.below by caca-oriya;\012	sub ca-oriya.base cha-oriya.below by cacha-oriya;\012	sub ca-oriya.base ra-oriya.below by cara-oriya;\012	sub cha-oriya.base ra-oriya.below by chara-oriya;\012	sub da-oriya.base bha-oriya.below by dabha-oriya;\012	sub da-oriya.base da-oriya.below by dada-oriya;\012	sub da-oriya.base dha-oriya.below by dadha-oriya;\012	sub da-oriya.base ga-oriya.below by daga-oriya;\012	sub da-oriya.base gha-oriya.below by dagha-oriya;\012	sub da-oriya.base ra-oriya.below by dara-oriya;\012	sub da-oriya.base va-oriya.below by dava-oriya;\012	sub dda-oriya.base dda-oriya.below by ddadda-oriya;\012	sub dda-oriya.base ga-oriya.below by ddaga-oriya;\012	sub dda-oriya.base ra-oriya.below by ddara-oriya;\012	sub ddha-oriya.base ra-oriya.below by ddhara-oriya;\012	sub dha-oriya.base ra-oriya.below by dhara-oriya;\012	sub dha-oriya.base va-oriya.below by dhava-oriya;\012	sub dha-oriya.base ya-oriya.below by dhaya-oriya;\012	sub dha-oriya yya-oriya.post by dhayya-oriya;\012	sub ga-oriya.base da-oriya.below by gada-oriya;\012	sub ga-oriya.base dha-oriya.below by gadha-oriya;\012	sub ga-oriya.base lla-oriya.below by galla-oriya;\012	sub ga-oriya.base na-oriya.below by gana-oriya;\012	sub ga-oriya.base ra-oriya.below by gara-oriya;\012	sub gha-oriya.base na-oriya.below by ghana-oriya;\012	sub gha-oriya.base ra-oriya.below by ghara-oriya;\012	sub ha-oriya.base ja-oriya.below by haja-oriya;\012	sub ha-oriya.base ka-oriya.below by haka-oriya;\012	sub ha-oriya.base la-oriya.below by hala-oriya;\012	sub ha-oriya.base lla-oriya.below by halla-oriya;\012	sub ha-oriya.base ma-oriya.below by hama-oriya;\012	sub ha-oriya.base na-oriya.below by hana-oriya;\012	sub ha-oriya.base ra-oriya.below by hara-oriya;\012	sub ha-oriya.base va-oriya.below by hava-oriya;\012	sub ja-oriya.base ja-oriya.below by jaja-oriya;\012	sub ja-oriya.base jha-oriya.below by jajha-oriya;\012	sub ja-oriya.base ra-oriya.below by jara-oriya;\012	sub ja-oriya.base va-oriya.below by java-oriya;\012	sub jha-oriya.base ra-oriya.below by jhara-oriya;\012	sub ka-oriya.base ca-oriya.below by kaca-oriya;\012	sub ka-oriya.base ka-oriya.below by kaka-oriya;\012	sub ka-oriya.base lla-oriya.below by kalla-oriya;\012	sub ka-oriya.base ra-oriya.below by kara-oriya;\012	sub ka-oriya.base sa-oriya.below by kasa-oriya;\012	sub ka-oriya.base ssa-oriya.below by kassa-oriya;\012	sub ka-oriya.base ta-oriya.below by kata-oriya;\012	sub ka-oriya.base tta-oriya.below by katta-oriya;\012	sub ka-oriya.base va-oriya.below by kava-oriya;\012	sub kha-oriya.base ra-oriya.below by khara-oriya;\012	sub la-oriya.base ga-oriya.below by laga-oriya;\012	sub la-oriya.base ka-oriya.below by laka-oriya;\012	sub la-oriya.base la-oriya.below by lala-oriya;\012	sub la-oriya.base lla-oriya.below by lalla-oriya;\012	sub la-oriya.base ma-oriya.below by lama-oriya;\012	sub la-oriya.base pa-oriya.below by lapa-oriya;\012	sub la-oriya.base pha-oriya.below by lapha-oriya;\012	sub la-oriya.base ra-oriya.below by lara-oriya;\012	sub lla-oriya.base ka-oriya.below by llaka-oriya;\012	sub lla-oriya.base lla-oriya.below by llalla-oriya;\012	sub lla-oriya.base pa-oriya.below by llapa-oriya;\012	sub lla-oriya.base pha-oriya.below by llapha-oriya;\012	sub lla-oriya.base ra-oriya.below by llara-oriya;\012	sub ma-oriya.base ba-oriya.below by maba-oriya;\012	sub ma-oriya.base bha-oriya.below by mabha-oriya;\012	sub ma-oriya.base ma-oriya.below by mama-oriya;\012	sub ma-oriya.base pa-oriya.below by mapa-oriya;\012	sub ma-oriya.base pha-oriya.below by mapha-oriya;\012	sub ma-oriya.base ra-oriya.below by mara-oriya;\012	sub na-oriya.base da-oriya.below by nada-oriya;\012	sub na-oriya.base dha-oriya.below by nadha-oriya;\012	sub na-oriya.base na-oriya.below by nana-oriya;\012	sub na-oriya.base ra-oriya.below by nara-oriya;\012	sub na-oriya.base ta-oriya.below by nata-oriya;\012	sub na-oriya.base tha-oriya.below by natha-oriya;\012	sub nga-oriya.base ga-oriya.below by ngaga-oriya;\012	sub nga-oriya.base gha-oriya.below by ngagha-oriya;\012	sub nga-oriya.base ka-oriya.below by ngaka-oriya;\012	sub nga-oriya.base kha-oriya.below by ngakha-oriya;\012	sub nga-oriya.base ra-oriya.below by ngara-oriya;\012	sub nna-oriya.base dda-oriya.below by nnadda-oriya;\012	sub nna-oriya.base ddha-oriya.below by nnaddha-oriya;\012	sub nna-oriya.base nna-oriya.below by nnanna-oriya;\012	sub nna-oriya.base ra-oriya.below by nnara-oriya;\012	sub nna-oriya.base tta-oriya.below by nnatta-oriya;\012	sub nna-oriya.base ttha-oriya.below by nnattha-oriya;\012	sub nya-oriya.base ca-oriya.below by nyaca-oriya;\012	sub nya-oriya.base cha-oriya.below by nyacha-oriya;\012	sub nya-oriya.base ja-oriya.below by nyaja-oriya;\012	sub nya-oriya.base jha-oriya.below by nyajha-oriya;\012	sub nya-oriya.base ra-oriya.below by nyara-oriya;\012	sub pa-oriya.base ka-oriya.below by paka-oriya;\012	sub pa-oriya.base lla-oriya.below by palla-oriya;\012	sub pa-oriya.base pa-oriya.below by papa-oriya;\012	sub pa-oriya.base ra-oriya.below by para-oriya;\012	sub pa-oriya.base sa-oriya.below by pasa-oriya;\012	sub pa-oriya.base ta-oriya.below by pata-oriya;\012	sub pa-oriya.base tta-oriya.below by patta-oriya;\012	sub pha-oriya.base ra-oriya.below by phara-oriya;\012	sub rha-oriya.base ra-oriya.below by rhara-oriya;\012	sub rra-oriya.base ra-oriya.below by rrara-oriya;\012	sub sa-oriya.base ka-oriya.below by saka-oriya;\012	sub sa-oriya.base kha-oriya.below by sakha-oriya;\012	sub sa-oriya.base ma-oriya.below by sama-oriya;\012	sub sa-oriya.base na-oriya.below by sana-oriya;\012	sub sa-oriya.base pa-oriya.below by sapa-oriya;\012	sub sa-oriya.base pha-oriya.below by sapha-oriya;\012	sub sa-oriya.base ra-oriya.below by sara-oriya;\012	sub sa-oriya.base ta-oriya.below by sata-oriya;\012	sub sa-oriya.base tha-oriya.below by satha-oriya;\012	sub sa-oriya.base va-oriya.below by sava-oriya;\012	sub sha-oriya.base ca-oriya.below by shaca-oriya;\012	sub sha-oriya.base cha-oriya.below by shacha-oriya;\012	sub sha-oriya.base lla-oriya.below by shalla-oriya;\012	sub sha-oriya.base ra-oriya.below by shara-oriya;\012	sub sha-oriya.base va-oriya.below by shava-oriya;\012	sub ssa-oriya.base ka-oriya.below by ssaka-oriya;\012	sub ssa-oriya.base nna-oriya.below by ssanna-oriya;\012	sub ssa-oriya.base pa-oriya.below by ssapa-oriya;\012	sub ssa-oriya.base pha-oriya.below by ssapha-oriya;\012	sub ssa-oriya.base ra-oriya.below by ssara-oriya;\012	sub ssa-oriya.base tta-oriya.below by ssatta-oriya;\012	sub ssa-oriya.base ttha-oriya.below by ssattha-oriya;\012	sub ta-oriya.base ka-oriya.below by taka-oriya;\012	sub ta-oriya.base ma-oriya.below by tama-oriya;\012	sub ta-oriya.base na-oriya.below by tana-oriya;\012	sub ta-oriya.base pa-oriya.below by tapa-oriya;\012	sub ta-oriya.base ra-oriya.below by tara-oriya;\012	sub ta-oriya.base sa-oriya.below by tasa-oriya;\012	sub ta-oriya.base ta-oriya.below by tata-oriya;\012	sub ta-oriya.base tha-oriya.below by tatha-oriya;\012	sub ta-oriya.base va-oriya.below by tava-oriya;\012	sub tha-oriya.base ra-oriya.below by thara-oriya;\012	sub tta-oriya.base ra-oriya.below by ttara-oriya;\012	sub tta-oriya.base tta-oriya.below by ttatta-oriya;\012	sub ttha-oriya.base ra-oriya.below by tthara-oriya;\012	sub va-oriya.base ra-oriya.below by vara-oriya;\012	sub wa-oriya.base ra-oriya.below by wara-oriya;\012	sub ya-oriya.base ra-oriya.below by yara-oriya;\012	sub kassa-oriya.base ma-oriya.below by kassama-oriya;\012	sub kassa-oriya.base nna-oriya.below by kassanna-oriya;\012	sub kassa-oriya.base ra-oriya.below by kassara-oriya;\012	sub ha-oriya rVocalicMatra-oriya by harVocalic-oriya;\012	sub ha-oriya uMatra-oriya by hau-oriya;\012	sub ha-oriya uuMatra-oriya by hauu-oriya;\012  } blws1;\012\012\012  lookup blws2 {\012	sub ra-oriya.below uMatra-oriya by rauMatra-oriya.below;\012	sub ra-oriya.below uuMatra-oriya by rauuMatra-oriya.below;\012	sub ra-oriya.below rVocalicMatra-oriya by rarVocalicMatra-oriya.below;\012	sub ra-oriya.below rrVocalicMatra-oriya by rarrVocalicMatra-oriya.below;\012  } blws2;\012\012\012  lookup blws3 {\012	sub da-oriya rauMatra-oriya.below by darauMatra-oriya;\012	sub ta-oriya rauMatra-oriya.below by tarauMatra-oriya;\012	sub nata-oriya uMatra-oriya by natauMatra-oriya;\012	sub sapa-oriya rVocalicMatra-oriya by saparVocalicMatra-oriya;\012  } blws3;";
 name = blws;
 },
 {
-automatic = 1;
-code = "script ory2;\012	sub iMatra-oriya reph-oriya candraBindu-oriya by iMatrarephcandraBindu-oriya;\012	sub reph-oriya iMatra-oriya candraBindu-oriya by iMatrarephcandraBindu-oriya;\012	sub reph-oriya aiLength-oriya candraBindu-oriya by rephaiLengthcandraBindu-oriya;\012	sub reph-oriya auLength-oriya candraBindu-oriya by rephauLengthcandraBindu-oriya;\012	sub aiLength-oriya candraBindu-oriya by aiLengthcandraBindu-oriya;\012	sub auLength-oriya candraBindu-oriya by auLengthcandraBindu-oriya;\012	sub iMatra-oriya candraBindu-oriya by iMatracandraBindu-oriya;\012	sub iMatra-oriya reph-oriya by iMatrareph-oriya;\012	sub reph-oriya iMatra-oriya by iMatrareph-oriya;\012	sub ka-oriya.below ssa-oriya.below by kassa-oriya.below;\012	sub reph-oriya aiLength-oriya by rephaiLength-oriya;\012	sub reph-oriya auLength-oriya by rephauLength-oriya;\012	sub reph-oriya candraBindu-oriya by rephcandraBindu-oriya;\012";
+code = "script ory2;\012	sub iMatra-oriya reph-oriya candraBindu-oriya by iMatrarephcandraBindu-oriya;\012	sub reph-oriya iMatra-oriya candraBindu-oriya by iMatrarephcandraBindu-oriya;\012	sub aiLength-oriya reph-oriya candraBindu-oriya by rephaiLengthcandraBindu-oriya;\012	sub reph-oriya candraBindu-oriya auLength-oriya by rephauLengthcandraBindu-oriya;\012	sub aiLength-oriya candraBindu-oriya by aiLengthcandraBindu-oriya;\012	sub auLength-oriya candraBindu-oriya by auLengthcandraBindu-oriya;\012	sub iMatra-oriya candraBindu-oriya by iMatracandraBindu-oriya;\012	sub iMatra-oriya reph-oriya by iMatrareph-oriya;\012	sub reph-oriya iMatra-oriya by iMatrareph-oriya;\012	sub ka-oriya.below ssa-oriya.below by kassa-oriya.below;\012	sub aiLength-oriya reph-oriya by rephaiLength-oriya;\012	sub reph-oriya auLength-oriya by rephauLength-oriya;\012	sub reph-oriya candraBindu-oriya by rephcandraBindu-oriya;\012";
 name = psts;
 },
 {
-code = "script ory2;\012\012	sub [kha-oriya tha-oriya dha-oriya] iMatra-oriya' by iMatra-oriya.below;\012\012	sub iMatra-oriya reph-oriya candraBindu-oriya by iMatrarephcandraBindu-oriya;\012	sub reph-oriya aiLength-oriya candraBindu-oriya by rephaiLengthcandraBindu-oriya;\012	sub reph-oriya auLength-oriya candraBindu-oriya by rephauLengthcandraBindu-oriya;\012	sub aiLength-oriya candraBindu-oriya by aiLengthcandraBindu-oriya;\012	sub auLength-oriya candraBindu-oriya by auLengthcandraBindu-oriya;\012	sub iMatra-oriya candraBindu-oriya by iMatracandraBindu-oriya;\012	sub iMatra-oriya reph-oriya by iMatrareph-oriya;\012	sub ka-oriya.below ssa-oriya.below by kassa-oriya.below;\012	sub reph-oriya aiLength-oriya by rephaiLength-oriya;\012	sub reph-oriya auLength-oriya by rephauLength-oriya;\012	sub reph-oriya candraBindu-oriya by rephcandraBindu-oriya;";
+code = "script ory2;\012\012	sub [kha-oriya tha-oriya dha-oriya] iMatra-oriya' by iMatra-oriya.below;\012\012  lookup abvs1{\012	sub iMatra-oriya reph-oriya candraBindu-oriya by iMatrarephcandraBindu-oriya;\012	sub reph-oriya aiLength-oriya candraBindu-oriya by rephaiLengthcandraBindu-oriya;\012	sub reph-oriya auLength-oriya candraBindu-oriya by rephauLengthcandraBindu-oriya;\012	sub aiLength-oriya candraBindu-oriya by aiLengthcandraBindu-oriya;\012	sub candraBindu-oriya auLength-oriya by auLengthcandraBindu-oriya;\012	sub iMatra-oriya candraBindu-oriya by iMatracandraBindu-oriya;\012	sub iMatra-oriya reph-oriya by iMatrareph-oriya;\012	sub ka-oriya.below ssa-oriya.below by kassa-oriya.below;\012	sub aiLength-oriya reph-oriya by rephaiLength-oriya;\012	sub reph-oriya auLength-oriya by rephauLength-oriya;\012	sub reph-oriya candraBindu-oriya by rephcandraBindu-oriya;\012  } abvs1;";
 name = abvs;
 },
 {
@@ -2276,7 +2274,7 @@ unicode = 0B03;
 },
 {
 glyphname = "a-oriya";
-lastChange = "2019-12-12 03:26:31 +0000";
+lastChange = "2022-06-06 07:14:23 +0000";
 layers = (
 {
 anchors = (
@@ -34457,7 +34455,7 @@ note = ailengthmarkorya;
 },
 {
 glyphname = "auLength-oriya";
-lastChange = "2019-12-12 03:26:32 +0000";
+lastChange = "2022-06-14 02:40:16 +0000";
 layers = (
 {
 layerId = "926CF2F4-31F1-4036-BA3C-0F7EE51EF36A";
@@ -161881,7 +161879,7 @@ rightMetricsKey = "ha-oriya";
 },
 {
 glyphname = "rephcandraBindu-oriya";
-lastChange = "2019-12-12 03:26:34 +0000";
+lastChange = "2022-06-14 04:39:47 +0000";
 layers = (
 {
 anchors = (
@@ -161981,10 +161979,13 @@ width = 600;
 }
 );
 note = rephcandrabinduorya;
+script = oriya;
+category = Mark;
+subCategory = Nonspacing;
 },
 {
 glyphname = "iMatracandraBindu-oriya";
-lastChange = "2019-12-12 03:26:34 +0000";
+lastChange = "2022-06-14 04:39:47 +0000";
 layers = (
 {
 anchors = (
@@ -162068,10 +162069,13 @@ width = 800;
 }
 );
 note = ivowelsigncandrabinduorya;
+script = oriya;
+category = Mark;
+subCategory = Nonspacing;
 },
 {
 glyphname = "iMatracandraBindu-oriya.wide";
-lastChange = "2019-12-12 03:26:34 +0000";
+lastChange = "2022-06-14 04:39:47 +0000";
 layers = (
 {
 anchors = (
@@ -162154,10 +162158,13 @@ layerId = "A6029D4D-1571-45DB-86AE-EDC9D2308E6F";
 width = 800;
 }
 );
+script = oriya;
+category = Mark;
+subCategory = Nonspacing;
 },
 {
 glyphname = "iMatrareph-oriya";
-lastChange = "2019-12-12 03:26:34 +0000";
+lastChange = "2022-06-14 04:39:47 +0000";
 layers = (
 {
 anchors = (
@@ -162320,10 +162327,13 @@ nodes = (
 width = 600;
 }
 );
+script = oriya;
+category = Mark;
+subCategory = Nonspacing;
 },
 {
 glyphname = "iMatrareph-oriya.wide";
-lastChange = "2019-12-12 03:26:34 +0000";
+lastChange = "2022-06-14 04:39:47 +0000";
 layers = (
 {
 anchors = (
@@ -162486,10 +162496,13 @@ nodes = (
 width = 600;
 }
 );
+script = oriya;
+category = Mark;
+subCategory = Nonspacing;
 },
 {
 glyphname = "iMatrarephcandraBindu-oriya";
-lastChange = "2019-12-12 03:26:34 +0000";
+lastChange = "2022-06-14 04:39:47 +0000";
 layers = (
 {
 anchors = (
@@ -162572,10 +162585,13 @@ layerId = "A6029D4D-1571-45DB-86AE-EDC9D2308E6F";
 width = 1000;
 }
 );
+script = oriya;
+category = Mark;
+subCategory = Nonspacing;
 },
 {
 glyphname = "iMatrarephcandraBindu-oriya.wide";
-lastChange = "2019-12-12 03:26:34 +0000";
+lastChange = "2022-06-14 04:39:47 +0000";
 layers = (
 {
 anchors = (
@@ -162658,10 +162674,13 @@ layerId = "A6029D4D-1571-45DB-86AE-EDC9D2308E6F";
 width = 800;
 }
 );
+script = oriya;
+category = Mark;
+subCategory = Nonspacing;
 },
 {
 glyphname = "aiLengthcandraBindu-oriya";
-lastChange = "2019-12-12 03:26:34 +0000";
+lastChange = "2022-06-14 04:39:47 +0000";
 layers = (
 {
 anchors = (
@@ -162755,10 +162774,13 @@ width = 920;
 }
 );
 note = ailengthmarkcandrabinduorya;
+script = oriya;
+category = Mark;
+subCategory = Nonspacing;
 },
 {
 glyphname = "aiLengthcandraBindu-oriya.stem";
-lastChange = "2019-12-12 03:26:34 +0000";
+lastChange = "2022-06-14 04:39:47 +0000";
 layers = (
 {
 anchors = (
@@ -162852,10 +162874,13 @@ width = 800;
 }
 );
 note = ailengthmarkcandrabinduorya;
+script = oriya;
+category = Mark;
+subCategory = Nonspacing;
 },
 {
 glyphname = "aiLengthcandraBindu-oriya.umbrella";
-lastChange = "2019-12-12 03:26:34 +0000";
+lastChange = "2022-06-14 04:39:47 +0000";
 layers = (
 {
 anchors = (
@@ -162949,10 +162974,13 @@ width = 920;
 }
 );
 note = ailengthmarkcandrabinduorya;
+script = oriya;
+category = Mark;
+subCategory = Nonspacing;
 },
 {
 glyphname = "rephaiLength-oriya";
-lastChange = "2019-12-12 03:26:34 +0000";
+lastChange = "2022-06-14 04:39:47 +0000";
 layers = (
 {
 anchors = (
@@ -163168,10 +163196,13 @@ width = 800;
 }
 );
 note = ailengthmarkrephorya;
+script = oriya;
+category = Mark;
+subCategory = Nonspacing;
 },
 {
 glyphname = "rephaiLength-oriya.stem";
-lastChange = "2019-12-12 03:26:34 +0000";
+lastChange = "2022-06-14 04:39:47 +0000";
 layers = (
 {
 anchors = (
@@ -163387,10 +163418,13 @@ width = 800;
 }
 );
 note = ailengthmarkrephorya;
+script = oriya;
+category = Mark;
+subCategory = Nonspacing;
 },
 {
 glyphname = "rephaiLength-oriya.umbrella";
-lastChange = "2019-12-12 03:26:34 +0000";
+lastChange = "2022-06-14 04:39:47 +0000";
 layers = (
 {
 anchors = (
@@ -163606,10 +163640,13 @@ width = 800;
 }
 );
 note = ailengthmarkrephorya;
+script = oriya;
+category = Mark;
+subCategory = Nonspacing;
 },
 {
 glyphname = "rephaiLengthcandraBindu-oriya";
-lastChange = "2019-12-12 03:26:34 +0000";
+lastChange = "2022-06-14 04:39:47 +0000";
 layers = (
 {
 anchors = (
@@ -163698,10 +163735,13 @@ layerId = "A6029D4D-1571-45DB-86AE-EDC9D2308E6F";
 width = 1000;
 }
 );
+script = oriya;
+category = Mark;
+subCategory = Nonspacing;
 },
 {
 glyphname = "rephaiLengthcandraBindu-oriya.stem";
-lastChange = "2019-12-12 03:26:34 +0000";
+lastChange = "2022-06-14 04:39:47 +0000";
 layers = (
 {
 anchors = (
@@ -163791,10 +163831,13 @@ width = 1000;
 }
 );
 note = ailengthmarkrephcandrabinduorya;
+script = oriya;
+category = Mark;
+subCategory = Nonspacing;
 },
 {
 glyphname = "rephaiLengthcandraBindu-oriya.umbrella";
-lastChange = "2019-12-12 03:26:34 +0000";
+lastChange = "2022-06-14 04:39:47 +0000";
 layers = (
 {
 anchors = (
@@ -163883,10 +163926,13 @@ layerId = "A6029D4D-1571-45DB-86AE-EDC9D2308E6F";
 width = 1000;
 }
 );
+script = oriya;
+category = Mark;
+subCategory = Nonspacing;
 },
 {
 glyphname = "auLengthcandraBindu-oriya";
-lastChange = "2019-12-12 03:26:34 +0000";
+lastChange = "2022-06-14 04:40:17 +0000";
 layers = (
 {
 components = (
@@ -163943,10 +163989,13 @@ width = 215;
 );
 leftMetricsKey = "auLength-oriya";
 note = aulengthmarkcandrabinduorya;
+script = oriya;
+category = Mark;
+subCategory = Spacing;
 },
 {
 glyphname = "rephauLength-oriya";
-lastChange = "2019-12-12 03:26:34 +0000";
+lastChange = "2022-06-14 04:40:17 +0000";
 layers = (
 {
 layerId = "926CF2F4-31F1-4036-BA3C-0F7EE51EF36A";
@@ -164174,10 +164223,13 @@ width = 215;
 }
 );
 note = aurephorya;
+script = oriya;
+category = Mark;
+subCategory = Spacing;
 },
 {
 glyphname = "rephauLengthcandraBindu-oriya";
-lastChange = "2019-12-12 03:26:34 +0000";
+lastChange = "2022-06-14 04:40:17 +0000";
 layers = (
 {
 components = (
@@ -164234,6 +164286,9 @@ width = 215;
 );
 leftMetricsKey = "auLength-oriya";
 note = aulengthmarkrephcandrabinduorya;
+script = oriya;
+category = Mark;
+subCategory = Spacing;
 },
 {
 glyphname = "rauMatra-oriya.below";

--- a/test/Oriya/fontdiff-or-20220616.html
+++ b/test/Oriya/fontdiff-or-20220616.html
@@ -1,0 +1,8 @@
+<html lang="or">
+  <p><span style="font-weight:400">କ୍ର ଖ୍ର ଗ୍ର ଘ୍ର ଙ୍ର ଚ୍ର ଛ୍ର ଜ୍ର ଝ୍ର ଞ୍ର ଟ୍ର ଠ୍ର ଡ୍ର ଢ୍ର ଣ୍ର ତ୍ର ଥ୍ର ଦ୍ର ଧ୍ର ନ୍ର ପ୍ର ଫ୍ର ବ୍ର ଭ୍ର ମ୍ର ଯ୍ର ଲ୍ର ଳ୍ର ଵ୍ର ଶ୍ର ଷ୍ର ସ୍ର ହ୍ର ୱ୍ର ଡ଼୍ର ଢ଼୍ର</span></p>
+  <p><span style="font-weight:400">କିଁ ଞିଁ ର୍କି ର୍ଞି ର୍କିଁ ର୍ଞିଁ ଞୈଁ ଖୈଁ କୈଁ</span></p>
+  <p><span style="font-weight:400">ର୍ଞୈ ର୍ଖୈ ର୍କୈ ର୍ଞୈଁ ର୍ଖୈଁ ର୍କୈଁ ର୍କୌଁ</span></p>
+  <p><span style="font-weight:400">ଧ୍ୟ କୌଁ ସ୍ପୃ ତ୍ରୁ ଦ୍ରୁ ନ୍ତୁ ସ୍ପୃ ହୁ ହୂ ହୃ </span></p>
+  <p><span style="font-weight:400"></span></p>
+</html>
+


### PR DESCRIPTION
The work I did was to fix GSUB and GDEF to use glyphs that already existed in the font but weren't used.
No modifications have been made to the glyph design or anchors.

I also added a test that uses fontdiff.
The result of the test is as follows.
I sought to minimize the impact on strings that already exist.
![image](https://user-images.githubusercontent.com/21096794/174014987-ca0f29e5-7260-464e-91be-1230c307e6cf.png)



The issues I have modified and the details of the modifications are as follows.

### Fixes googlefonts/noto-fonts#2380


**Cause:**
■ pres
- When ra-oriya.below is involved, the first consonant is not replaced by * .base

■ blws
- Substitutions related to the defined ra-oriya.below do not trigger.

**Measures:**
■ pres
- Added processing to replace the consonant of the first character with * .base when ra-oriya.below is involved (addition of backtrack)
- Define ignore sub to use RA + Vowl glyphs of GID408-411 when ra-oriya.below and u, uu, r, rr, l, ll are combined

■ blws
- Split the blws lookup to trigger the intended replacement

### Fixes googlefonts/noto-fonts#2381
**Cause**
-Not included in the GDEF Markclass

**Measures**
-Fixed glyph properties in Glyphs App. Script to oriya, category to Mark, subcategory to Nospacing.

### Fixes googlefonts/noto-fonts#2382
**Cause**
■ psts, abvs
- The position of reph-oriya in the substitution condition is different from the position reordering Indic after rphf feature.

**Measures**
- Fixed reph-oriya position

### Fixes googlefonts/noto-fonts#2383
**Measures**
- Fixed abvs and blws conditions
